### PR TITLE
docs: advertise v2.26.0 in the READMEs

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -36,7 +36,7 @@
 
 **Markleaf** ist eine Android-Markdown-Notiz-App, die bewusst auf Ballast verzichtet, damit du dich auf zwei Dinge konzentrieren kannst: festhalten und ordnen. Deine Daten liegen ausschließlich auf deinem Gerät, und das standardisierte Markdown-Format garantiert volle Eigentümerschaft und Portabilität. Auch die Synchronisierung läuft nur über *einen von dir gewählten Ordner* – Markleaf selbst geht nie online.
 
-[**Branding-Seite ansehen**](https://jeiel85.github.io/markleaf-android/) · [Aktuelle Version: v2.24.0](https://github.com/jeiel85/markleaf-android/releases/tag/v2.24.0) · [GitLab-Release-Mirror](https://gitlab.com/jeiel85/markleaf-android/-/releases/v2.24.0) · [Datenschutzerklärung](https://jeiel85.github.io/markleaf-android/privacy.html) · [F-Droid](https://f-droid.org/packages/com.markleaf.notes/) · [Google Play](https://play.google.com/store/apps/details?id=com.markleaf.notes)
+[**Branding-Seite ansehen**](https://jeiel85.github.io/markleaf-android/) · [Aktuelle Version: v2.26.0](https://github.com/jeiel85/markleaf-android/releases/tag/v2.26.0) · [GitLab-Release-Mirror](https://gitlab.com/jeiel85/markleaf-android/-/releases/v2.26.0) · [Datenschutzerklärung](https://jeiel85.github.io/markleaf-android/privacy.html) · [F-Droid](https://f-droid.org/packages/com.markleaf.notes/) · [Google Play](https://play.google.com/store/apps/details?id=com.markleaf.notes)
 
 ---
 
@@ -125,7 +125,7 @@ com.markleaf.notes
 > **Google-Play-Updates sind derzeit ausgesetzt.** Bis eine koreanische Gewerbeanmeldungs-Anforderung für den Einzelentwickler geklärt ist, werden keine neuen Versionen in den Play Store geladen. Hol dir in der Zwischenzeit **die neueste Version über F-Droid, GitHub Releases oder GitLab Releases.** (Wenn du sie bereits aus dem Play Store installiert hast, funktioniert sie weiterhin.)
 
 - **F-Droid** *(empfohlen)*: [Markleaf on F-Droid](https://f-droid.org/packages/com.markleaf.notes/) – im F-Droid-Client suchen oder über den Link oben installieren. Es wird derselbe Signaturschlüssel (SHA-256 `0be97352…f91a`) verwendet, sodass Updates auch dann nahtlos weiterlaufen, wenn du ein APK aus den GitHub- oder GitLab-Releases per Sideload installiert hast.
-- **Direkte APK-Installation**: lade das APK aus dem [GitHub-v2.24.0-Release](https://github.com/jeiel85/markleaf-android/releases/tag/v2.24.0) oder dem [GitLab-v2.24.0-Release](https://gitlab.com/jeiel85/markleaf-android/-/releases/v2.24.0) herunter und führe es auf deinem Android-Gerät aus.
+- **Direkte APK-Installation**: lade das APK aus dem [GitHub-v2.26.0-Release](https://github.com/jeiel85/markleaf-android/releases/tag/v2.26.0) oder dem [GitLab-v2.26.0-Release](https://gitlab.com/jeiel85/markleaf-android/-/releases/v2.26.0) herunter und führe es auf deinem Android-Gerät aus.
 - **Google Play**: [Markleaf on Google Play](https://play.google.com/store/apps/details?id=com.markleaf.notes) – **Updates sind ausgesetzt** (siehe Hinweis oben). Wenn du die App bereits hast, funktioniert sie weiter, aber die neueste Version gibt es über F-Droid, GitHub oder GitLab.
 
 ### Aus dem Quellcode bauen

--- a/README.ja.md
+++ b/README.ja.md
@@ -36,7 +36,7 @@
 
 **Markleaf** は、余計なものをそぎ落とし「記録」と「整理」だけに集中できるよう設計された Android 向け Markdown メモアプリです。データは端末内にのみ保存され、標準 Markdown 形式によってデータの所有権と移植性が完全に保証されます。同期も *あなたが選んだフォルダ* を介してのみ行われ、Markleaf 自体はインターネットに接続しません。
 
-[**ブランディングページを見る**](https://jeiel85.github.io/markleaf-android/) · [現在のバージョン: v2.24.0](https://github.com/jeiel85/markleaf-android/releases/tag/v2.24.0) · [GitLab リリースミラー](https://gitlab.com/jeiel85/markleaf-android/-/releases/v2.24.0) · [プライバシーポリシー](https://jeiel85.github.io/markleaf-android/privacy.html) · [F-Droid](https://f-droid.org/packages/com.markleaf.notes/) · [Google Play](https://play.google.com/store/apps/details?id=com.markleaf.notes)
+[**ブランディングページを見る**](https://jeiel85.github.io/markleaf-android/) · [現在のバージョン: v2.26.0](https://github.com/jeiel85/markleaf-android/releases/tag/v2.26.0) · [GitLab リリースミラー](https://gitlab.com/jeiel85/markleaf-android/-/releases/v2.26.0) · [プライバシーポリシー](https://jeiel85.github.io/markleaf-android/privacy.html) · [F-Droid](https://f-droid.org/packages/com.markleaf.notes/) · [Google Play](https://play.google.com/store/apps/details?id=com.markleaf.notes)
 
 ---
 
@@ -125,7 +125,7 @@ com.markleaf.notes
 > **現在、Google Play での更新は一時保留中です。** 個人開発者の韓国の事業者登録に関するポリシー要件が解決するまで、新しいバージョンは Play ストアに公開しません。その間は **最新版を F-Droid、GitHub Releases、または GitLab Releases から入手してください。**（すでに Play ストアからインストール済みの場合はそのまま使えます。）
 
 - **F-Droid** *(推奨)*: [Markleaf on F-Droid](https://f-droid.org/packages/com.markleaf.notes/) — F-Droid クライアントで検索するか、上のリンクから直接インストールできます。同じ署名鍵（SHA-256 `0be97352…f91a`）を使用するため、GitHub/GitLab Releases の APK をサイドロードした場合でも途切れなく更新が続きます。
-- **APK の直接インストール**: [GitHub v2.24.0](https://github.com/jeiel85/markleaf-android/releases/tag/v2.24.0) または [GitLab v2.24.0](https://gitlab.com/jeiel85/markleaf-android/-/releases/v2.24.0) リリースから APK をダウンロードし、Android 端末で実行してインストールします。
+- **APK の直接インストール**: [GitHub v2.26.0](https://github.com/jeiel85/markleaf-android/releases/tag/v2.26.0) または [GitLab v2.26.0](https://gitlab.com/jeiel85/markleaf-android/-/releases/v2.26.0) リリースから APK をダウンロードし、Android 端末で実行してインストールします。
 - **Google Play**: [Markleaf on Google Play](https://play.google.com/store/apps/details?id=com.markleaf.notes) — **更新は一時保留中**です（上の注記を参照）。すでにインストール済みなら引き続き使えますが、最新版は F-Droid・GitHub・GitLab から入手してください。
 
 ### 開発環境の構築

--- a/README.ko.md
+++ b/README.ko.md
@@ -36,7 +36,7 @@
 
 **Markleaf**는 군더더기를 덜어내고 오직 '기록'과 '정리'에만 집중할 수 있도록 설계된 Android Markdown 메모 앱입니다. 당신의 데이터는 오직 당신의 기기에만 저장되며, 표준 Markdown 형식을 사용하여 데이터의 소유권과 이식성을 완벽히 보장합니다. 동기화도 *당신이 선택한 폴더* 를 통해서만 일어납니다 — Markleaf 자체는 인터넷에 나가지 않습니다.
 
-[**브랜딩 페이지 보기**](https://jeiel85.github.io/markleaf-android/) · [현재 버전: v2.24.0](https://github.com/jeiel85/markleaf-android/releases/tag/v2.24.0) · [GitLab 릴리스 미러](https://gitlab.com/jeiel85/markleaf-android/-/releases/v2.24.0) · [Privacy Policy](https://jeiel85.github.io/markleaf-android/privacy.html) · [F-Droid](https://f-droid.org/packages/com.markleaf.notes/) · [Google Play](https://play.google.com/store/apps/details?id=com.markleaf.notes)
+[**브랜딩 페이지 보기**](https://jeiel85.github.io/markleaf-android/) · [현재 버전: v2.26.0](https://github.com/jeiel85/markleaf-android/releases/tag/v2.26.0) · [GitLab 릴리스 미러](https://gitlab.com/jeiel85/markleaf-android/-/releases/v2.26.0) · [Privacy Policy](https://jeiel85.github.io/markleaf-android/privacy.html) · [F-Droid](https://f-droid.org/packages/com.markleaf.notes/) · [Google Play](https://play.google.com/store/apps/details?id=com.markleaf.notes)
 
 ---
 
@@ -125,7 +125,7 @@ com.markleaf.notes
 > **Google Play 업데이트는 현재 잠정 보류 중입니다.** 1인 개발자의 한국 사업자 등록 요건 관련 정책 이슈가 정리될 때까지 새 버전을 Play Store에 올리지 않습니다. 그동안 **최신 버전은 F-Droid, GitHub Releases 또는 GitLab Releases에서 받아 주세요.** (Play Store에 이미 설치돼 있다면 그대로 사용할 수 있습니다.)
 
 - **F-Droid** *(권장)*: [Markleaf on F-Droid](https://f-droid.org/packages/com.markleaf.notes/) — F-Droid 클라이언트에서 검색하거나 위 링크로 바로 설치할 수 있습니다. 동일 서명 키(SHA-256 `0be97352…f91a`)를 사용하므로 GitHub/GitLab Releases APK로 사이드로드한 경우에도 끊김 없이 업데이트가 이어집니다.
-- **APK 직접 설치**: [GitHub v2.24.0](https://github.com/jeiel85/markleaf-android/releases/tag/v2.24.0) 또는 [GitLab v2.24.0](https://gitlab.com/jeiel85/markleaf-android/-/releases/v2.24.0) 릴리스에서 APK를 다운로드한 뒤 Android 기기에서 실행해 설치합니다.
+- **APK 직접 설치**: [GitHub v2.26.0](https://github.com/jeiel85/markleaf-android/releases/tag/v2.26.0) 또는 [GitLab v2.26.0](https://gitlab.com/jeiel85/markleaf-android/-/releases/v2.26.0) 릴리스에서 APK를 다운로드한 뒤 Android 기기에서 실행해 설치합니다.
 - **Google Play**: [Markleaf on Google Play](https://play.google.com/store/apps/details?id=com.markleaf.notes) — **업데이트 잠정 보류 중**입니다(위 안내 참고). 이미 설치돼 있으면 계속 쓸 수 있지만, 최신 버전은 F-Droid·GitHub·GitLab에서 받으세요.
 
 ### 개발 환경 구축

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 
 **Markleaf** is an Android Markdown note app designed to strip away the clutter so you can focus on just two things: capturing and organizing. Your data is stored only on your device, and standard Markdown guarantees full ownership and portability. Even sync happens only through *a folder you choose* — Markleaf itself never goes online.
 
-[**View the branding page**](https://jeiel85.github.io/markleaf-android/) · [Current version: v2.24.0](https://github.com/jeiel85/markleaf-android/releases/tag/v2.24.0) · [GitLab release mirror](https://gitlab.com/jeiel85/markleaf-android/-/releases/v2.24.0) · [Privacy Policy](https://jeiel85.github.io/markleaf-android/privacy.html) · [F-Droid](https://f-droid.org/packages/com.markleaf.notes/) · [Google Play](https://play.google.com/store/apps/details?id=com.markleaf.notes)
+[**View the branding page**](https://jeiel85.github.io/markleaf-android/) · [Current version: v2.26.0](https://github.com/jeiel85/markleaf-android/releases/tag/v2.26.0) · [GitLab release mirror](https://gitlab.com/jeiel85/markleaf-android/-/releases/v2.26.0) · [Privacy Policy](https://jeiel85.github.io/markleaf-android/privacy.html) · [F-Droid](https://f-droid.org/packages/com.markleaf.notes/) · [Google Play](https://play.google.com/store/apps/details?id=com.markleaf.notes)
 
 ---
 
@@ -125,7 +125,7 @@ com.markleaf.notes
 > **Google Play updates are currently on hold.** New versions won't be pushed to the Play Store until a Korean business-registration policy requirement for the solo developer is resolved. In the meantime, **get the latest version from F-Droid, GitHub Releases, or GitLab Releases.** (If you already installed it from the Play Store, it keeps working.)
 
 - **F-Droid** *(recommended)*: [Markleaf on F-Droid](https://f-droid.org/packages/com.markleaf.notes/) — search in the F-Droid client or install via the link above. It uses the same signing key (SHA-256 `0be97352…f91a`), so updates continue seamlessly even if you sideloaded an APK from GitHub or GitLab Releases.
-- **Direct APK install**: download the APK from the [GitHub v2.24.0 release](https://github.com/jeiel85/markleaf-android/releases/tag/v2.24.0) or the [GitLab v2.24.0 release](https://gitlab.com/jeiel85/markleaf-android/-/releases/v2.24.0), then run it on your Android device.
+- **Direct APK install**: download the APK from the [GitHub v2.26.0 release](https://github.com/jeiel85/markleaf-android/releases/tag/v2.26.0) or the [GitLab v2.26.0 release](https://gitlab.com/jeiel85/markleaf-android/-/releases/v2.26.0), then run it on your Android device.
 - **Google Play**: [Markleaf on Google Play](https://play.google.com/store/apps/details?id=com.markleaf.notes) — **updates are paused** (see the note above). If you already have it, it keeps working, but get the latest version from F-Droid, GitHub, or GitLab.
 
 ### Building from source


### PR DESCRIPTION
## What

Bumps the release version in the four READMEs from **v2.24.0 → v2.26.0**.

`445deda` ("docs: advertise v2.26.0 on the landing pages") updated `docs/index*.html` but left the READMEs behind, so `README.{md,ko,ja,de}.md` still announced "current version: v2.24.0" and pointed the direct-APK links at the v2.24.0 tag on both GitHub and GitLab — two releases stale.

Each README carries the version in 7 places across 2 lines:

| Line | Occurrences |
|---|---|
| 39 — "Current version" badge | display text + GitHub `releases/tag/v…` + GitLab `releases/v…` |
| 128 — direct APK install | GitHub display + URL, GitLab display + URL |

Release version only. The landing-page `figcaption` screenshot version is untouched and stays at **v2.23.0** until the screenshots are retaken.

Historical references to v2.24.0 in `HISTORY.md`, `.agent/progress.md`, `AGENTS.md`, `docs/mirror-runbook.md`, and `CHANGELOG.md` are deliberately left alone — they describe past events.

## Verification

- `pwsh scripts/verify-landing-versions.ps1` → **exit 0** (all four languages `release=2.26.0`, `screenshot=2.23.0`)
- `git grep "2\.24\.0" -- 'README*.md'` → no matches
- Diff is a symmetric `2.24.0`↔`2.26.0` substitution (8 lines, 8+/8-), no other content changed

## Note for #157

The verify script only checks that the languages **agree with each other**, not that they match the current release — so four uniformly stale pages pass with exit 0. That blind spot is why this drift survived both v2.25.0 and v2.26.0.

This matters for #157: the `README.es/fr.md` and `docs/index.es/fr.html` it adds were translated from v2.24.0-era content and still say **v2.24.0**, and that PR extends the verify script to all six languages. Once #157 merges on top of this, es/fr will disagree with the other four and the script will **fail with exit 2**. Either rebase #157 onto this and bump its new files to v2.26.0, or land them together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
