### PR TITLE
fix(i18n): untranslated strings, Spanish diacritics, and four resource-correctness bugs

### DIFF
--- a/app/src/main/java/com/markleaf/notes/feature/notes/NotesListScreen.kt
+++ b/app/src/main/java/com/markleaf/notes/feature/notes/NotesListScreen.kt
@@ -576,7 +576,7 @@ private fun NoteRow(
             )
             DropdownMenuItem(
                 leadingIcon = { Icon(Icons.Default.Archive, contentDescription = null) },
-                text = { Text(stringResource(R.string.archive)) },
+                text = { Text(stringResource(R.string.archive_action)) },
                 onClick = {
                     menuExpanded = false
                     onArchive()

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -10,6 +10,7 @@
     <string name="tags">Tags</string>
     <string name="trash">Papierkorb</string>
     <string name="archive">Archiv</string>
+    <string name="archive_action">Archivieren</string>
     <string name="unarchive">Aus Archiv holen</string>
     <string name="archive_empty">Keine archivierten Notizen</string>
     <string name="archive_empty_hint">Halte eine Notiz in der Hauptliste gedrückt und wähle „Archivieren“, um sie hierher zu verschieben.</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -223,7 +223,7 @@
 
     <!-- Onboarding -->
     <string name="onboarding_title_welcome">Willkommen bei Markleaf</string>
-    <string name="onboarding_body_welcome">Eine ruhige, lokal-first Markdown-Notiz-App für Android. Dein Text bleibt auf diesem Gerät, sofern du ihn nicht ausdrücklich teilst oder exportierst.</string>
+    <string name="onboarding_body_welcome">Eine ruhige Markdown-Notiz-App für Android, die deine Notizen zuerst lokal speichert. Dein Text bleibt auf diesem Gerät, sofern du ihn nicht ausdrücklich teilst oder exportierst.</string>
     <string name="onboarding_title_markdown">In Markdown schreiben</string>
     <string name="onboarding_body_markdown">Nutze **fett**, _kursiv_, # Überschriften, Listen, Code und Zitate. Tippe oben auf Vorschau, um das Ergebnis jederzeit zu sehen.</string>
     <string name="onboarding_title_tags">Mit #Tags organisieren</string>
@@ -295,7 +295,7 @@
     <string name="privacy_dashboard_title">Datenschutz-Dashboard</string>
     <string name="privacy_guarantee_title">Deine Daten bleiben lokal</string>
     <string name="privacy_guarantee_desc">Markleaf ist konsequent auf Datenschutz ausgelegt. Deine Notizen verlassen dein Gerät nur, wenn du sie ausdrücklich exportierst oder teilst.</string>
-    <string name="privacy_data_storage_title">Lokal-first-Speicherung</string>
+    <string name="privacy_data_storage_title">Zuerst lokal gespeichert</string>
     <string name="privacy_data_storage_desc">Alle Notizen und Tags werden lokal auf deinem Gerät in Androids sicherer Room-Datenbank gespeichert. Keine Cloud-Server, keine Daten-Uploads.</string>
     <string name="privacy_no_cloud_title">Keine Cloud-Abhängigkeiten</string>
     <string name="privacy_no_cloud_desc">Wir nutzen für die Kernfunktionen keine Cloud-Dienste. Keine Google-Drive-Synchronisation, keine Dropbox-Integration, keine proprietären Backend-Server.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -10,6 +10,7 @@
     <string name="tags">Etiquetas</string>
     <string name="trash">Papelera</string>
     <string name="archive">Archivo</string>
+    <string name="archive_action">Archivar</string>
     <string name="unarchive">Quitar del archivo</string>
     <string name="archive_empty">No hay notas archivadas</string>
     <string name="archive_empty_hint">Mantén pulsada una nota en la lista principal y elige Archivar para moverla aquí.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -12,10 +12,10 @@
     <string name="archive">Archivo</string>
     <string name="unarchive">Quitar del archivo</string>
     <string name="archive_empty">No hay notas archivadas</string>
-    <string name="archive_empty_hint">Manten pulsada una nota en la lista principal y elige Archivar para moverla aqui.</string>
+    <string name="archive_empty_hint">Mantén pulsada una nota en la lista principal y elige Archivar para moverla aquí.</string>
     <string name="settings">Ajustes</string>
-    <string name="more_options">Mas opciones</string>
-    <string name="quick_switcher_title">Salto rapido</string>
+    <string name="more_options">Más opciones</string>
+    <string name="quick_switcher_title">Salto rápido</string>
     <string name="quick_switcher_hint">Saltar a nota…</string>
     <string name="quick_switcher_no_results">Ninguna nota coincide.</string>
     <string name="backlinks_section_title">Enlazado desde</string>
@@ -32,25 +32,25 @@
     <string name="font_description">La serif da a las notas un aire clásico, como de libro. El código siempre se muestra en monoespaciado.</string>
     <string name="all_notes">Todas las notas</string>
     <string name="no_notes_for_tag">No hay notas con esta etiqueta</string>
-    <string name="image_alt_dialog_title">Editar descripcion de la imagen</string>
+    <string name="image_alt_dialog_title">Editar descripción de la imagen</string>
     <string name="image_alt_dialog_description">El texto alternativo ayuda a los lectores de pantalla y se muestra cuando la imagen no carga.</string>
-    <string name="image_alt_dialog_label">Descripcion</string>
+    <string name="image_alt_dialog_label">Descripción</string>
     <string name="image_alt_dialog_save">Guardar</string>
     <string name="add_note">Agregar nota</string>
-    <string name="no_notes_yet">Aun no hay notas</string>
+    <string name="no_notes_yet">Aún no hay notas</string>
     <string name="create_first_note_hint">Toca + para crear tu primera nota</string>
     <string name="create_note">Crear nota</string>
-    <string name="untitled">Sin titulo</string>
-    <string name="untitled_parenthesized">(Sin titulo)</string>
+    <string name="untitled">Sin título</string>
+    <string name="untitled_parenthesized">(Sin título)</string>
     <string name="select_note_to_view">Selecciona una nota para verla</string>
 
     <string name="preview">Vista previa</string>
     <string name="edit">Editar</string>
     <string name="edit_note">Editar nota</string>
     <string name="new_note">Nueva nota</string>
-    <string name="back">Atras</string>
+    <string name="back">Atrás</string>
     <string name="note_content">Contenido de la nota</string>
-    <string name="editor_empty_title">Una pagina tranquila esta lista</string>
+    <string name="editor_empty_title">Una página tranquila está lista</string>
     <string name="editor_empty_hint">Usa Markdown, #etiquetas, enlaces y casillas. Markleaf guarda localmente mientras escribes.</string>
     <string name="bold">Negrita</string>
     <string name="formatting">Formato</string>
@@ -61,16 +61,16 @@
     <string name="collapsed">Contraído</string>
     <string name="italic">Cursiva</string>
     <string name="strikethrough">Tachado</string>
-    <string name="inline_code">Codigo en linea</string>
+    <string name="inline_code">Código en línea</string>
     <string name="checkbox">Casilla</string>
     <string name="markdown_link">Enlace Markdown</string>
     <string name="insert_image">Insertar imagen</string>
     <string name="attachment_failed">No se pudo adjuntar la imagen.</string>
     <string name="heading">Encabezado</string>
-    <string name="bullet_list">Lista con vinetas</string>
+    <string name="bullet_list">Lista con viñetas</string>
     <string name="ordered_list">Lista numerada</string>
     <string name="blockquote">Cita</string>
-    <string name="code_block">Bloque de codigo</string>
+    <string name="code_block">Bloque de código</string>
     <string name="horizontal_rule">Divisor</string>
     <string name="quick_insert_title">Inserción rápida</string>
     <string name="quick_insert_heading_1">Encabezado 1</string>
@@ -111,7 +111,7 @@
     <string name="callout_tip">Consejo</string>
     <string name="callout_important">Importante</string>
     <string name="callout_warning">Advertencia</string>
-    <string name="callout_caution">Precaucion</string>
+    <string name="callout_caution">Precaución</string>
 
     <string name="pin">Fijar</string>
     <string name="unpin">Quitar fijado</string>
@@ -119,7 +119,7 @@
     <string name="section_pinned">Fijadas</string>
     <string name="section_today">Hoy</string>
     <string name="section_yesterday">Ayer</string>
-    <string name="section_past_week">Ultimos 7 dias</string>
+    <string name="section_past_week">Últimos 7 días</string>
     <string name="section_older">Anteriores</string>
     <string name="relative_today">Hoy %1$s</string>
     <string name="relative_yesterday">Ayer %1$s</string>
@@ -131,26 +131,26 @@
     <string name="matching_notes">Notas</string>
     <string name="matching_tags">Etiquetas</string>
     <string name="tag_result_format">#%1$s</string>
-    <string name="no_tags_yet">Aun no hay etiquetas</string>
+    <string name="no_tags_yet">Aún no hay etiquetas</string>
     <string name="tags_empty_hint">Escribe #etiquetas en una nota para organizarla</string>
     <plurals name="tag_note_count_format">
         <item quantity="one">%1$d nota</item>
         <item quantity="other">%1$d notas</item>
     </plurals>
 
-    <string name="trash_empty">La papelera esta vacia</string>
-    <string name="trash_empty_hint">Las notas que elimines apareceran aqui</string>
+    <string name="trash_empty">La papelera está vacía</string>
+    <string name="trash_empty_hint">Las notas que elimines aparecerán aquí</string>
     <string name="restore">Restaurar</string>
     <string name="delete">Eliminar</string>
-    <string name="delete_forever_title">Eliminar para siempre?</string>
-    <string name="delete_forever_message">Esta nota se eliminara permanentemente y no se podra recuperar.</string>
+    <string name="delete_forever_title">¿Eliminar para siempre?</string>
+    <string name="delete_forever_message">Esta nota se eliminará permanentemente y no se podrá recuperar.</string>
     <string name="delete_forever">Eliminar para siempre</string>
     <string name="cancel">Cancelar</string>
 
     <string name="move_to_trash">Mover a la papelera</string>
-    <string name="move_to_trash_title">Mover a la papelera?</string>
-    <string name="move_to_trash_message">Mover \"%1$s\" a la papelera? Puedes restaurarla despues desde la Papelera.</string>
-    <string name="move_to_trash_editor_message">Mover esta nota a la papelera? Puedes restaurarla despues desde la Papelera.</string>
+    <string name="move_to_trash_title">¿Mover a la papelera?</string>
+    <string name="move_to_trash_message">¿Mover \"%1$s\" a la papelera? Puedes restaurarla después desde la Papelera.</string>
+    <string name="move_to_trash_editor_message">¿Mover esta nota a la papelera? Puedes restaurarla después desde la Papelera.</string>
 
     <string name="settings_appearance">Apariencia</string>
     <string name="theme_label">Tema</string>
@@ -161,14 +161,14 @@
     <string name="settings_markdown">Markdown</string>
     <string name="show_markdown_syntax">Mostrar sintaxis Markdown</string>
     <string name="show_markdown_syntax_description">El editor resalta caracteres Markdown mientras escribes.</string>
-    <string name="line_width">Ancho de linea</string>
+    <string name="line_width">Ancho de línea</string>
     <string name="line_width_narrow">Estrecho</string>
-    <string name="line_width_comfortable">Comodo</string>
+    <string name="line_width_comfortable">Cómodo</string>
     <string name="line_width_wide">Ancho</string>
     <string name="settings_privacy">Privacidad</string>
-    <string name="privacy_no_tracking">Sin cuenta, analiticas, anuncios, configuracion remota ni SDK propietario de fallos.</string>
+    <string name="privacy_no_tracking">Sin cuenta, analíticas, anuncios, configuración remota ni SDK propietario de fallos.</string>
     <string name="privacy_no_internet">El MVP no declara permiso INTERNET.</string>
-    <string name="privacy_local_first">Las notas salen del dispositivo solo cuando las exportas o compartes explicitamente.</string>
+    <string name="privacy_local_first">Las notas salen del dispositivo solo cuando las exportas o compartes explícitamente.</string>
     <string name="settings_data">Datos</string>
     <string name="export_all_notes">Exportar todas las notas…</string>
     <string name="export_all_notes_description">Elige una carpeta y Markleaf guarda cada nota como un archivo .md independiente. Las notas en la papelera se omiten.</string>
@@ -177,18 +177,18 @@
         <item quantity="other">%1$d notas exportadas.</item>
     </plurals>
 
-    <string name="sync_title">Sincronizacion entre dispositivos (carpeta espejo)</string>
-    <string name="sync_explainer">Markleaf nunca se conecta a internet por si mismo. En su lugar, tu eliges una carpeta y Markleaf guarda cada nota como archivo .md ahi. Si esa carpeta la sincroniza otra app — Dropbox, Drive, Syncthing, OneDrive, un NAS — tus notas siguen a tus otros dispositivos.</string>
+    <string name="sync_title">Sincronización entre dispositivos (carpeta espejo)</string>
+    <string name="sync_explainer">Markleaf nunca se conecta a internet por sí mismo. En su lugar, tú eliges una carpeta y Markleaf guarda cada nota como archivo .md ahí. Si esa carpeta la sincroniza otra app — Dropbox, Drive, Syncthing, OneDrive, un NAS — tus notas siguen a tus otros dispositivos.</string>
     <string name="sync_recommended_locations">Lugares recomendados:\n· /Almacenamiento interno/Dropbox/Markleaf\n· /Almacenamiento interno/Drive/Markleaf\n· /Almacenamiento interno/Sync/Markleaf  (Syncthing)</string>
     <string name="sync_status_unset">Ninguna carpeta seleccionada.</string>
     <string name="sync_status_folder_format">Carpeta: %1$s</string>
-    <string name="sync_status_last_synced_format">Ultima sincronizacion: %1$s</string>
-    <string name="sync_status_last_synced_never">Ultima sincronizacion: nunca</string>
-    <string name="sync_behavior_summary">· Guarda en la carpeta ~1 segundo despues de cada edicion.\n· "Sincronizar ahora" trae los cambios de otros dispositivos.\n· Conflictos: gana la edicion mas reciente.\n· Los borrados no se sincronizan — gestiona la papelera en cada dispositivo.</string>
+    <string name="sync_status_last_synced_format">Última sincronización: %1$s</string>
+    <string name="sync_status_last_synced_never">Última sincronización: nunca</string>
+    <string name="sync_behavior_summary">· Guarda en la carpeta ~1 segundo después de cada edición.\n· "Sincronizar ahora" trae los cambios de otros dispositivos.\n· Conflictos: gana la edición más reciente.\n· Los borrados no se sincronizan — gestiona la papelera en cada dispositivo.</string>
     <string name="sync_pick_folder">Elegir carpeta</string>
     <string name="sync_change_folder">Cambiar carpeta</string>
     <string name="sync_now">Sincronizar ahora</string>
-    <string name="sync_stop">Desactivar sincronizacion</string>
+    <string name="sync_stop">Desactivar sincronización</string>
     <plurals name="sync_seeded_format">
         <item quantity="one">%1$d nota reflejada en la carpeta.</item>
         <item quantity="other">%1$d notas reflejadas en la carpeta.</item>
@@ -201,41 +201,41 @@
     </plurals>
     <string name="sync_done_format">Sincronizado — %1$d actualizadas, %2$d nuevas, %3$d sin cambios.</string>
     <string name="sync_done_with_conflicts_format">Sincronizado — %1$d actualizadas, %2$d nuevas, %3$d guardadas como duplicado (conflicto), %4$d sin cambios.</string>
-    <string name="sync_stopped">Sincronizacion desactivada.</string>
+    <string name="sync_stopped">Sincronización desactivada.</string>
     <string name="screenshot_protection">Bloquear capturas y vista previa de Recientes</string>
     <string name="screenshot_protection_description">Oculta el contenido de las notas en capturas de pantalla y en la vista de aplicaciones recientes. Reabre el editor para aplicar el cambio.</string>
-    <string name="settings_app">Aplicacion</string>
-    <string name="version_format">Version %1$s</string>
-    <string name="application_id_format">Application ID %1$s</string>
+    <string name="settings_app">Aplicación</string>
+    <string name="version_format">Versión %1$s</string>
+    <string name="application_id_format">ID de aplicación %1$s</string>
 
     <!-- Widget -->
-    <string name="quick_note_widget_label">Nota rapida</string>
-    <string name="quick_note_widget_description">Toca para crear rapidamente una nueva nota</string>
+    <string name="quick_note_widget_label">Nota rápida</string>
+    <string name="quick_note_widget_description">Toca para crear rápidamente una nueva nota</string>
 
     <!-- Privacy Dashboard -->
     <string name="privacy_dashboard_title">Panel de privacidad</string>
     <string name="privacy_guarantee_title">Tus datos se quedan locales</string>
-    <string name="privacy_guarantee_desc">Markleaf esta disenado con la privacidad como nucleo. Tus notas nunca abandonan tu dispositivo a menos que elijas exportarlas o compartirlas explicitamente.</string>
+    <string name="privacy_guarantee_desc">Markleaf está diseñado con la privacidad como núcleo. Tus notas nunca abandonan tu dispositivo a menos que elijas exportarlas o compartirlas explícitamente.</string>
     <string name="privacy_data_storage_title">Almacenamiento local primero</string>
     <string name="privacy_data_storage_desc">Todas tus notas y etiquetas se almacenan localmente en tu dispositivo usando la base de datos segura Room de Android. Sin servidores en la nube, sin subidas de datos.</string>
     <string name="privacy_no_cloud_title">Sin dependencias de la nube</string>
-    <string name="privacy_no_cloud_desc">No usamos servicios en la nube para la funcionalidad principal. Sin sincronizacion con Google Drive, sin integracion con Dropbox, sin servidores backend propietarios.</string>
+    <string name="privacy_no_cloud_desc">No usamos servicios en la nube para la funcionalidad principal. Sin sincronización con Google Drive, sin integración con Dropbox, sin servidores backend propietarios.</string>
     <string name="privacy_no_tracking_title">Rastreo cero</string>
-    <string name="privacy_no_tracking_desc">Sin analiticas, sin SDKs de reporte de fallos, sin redes publicitarias. No tenemos idea de como usas la aplicacion, y nos gusta asi.</string>
-    <string name="privacy_verification_title">Verificacion de privacidad</string>
+    <string name="privacy_no_tracking_desc">Sin analíticas, sin SDKs de reporte de fallos, sin redes publicitarias. No tenemos idea de cómo usas la aplicación, y nos gusta así.</string>
+    <string name="privacy_verification_title">Verificación de privacidad</string>
     <string name="privacy_verify_no_internet">Permiso INTERNET no declarado</string>
     <string name="privacy_verify_local_only">Procesamiento de datos 100% local</string>
     <string name="privacy_verify_no_ads">Sin anuncios ni rastreadores</string>
-    <string name="privacy_verify_no_analytics">Sin analiticas ni telemetria</string>
-    <string name="privacy_verify_open_source">Codigo abierto y auditable</string>
-    <string name="privacy_app_info_title">Acerca de esta version</string>
-    <string name="privacy_app_info_desc">Version %1$s\n\nEsta version de Markleaf mantiene estrictos estandares de privacidad. Todas las caracteristicas funcionan completamente sin conexion.</string>
+    <string name="privacy_verify_no_analytics">Sin analíticas ni telemetría</string>
+    <string name="privacy_verify_open_source">Código abierto y auditable</string>
+    <string name="privacy_app_info_title">Acerca de esta versión</string>
+    <string name="privacy_app_info_desc">Versión %1$s\n\nEsta versión de Markleaf mantiene estrictos estándares de privacidad. Todas las características funcionan completamente sin conexión.</string>
     <string name="privacy_dashboard_button">Ver panel de privacidad</string>
 
-    <string name="settings_open_source">Codigo abierto</string>
+    <string name="settings_open_source">Código abierto</string>
     <string name="oss_license_label">Licencia</string>
     <string name="oss_license_value">Apache License 2.0</string>
-    <string name="oss_source_label">Codigo fuente</string>
+    <string name="oss_source_label">Código fuente</string>
     <string name="oss_source_url">https://github.com/jeiel85/markleaf-android</string>
     <string name="oss_view_source">Ver en GitHub</string>
     <string name="oss_view_license">Ver licencia completa</string>
@@ -243,31 +243,31 @@
     <string name="oss_fdroid_label">F-Droid</string>
     <string name="oss_fdroid_url">https://f-droid.org/packages/com.markleaf.notes/</string>
     <string name="oss_view_fdroid">Ver en F-Droid</string>
-    <string name="oss_explainer">Markleaf es totalmente codigo abierto bajo Apache 2.0. Lee el codigo, audita como se guardan tus notas y contribuye en GitHub.</string>
+    <string name="oss_explainer">Markleaf es totalmente código abierto bajo Apache 2.0. Lee el código, audita cómo se guardan tus notas y contribuye en GitHub.</string>
 
     <!-- Onboarding -->
     <string name="onboarding_title_welcome">Bienvenido a Markleaf</string>
-    <string name="onboarding_body_welcome">Una aplicacion tranquila de notas Markdown local-first para Android. Tu texto se queda en este dispositivo a menos que decidas compartirlo o exportarlo.</string>
+    <string name="onboarding_body_welcome">Una aplicación tranquila de notas Markdown, con almacenamiento local primero, para Android. Tu texto se queda en este dispositivo a menos que decidas compartirlo o exportarlo.</string>
     <string name="onboarding_title_markdown">Escribe en Markdown</string>
-    <string name="onboarding_body_markdown">Usa **negrita**, _cursiva_, # titulos, listas, codigo y citas. Toca Vista previa en la barra superior para ver el resultado renderizado en cualquier momento.</string>
+    <string name="onboarding_body_markdown">Usa **negrita**, _cursiva_, # títulos, listas, código y citas. Toca Vista previa en la barra superior para ver el resultado renderizado en cualquier momento.</string>
     <string name="onboarding_title_tags">Organiza con #etiquetas</string>
-    <string name="onboarding_body_tags">Escribe #proyecto o #reunion en cualquier parte de una nota. Las etiquetas se detectan automaticamente y aparecen en la pantalla de Etiquetas.</string>
+    <string name="onboarding_body_tags">Escribe #proyecto o #reunión en cualquier parte de una nota. Las etiquetas se detectan automáticamente y aparecen en la pantalla de Etiquetas.</string>
     <string name="onboarding_title_local">Tus datos se quedan locales</string>
-    <string name="onboarding_body_local">Sin cuenta, sin analiticas, sin nube. Exporta cualquier nota como archivo .md, o apunta Markleaf a una carpeta sincronizada (Dropbox / Drive / Syncthing) para multi-dispositivo.</string>
+    <string name="onboarding_body_local">Sin cuenta, sin analíticas, sin nube. Exporta cualquier nota como archivo .md, o apunta Markleaf a una carpeta sincronizada (Dropbox / Drive / Syncthing) para multi-dispositivo.</string>
     <string name="onboarding_next">Siguiente</string>
     <string name="onboarding_done">Empezar</string>
     <string name="onboarding_skip">Omitir</string>
 
     <!-- Biometric lock -->
-    <string name="biometric_lock_title">Bloqueo de la aplicacion</string>
-    <string name="biometric_lock_setting">Requerir biometria al abrir</string>
-    <string name="biometric_lock_description">Se requiere huella o reconocimiento facial cuando se abre Markleaf. Las notas en si nunca salen del dispositivo.</string>
+    <string name="biometric_lock_title">Bloqueo de la aplicación</string>
+    <string name="biometric_lock_setting">Requerir biometría al abrir</string>
+    <string name="biometric_lock_description">Se requiere huella o reconocimiento facial cuando se abre Markleaf. Las notas en sí nunca salen del dispositivo.</string>
     <string name="biometric_lock_prompt_title">Desbloquear Markleaf</string>
-    <string name="biometric_lock_prompt_subtitle">Autenticate para acceder a tus notas</string>
+    <string name="biometric_lock_prompt_subtitle">Autentícate para acceder a tus notas</string>
     <string name="biometric_lock_cancel">Cancelar</string>
-    <string name="biometric_lock_unavailable">La autenticacion biometrica no esta disponible en este dispositivo. Configura una huella o cara en los ajustes del sistema para usar el bloqueo.</string>
+    <string name="biometric_lock_unavailable">La autenticación biométrica no está disponible en este dispositivo. Configura una huella o cara en los ajustes del sistema para usar el bloqueo.</string>
     <string name="biometric_lock_retry">Reintentar</string>
-    <string name="biometric_lock_locked_message">Markleaf esta bloqueado.</string>
+    <string name="biometric_lock_locked_message">Markleaf está bloqueado.</string>
 
     <!-- Locked notes (#155) -->
     <string name="locked_notes_title">Notas bloqueadas</string>
@@ -309,7 +309,7 @@
     <!-- PDF export -->
     <string name="export_pdf">Exportar como PDF…</string>
     <string name="export_pdf_job_name">Markleaf — %1$s</string>
-    <string name="export_pdf_unavailable">La exportacion a PDF solo esta disponible en Android 5 y posteriores.</string>
+    <string name="export_pdf_unavailable">La exportación a PDF solo está disponible en Android 5 y posteriores.</string>
 
     <!-- Sync & Conflict Center -->
     <string name="sync_center_title">Centro de sincronización</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -184,7 +184,7 @@
     <string name="sync_status_folder_format">Carpeta: %1$s</string>
     <string name="sync_status_last_synced_format">Última sincronización: %1$s</string>
     <string name="sync_status_last_synced_never">Última sincronización: nunca</string>
-    <string name="sync_behavior_summary">· Guarda en la carpeta ~1 segundo después de cada edición.\n· "Sincronizar ahora" trae los cambios de otros dispositivos.\n· Conflictos: gana la edición más reciente.\n· Los borrados no se sincronizan — gestiona la papelera en cada dispositivo.</string>
+    <string name="sync_behavior_summary">· Guarda en la carpeta ~1 segundo después de cada edición.\n· \"Sincronizar ahora\" trae los cambios de otros dispositivos.\n· Conflictos: gana la edición más reciente.\n· Los borrados no se sincronizan — gestiona la papelera en cada dispositivo.</string>
     <string name="sync_pick_folder">Elegir carpeta</string>
     <string name="sync_change_folder">Cambiar carpeta</string>
     <string name="sync_now">Sincronizar ahora</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -10,6 +10,7 @@
     <string name="tags">Étiquettes</string>
     <string name="trash">Corbeille</string>
     <string name="archive">Archives</string>
+    <string name="archive_action">Archiver</string>
     <string name="unarchive">Désarchiver</string>
     <string name="archive_empty">Aucune note archivée</string>
     <string name="archive_empty_hint">Appuyez longuement sur une note dans la liste principale et choisissez Archiver pour la déplacer ici.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -177,9 +177,9 @@
         <item quantity="other">%1$d notes exportées.</item>
     </plurals>
 
-    <string name="sync_title">Multi-device sync (folder mirror)</string>
-    <string name="sync_explainer">Markleaf ne se connecte jamais à Internet lui-même. Au lieu de cela, vous choisissez un dossier et Markleaf y enregistre chaque note sous forme de fichier `.md`. Si ce dossier est synchronisé par une autre application — Dropbox, Drive, Syncthing, OneDrive, a NAS — vos notes suivent vos autres appareils.</string>
-    <string name="sync_recommended_locations">Good places to point Markleaf at:\n· /Internal storage/Dropbox/Markleaf\n· /Internal storage/Drive/Markleaf\n· /Internal storage/Sync/Markleaf  (Syncthing)</string>
+    <string name="sync_title">Synchronisation multi-appareils (dossier miroir)</string>
+    <string name="sync_explainer">Markleaf ne se connecte jamais à Internet lui-même. Au lieu de cela, vous choisissez un dossier et Markleaf y enregistre chaque note sous forme de fichier `.md`. Si ce dossier est synchronisé par une autre application — Dropbox, Drive, Syncthing, OneDrive, un NAS — vos notes suivent vos autres appareils.</string>
+    <string name="sync_recommended_locations">Emplacements recommandés pour Markleaf :\n· /Stockage interne/Dropbox/Markleaf\n· /Stockage interne/Drive/Markleaf\n· /Stockage interne/Sync/Markleaf  (Syncthing)</string>
     <string name="sync_status_unset">Aucun dossier sélectionné.</string>
     <string name="sync_status_folder_format">Dossier : %1$s</string>
     <string name="sync_status_last_synced_format">Dernière synchronisation : %1$s</string>
@@ -263,7 +263,7 @@
     <string name="locked_need_passcode_title">Définissez d\'abord un code</string>
     <string name="locked_need_passcode_message">Pour verrouiller des notes, définissez un code de notes verrouillées dans les Paramètres.</string>
     <string name="locked_passcode_setting_title">Code des notes verrouillées</string>
-    <string name="locked_passcode_setting_description">Protège les notes déplacées vers Verrouillées. Les masque dans l\'app — ce n\'est pas un chiffrement complet.</string>
+    <string name="locked_passcode_setting_description">Protège les notes déplacées vers Verrouillées. Cela les masque dans l\'application — ce n\'est pas un chiffrement complet.</string>
     <string name="locked_passcode_set">Définir un code</string>
     <string name="locked_passcode_change">Modifier le code</string>
     <string name="locked_passcode_remove">Supprimer le code</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -243,7 +243,7 @@
     <!-- Locked notes (#155) -->
     <string name="locked_notes_title">ロックされたノート</string>
     <string name="move_to_locked">ロックに移動</string>
-    <string name="remove_from_locked">ロックを解除</string>
+    <string name="remove_from_locked">ロックから戻す</string>
     <string name="locked_notes_empty">ロックされたノートはありません</string>
     <string name="locked_notes_empty_hint">ロックに移動したノートは、パスコードの内側にここに表示されます。</string>
     <string name="locked_unlock_hint">ロックされたノートを開くにはパスコードを入力してください。</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -10,6 +10,7 @@
     <string name="tags">タグ</string>
     <string name="trash">ゴミ箱</string>
     <string name="archive">アーカイブ</string>
+    <string name="archive_action">アーカイブ</string>
     <string name="unarchive">アーカイブ解除</string>
     <string name="archive_empty">アーカイブされたノートはありません</string>
     <string name="archive_empty_hint">メイン一覧でノートを長押しし、アーカイブを選ぶとここに移動します。</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -201,7 +201,7 @@
     <string name="screenshot_protection_description">スクリーンショットや最近使ったアプリ画面でノート内容を非表示にします。変更を反映するにはエディタを開き直してください。</string>
     <string name="settings_app">アプリ</string>
     <string name="version_format">バージョン %1$s</string>
-    <string name="application_id_format">Application ID %1$s</string>
+    <string name="application_id_format">アプリケーション ID %1$s</string>
 
     <string name="settings_open_source">オープンソース</string>
     <string name="oss_license_label">ライセンス</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -10,6 +10,7 @@
     <string name="tags">태그</string>
     <string name="trash">휴지통</string>
     <string name="archive">보관함</string>
+    <string name="archive_action">보관</string>
     <string name="unarchive">보관 해제</string>
     <string name="archive_empty">보관된 노트가 없습니다</string>
     <string name="archive_empty_hint">노트 목록에서 길게 눌러 \"보관\"을 선택하면 여기로 옮겨집니다.</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -147,7 +147,7 @@
 
     <string name="move_to_trash">휴지통으로 이동</string>
     <string name="move_to_trash_title">휴지통으로 옮길까요?</string>
-    <string name="move_to_trash_message">\"%1$s\"를 휴지통으로 옮길까요? 나중에 다시 꺼낼 수 있습니다.</string>
+    <string name="move_to_trash_message">\"%1$s\" 노트를 휴지통으로 옮길까요? 나중에 다시 꺼낼 수 있습니다.</string>
     <string name="move_to_trash_editor_message">이 노트를 휴지통으로 옮길까요? 나중에 다시 꺼낼 수 있습니다.</string>
 
     <string name="settings_appearance">테마</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -154,7 +154,7 @@
     <string name="theme_label">테마</string>
     <string name="theme_markleaf_green">Markleaf 그린</string>
     <string name="theme_material_you">Material You</string>
-    <string name="theme_description">Markleaf 그린은 앱 이름의 leaf와 어울리는 원래 색상입니다. Material You는 Android 12 이상에서 시스템 배경화면의 색을 따라갑니다.</string>
+    <string name="theme_description">Markleaf 그린은 앱 이름의 잎과 어울리는 원래 색상입니다. Material You는 Android 12 이상에서 시스템 배경화면의 색을 따라갑니다.</string>
 
     <string name="settings_markdown">Markdown</string>
     <string name="show_markdown_syntax">Markdown 문법 표시</string>
@@ -201,7 +201,7 @@
     <string name="screenshot_protection_description">노트 본문이 스크린샷과 최근 앱 화면에 표시되지 않도록 합니다. 변경 사항이 반영되려면 에디터를 다시 열어주세요.</string>
     <string name="settings_app">앱</string>
     <string name="version_format">버전 %1$s</string>
-    <string name="application_id_format">Application ID %1$s</string>
+    <string name="application_id_format">애플리케이션 ID %1$s</string>
 
     <string name="settings_open_source">오픈소스</string>
     <string name="oss_license_label">라이선스</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -243,7 +243,7 @@
     <!-- Locked notes (#155) -->
     <string name="locked_notes_title">잠긴 노트</string>
     <string name="move_to_locked">잠금으로 이동</string>
-    <string name="remove_from_locked">잠금 해제</string>
+    <string name="remove_from_locked">잠금에서 제거</string>
     <string name="locked_notes_empty">잠긴 노트 없음</string>
     <string name="locked_notes_empty_hint">잠금으로 옮긴 노트가 암호 뒤에 여기 표시됩니다.</string>
     <string name="locked_unlock_hint">잠긴 노트를 열려면 암호를 입력하세요.</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -12,7 +12,7 @@
     <string name="archive">보관함</string>
     <string name="unarchive">보관 해제</string>
     <string name="archive_empty">보관된 노트가 없습니다</string>
-    <string name="archive_empty_hint">노트 목록에서 길게 눌러 "보관"을 선택하면 여기로 옮겨집니다.</string>
+    <string name="archive_empty_hint">노트 목록에서 길게 눌러 \"보관\"을 선택하면 여기로 옮겨집니다.</string>
     <string name="settings">설정</string>
     <string name="more_options">추가 옵션</string>
     <string name="quick_switcher_title">빠른 이동</string>
@@ -181,7 +181,7 @@
     <string name="sync_status_folder_format">현재 폴더: %1$s</string>
     <string name="sync_status_last_synced_format">마지막 동기화: %1$s</string>
     <string name="sync_status_last_synced_never">마지막 동기화: 아직 없음</string>
-    <string name="sync_behavior_summary">· 편집하고 약 1초 뒤 폴더에 자동으로 저장됩니다.\n· "지금 동기화"를 누르면 다른 기기의 변경 내용을 가져옵니다.\n· 같은 노트가 양쪽에서 바뀌면 더 최근에 수정한 쪽이 남습니다.\n· 삭제는 동기화되지 않습니다 — 각 기기에서 따로 정리해 주세요.</string>
+    <string name="sync_behavior_summary">· 편집하고 약 1초 뒤 폴더에 자동으로 저장됩니다.\n· \"지금 동기화\"를 누르면 다른 기기의 변경 내용을 가져옵니다.\n· 같은 노트가 양쪽에서 바뀌면 더 최근에 수정한 쪽이 남습니다.\n· 삭제는 동기화되지 않습니다 — 각 기기에서 따로 정리해 주세요.</string>
     <string name="sync_pick_folder">동기화 폴더 선택</string>
     <string name="sync_change_folder">폴더 변경</string>
     <string name="sync_now">지금 동기화</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,7 +9,12 @@
     <string name="search">Search</string>
     <string name="tags">Tags</string>
     <string name="trash">Trash</string>
+    <!-- "archive" names the destination: the Archive screen title, and the overflow
+         item that navigates there. "archive_action" is the verb on a note's own menu.
+         English spells both the same, but most locales need a noun and a verb, and
+         archive_empty_hint tells the user which menu entry to look for. -->
     <string name="archive">Archive</string>
+    <string name="archive_action">Archive</string>
     <string name="unarchive">Unarchive</string>
     <string name="archive_empty">No archived notes</string>
     <string name="archive_empty_hint">Long-press a note in the main list and choose Archive to move it here.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -184,7 +184,7 @@
     <string name="sync_status_folder_format">Folder: %1$s</string>
     <string name="sync_status_last_synced_format">Last synced: %1$s</string>
     <string name="sync_status_last_synced_never">Last synced: never</string>
-    <string name="sync_behavior_summary">· Saves to the folder ~1 second after each edit.\n· "Sync now" pulls in changes from other devices.\n· Conflicts: the most recent edit wins.\n· Deletions are not synced — manage trash on each device.</string>
+    <string name="sync_behavior_summary">· Saves to the folder ~1 second after each edit.\n· \"Sync now\" pulls in changes from other devices.\n· Conflicts: the most recent edit wins.\n· Deletions are not synced — manage trash on each device.</string>
     <string name="sync_pick_folder">Choose sync folder</string>
     <string name="sync_change_folder">Change folder</string>
     <string name="sync_now">Sync now</string>


### PR DESCRIPTION
Reported: `sync_title` in `values-fr` was showing the English source ("Multi-device sync (folder mirror)") on French devices. Auditing for that pattern turned up more of it, plus a separate orthography defect in `values-es`.

## Why lint never caught this

`lintRelease` passes on the unmodified code, with `sync_title` sitting there in English. `MissingTranslation` only fires when a `<string>` is **absent**; a present-but-untranslated one is indistinguishable from a legitimately identical value (`Markleaf`, `F-Droid`, `Apache License 2.0`, URLs, `#%1$s`). That is why these reached release.

This PR does not close that gap — a regression guard (`UntranslatedStringTest`, run under `./gradlew test`) is in **#164**, opened after this one merged.

## Untranslated English

| locale | resource | was | now |
|---|---|---|---|
| fr | `sync_title` | `Multi-device sync (folder mirror)` | `Synchronisation multi-appareils (dossier miroir)` |
| fr | `sync_recommended_locations` | English prose + `/Internal storage/` | French + `/Stockage interne/` |
| fr | `sync_explainer` | `OneDrive, a NAS` | `OneDrive, un NAS` |
| fr | `locked_passcode_setting_description` | `l'app`, subjectless `Les masque` | `l'application`, `Cela les masque` |
| de | `onboarding_body_welcome` | `lokal-first` (neither language) | fully German |
| de | `privacy_data_storage_title` | `Lokal-first-Speicherung` | `Zuerst lokal gespeichert` |
| es | `application_id_format` | `Application ID %1$s` | `ID de aplicación %1$s` |
| es | `onboarding_body_welcome` | `local-first` | `con almacenamiento local primero` |
| ja | `application_id_format` | `Application ID %1$s` | `アプリケーション ID %1$s` |
| ko | `application_id_format` | `Application ID %1$s` | `애플리케이션 ID %1$s` |
| ko | `theme_description` | bare English `leaf` in Korean prose | `잎` |

Two of these — the fr `a NAS` fragment and the de/es `local-first` hybrids — are invisible to exact-string comparison, since the surrounding text *is* translated.

`application_id_format` was English in es/de/ja/ko; only fr had translated it. Translated where the adjacent `version_format` was already localised (es/ja/ko). **Left as-is in de**, where `Version` is also the German word so there is no inconsistency to resolve, and the file deliberately keeps other English loanwords.

## Spanish diacritics

`values-es` spelled the same word both ways, which is self-proving without any external dictionary:

`código`/`codigo` ×8 · `sincronización`/`sincronizacion` ×6 · `viñetas`/`vinetas` · `línea`/`linea` · `título`/`titulo` · `días`/`dias` · `aquí`/`aqui` · `rápida`/`rapida` · `aún`/`aun`

Four interrogatives were also missing the opening `¿` (`delete_forever_title`, `move_to_trash_title`, `move_to_trash_message`, `move_to_trash_editor_message`) while two others had it. **59 entries corrected.** Distinct accented word-types went from 27 to 70.

Homographs where the unaccented spelling is correct were deliberately left alone: comparative `como` ×8 (*"Guardar **como** archivo .md"*), possessive `tu` ×6, demonstrative `esta` ×5, conditional `Si` ×1, and `solo` per the 2010 RAE rule.

## `remove_from_locked` mistranslation (ja/ko)

Pulled in from #161 on request; everything else there stays out of this PR.

*Remove from Locked* takes a single note **out** of the Locked space and returns it to the note list (`LockedNotesScreen.kt:343`, `removeLock()`, which also restores the note's sync mirror file). Both ja and ko rendered it as *unlock* — a different action.

In Korean it was worse than a mistranslation: `remove_from_locked` and `locked_unlock_button` were the **byte-identical** string `잠금 해제`, so the per-note menu item and the passcode-entry button showed the same label for unrelated actions.

| | was | now |
|---|---|---|
| ja | `ロックを解除` | `ロックから戻す` |
| ko | `잠금 해제` | `잠금에서 제거` |

Both now pair with `move_to_locked` (`ロックに移動` / `잠금으로 이동`) and match how the app already describes this operation in `locked_passcode_removed_done` (`ノート一覧に戻しました` / `노트 목록으로 되돌렸습니다`). de, fr and es already had it right (`Aus Gesperrt entfernen`, `Retirer de Verrouillées`, `Quitar de Bloqueadas`), which is what established the intended meaning. The two labels are now distinct in all six locales.

## Korean object particle broken by a placeholder (ko)

Also pulled in from #161 on request.

Korean selects the object particle by whether the preceding noun ends in a consonant: `을` after a 받침, `를` otherwise. `move_to_trash_message` hardcoded `를` directly after the note-title placeholder:

| title | before | after |
|---|---|---|
| `회의록` (consonant-final) | `"회의록"를 휴지통으로…` ✗ should be `을` | `"회의록" 노트를 휴지통으로…` ✓ |
| `메모` (vowel-final) | `"메모"를 휴지통으로…` ✓ | `"메모" 노트를 휴지통으로…` ✓ |

Android cannot select a particle at format time, so it has to sit on a fixed noun. Putting it on `노트` also makes the string parallel to its own sibling `move_to_trash_editor_message`, which already reads `이 노트를 휴지통으로 옮길까요?`.

Every ko string was scanned for a variable particle (`을/를`, `이/가`, `은/는`, `과/와`, `으로/로`, …) adjacent to a placeholder: **11 placeholders are followed by Hangul and this was the only breaking one.** The other 10 are safe because the particle attaches to a fixed counter noun (`%1$d개를`, `%1$d단어`, `%1$s 후에`) rather than to the substituted value. The scan reports 0 after the change.

## Quotes silently stripped at build time (incl. the English source)

Also pulled in from #161 on request. **This one changes `values/strings.xml`.**

Android treats a bare `"` in a string resource as a whitespace-preservation delimiter and removes it from the compiled string; a literal quote must be written `\"`. Confirmed empirically with `aapt2 36.1.0` rather than from documentation — compiling a probe resource gave:

| source | compiled output |
|---|---|
| `Tap "Sync now" to pull changes.` | `Tap Sync now to pull changes.` ← quotes gone |
| `Tap \"Sync now\" to pull changes.` | `Tap "Sync now" to pull changes.` ✅ |

A scan of all six resource files found exactly 4 affected strings (8 bare quotes):

| file | resource | quoted text |
|---|---|---|
| `values/` | `sync_behavior_summary` | `"Sync now"` |
| `values-es/` | `sync_behavior_summary` | `"Sincronizar ahora"` |
| `values-ko/` | `sync_behavior_summary` | `"지금 동기화"` |
| `values-ko/` | `archive_empty_hint` | `"보관"` |

**The English source carried the bug**, which is how es and ko inherited the structure. fr already escaped correctly (`\"Synchroniser maintenant\"`), de used `„…"` and ja used `「…」`, so those three were never affected.

After the fix the real resource files were re-compiled with aapt2 and all four now emit their quotes. Bare-quote scan: 8 → 0.

Because this touches the default resource, regression surface was checked first: no test references either string, and none of the 42 Roborazzi snapshots covers the Sync Center or Archive empty state (they are all editor/markdown surfaces), so no snapshot re-record is needed. `:app:testDebugUnitTest` passes.

## `archive_empty_hint` named a menu entry that doesn't exist

Last item pulled in from #161. **This one changes Kotlin**, not just resources.

`archive_empty_hint` tells the user to long-press a note and choose a menu entry, but `R.string.archive` served both the Archive *destination* and the per-note archive *action*. English gets away with it because "Archive" is both noun and verb; other locales must pick one, so the hint pointed at a label that isn't on screen:

| locale | hint told the user to choose | menu actually showed |
|---|---|---|
| fr | `Archiver` | `Archives` |
| es | `Archivar` | `Archivo` |
| de | `„Archivieren"` | `Archiv` |
| ko | `"보관"` | `보관함` |

**The translations were already correct** — every locale's hint used the verb. Only the resource structure was wrong, so adding `archive_action` makes all six hints true *without editing a single hint string*; each locale's verb was taken from the wording its own hint already used.

What each call site actually does was checked rather than assumed:

| call site | behaviour | resource |
|---|---|---|
| `ArchiveScreen.kt:71` | screen title | `archive` (noun) |
| `NotesListScreen.kt:251` | `navController.navigate(NavRoutes.ARCHIVE)` — opens the Archive screen | `archive` (noun) |
| `NotesListScreen.kt:579` | `onArchive()` — archives this note | **`archive_action`** (verb) |

Only `:579` changed. `:251` is navigation, so the noun is right there and fr/de/ko keep showing `Archives`/`Archiv`/`보관함` for it — changing both would have introduced a new bug. `unarchive` needed no change: single call site, and every locale already renders it as a verb. `values/strings.xml` carries a comment explaining the split so it doesn't get merged back.

## Deliberately not changed

- **ja/ko `<plurals>` keep only `quantity="other"`.** CLDR defines no plural distinction for either language; all 5 plurals are consistently `other`-only in both files. Adding `one` would trip lint's `UnusedQuantity`. An initial mechanical pass flagged these as "5 missing entries" — they are not.
- **de keeps `Tags`, `Checkbox`, `App`, `Passcode`.** Established German loanwords, already morphologically integrated elsewhere in the file ("Checkboxen", "Noch keine Tags").

## Verification

- All six resource files parse.
- The es diff is provably **59 diacritic-only entries + exactly 2 intended semantic changes**, established by comparing both sides with accents stripped — so no meaning drifted while touching 61 strings.
- `./gradlew :app:lintRelease` → `BUILD SUCCESSFUL`, identical to the pre-change baseline captured before any edit.

This PR fixes the four **structural** user-visible bugs from #161 (broken particle, stripped quotes, wrong action label, missing menu label). Three wording-accuracy bugs remain open there (fr `privacy_data_storage_desc`, ko `editor_empty_hint`, de `expanded`/`collapsed`), along with terminology drift. The CI guard moved to #164, which was opened after this PR merged.

## Verification summary

| check | result |
|---|---|
| all six resource files parse | ✅ |
| es diff is 59 diacritic-only + exactly 2 intended semantic changes | ✅ proved by accent-stripped comparison |
| `remove_from_locked` vs `locked_unlock_button` distinct in all 6 locales | ✅ |
| ko variable-particle scan after a placeholder | ✅ 1 → 0 |
| bare-quote scan across all 6 files | ✅ 8 → 0 |
| aapt2 compile of real resources: quotes survive | ✅ |
| every locale's `archive_empty_hint` contains its own `archive_action` | ✅ 6/6 |
| `./gradlew :app:lintRelease` | ✅ matches pre-change baseline |
| `./gradlew test` (all 3 unit-test variants) | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
