### PR TITLE
test(i18n): fail the build when a locale string is still English

### DIFF
--- a/app/src/test/java/com/markleaf/notes/UntranslatedStringTest.kt
+++ b/app/src/test/java/com/markleaf/notes/UntranslatedStringTest.kt
@@ -1,0 +1,185 @@
+package com.markleaf.notes
+
+import java.io.File
+import javax.xml.parsers.DocumentBuilderFactory
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.w3c.dom.Element
+
+/**
+ * Catches locale strings that still hold the English source text.
+ *
+ * Android lint cannot do this. `MissingTranslation` only fires when a `<string>`
+ * is *absent*, and a present-but-untranslated value is indistinguishable from
+ * one that is legitimately identical — a brand name, a URL, a format-only
+ * string, or a word that simply coincides. That is how `sync_title` shipped
+ * reading "Multi-device sync (folder mirror)" on French devices while
+ * `lintRelease` stayed green (#161).
+ *
+ * So anything identical to `values/` has to be named below as deliberate, and
+ * [allowlistEntriesAreStillNeeded] fails as soon as an entry stops being needed,
+ * so the list cannot rot into a blanket exemption that hides the next
+ * regression.
+ */
+class UntranslatedStringTest {
+
+    @Test
+    fun localeStringsAreNotStillEnglish() {
+        val english = readStrings(resDir().resolve("values/strings.xml"))
+        val offenders = mutableListOf<String>()
+
+        for (locale in LOCALES) {
+            val allowed = STRUCTURALLY_IDENTICAL + LANGUAGE_COINCIDENCES.getValue(locale)
+            for ((key, value) in readStrings(stringsFor(locale))) {
+                if (key !in allowed && english[key] == value) {
+                    offenders += "values-$locale  $key = \"$value\""
+                }
+            }
+        }
+
+        assertTrue(
+            buildString {
+                appendLine("These locale strings still hold the English source text.")
+                appendLine("Translate them — or, if the value really is identical in that")
+                appendLine("language, add the key to this test's allowlist with a reason:")
+                offenders.sorted().forEach { appendLine("  - $it") }
+            },
+            offenders.isEmpty()
+        )
+    }
+
+    @Test
+    fun allowlistEntriesAreStillNeeded() {
+        val english = readStrings(resDir().resolve("values/strings.xml"))
+        val stale = mutableListOf<String>()
+
+        for (locale in LOCALES) {
+            val translated = readStrings(stringsFor(locale))
+            for (key in STRUCTURALLY_IDENTICAL + LANGUAGE_COINCIDENCES.getValue(locale)) {
+                val value = translated[key]
+                when {
+                    value == null -> stale += "values-$locale  $key (no longer exists)"
+                    english[key] != value -> stale += "values-$locale  $key (now translated)"
+                }
+            }
+        }
+
+        assertTrue(
+            buildString {
+                appendLine("These allowlist entries are no longer identical to English.")
+                appendLine("Remove them, so the allowlist keeps naming real exceptions rather")
+                appendLine("than silently exempting strings that could regress later:")
+                stale.sorted().forEach { appendLine("  - $it") }
+            },
+            stale.isEmpty()
+        )
+    }
+
+    private fun resDir(): File {
+        val res = File("src/main/res")
+        assertTrue(
+            "Expected to run with the app module as the working directory, " +
+                "but ${res.absolutePath} does not exist",
+            res.isDirectory
+        )
+        return res
+    }
+
+    private fun stringsFor(locale: String) = resDir().resolve("values-$locale/strings.xml")
+
+    /** Flattens a resource file to `name` -> value, with plurals as `name[quantity]`. */
+    private fun readStrings(file: File): Map<String, String> {
+        val root = DocumentBuilderFactory.newInstance()
+            .newDocumentBuilder()
+            .parse(file)
+            .documentElement
+            .childNodes
+        val values = mutableMapOf<String, String>()
+        for (i in 0 until root.length) {
+            val element = root.item(i) as? Element ?: continue
+            val name = element.getAttribute("name")
+            if (name.isEmpty()) continue
+            when (element.tagName) {
+                "string" -> values[name] = element.textContent
+                "plurals", "string-array" -> {
+                    val items = element.getElementsByTagName("item")
+                    for (j in 0 until items.length) {
+                        val item = items.item(j) as Element
+                        val key = item.getAttribute("quantity").ifEmpty { j.toString() }
+                        values["$name[$key]"] = item.textContent
+                    }
+                }
+            }
+        }
+        return values
+    }
+
+    private companion object {
+        val LOCALES = listOf("fr", "es", "de", "ja", "ko")
+
+        /**
+         * Identical in every language because they are not prose: the app name,
+         * brand names, URLs, a license title, and format-only strings.
+         */
+        val STRUCTURALLY_IDENTICAL = setOf(
+            "app_name",
+            "export_pdf_job_name",
+            "oss_fdroid_label",
+            "oss_fdroid_url",
+            "oss_license_url",
+            "oss_license_value",
+            "oss_source_url",
+            "settings_markdown",
+            "tag_result_format",
+            "theme_material_you"
+        )
+
+        /**
+         * Words that genuinely coincide with English in one language. Each entry
+         * is a translator's decision, not an oversight — so a new one belongs
+         * here only after checking the word really is correct in that language.
+         */
+        val LANGUAGE_COINCIDENCES = mapOf(
+            // French spells these the same as English.
+            "fr" to setOf(
+                "callout_important",
+                "callout_note",
+                "font_sans",
+                "font_serif",
+                "formatting_structure",
+                "image_alt_dialog_label",
+                "matching_notes",
+                "notes_title",
+                "quick_insert_image",
+                "settings_open_source",
+                "tag_note_count_format[one]",
+                "tag_note_count_format[other]",
+                "version_format"
+            ),
+            // Typography terms kept in their English form.
+            "es" to setOf(
+                "font_sans",
+                "font_serif"
+            ),
+            // German keeps these as established loanwords: "Tags", "Checkbox",
+            // "App", "Passcode", "Inline". "Version" is also the German word, so
+            // application_id_format stays English here even though fr/es/ja/ko
+            // translate it — German has no adjacent translated sibling to clash with.
+            "de" to setOf(
+                "application_id_format",
+                "checkbox",
+                "font_sans",
+                "font_serif",
+                "formatting_inline",
+                "locked_passcode_label",
+                "matching_tags",
+                "settings_app",
+                "tag_suggestions_title",
+                "tags",
+                "version_format"
+            ),
+            "ja" to emptySet(),
+            "ko" to emptySet()
+        )
+    }
+}


### PR DESCRIPTION
Follow-up to #160, which was merged before this commit landed on the branch. Closes the remaining CI-guard item in #161.

## The gap

`./gradlew :app:lintRelease` passed cleanly the whole time `values-fr/sync_title` displayed `Multi-device sync (folder mirror)` on French devices. Android lint cannot catch that class of bug: `MissingTranslation` only fires when a `<string>` is **absent**, and a present-but-untranslated value is indistinguishable from one that is legitimately identical — `Markleaf`, `F-Droid`, `Apache License 2.0`, URLs, `#%1$s`. Nothing in CI would notice if the strings fixed in #160 regressed tomorrow.

## The guard

`UntranslatedStringTest` compares every locale value against `values/` and fails on any match that is not explicitly allowlisted.

It lives in `src/test`, so it runs under **`./gradlew test`** — the gate CI already runs — rather than needing a new workflow or a script, and it fails locally too. Modelled on `ComposeTestSourceSetTest`, which already guards a structural invariant the same way.

The allowlist is split so every entry carries its reason instead of being one opaque blob:

| set | size | what it means |
|---|---|---|
| `STRUCTURALLY_IDENTICAL` | 10 | not prose in any language — app name, brand names, URLs, license title, format-only strings |
| `LANGUAGE_COINCIDENCES` | fr 13, es 2, de 11, ja 0, ko 0 | words that genuinely match English in that one language |

Splitting them matters: `Version` being identical is correct in fr and de but would be a defect in ja or ko, which translate it. A single flat list could not express that. Where a decision was non-obvious it is recorded in a comment — e.g. `application_id_format` stays English in de because `Version` is also the German word, so unlike fr/es/ja/ko there is no translated sibling for it to clash with.

## Keeping the allowlist honest

A second test, `allowlistEntriesAreStillNeeded`, fails when an allowlisted key stops being identical to English. Without it the list would quietly decay into a blanket exemption — a key parked there once would keep hiding a later regression of that same string, which is exactly the failure mode the guard exists to prevent.

## Verified in both directions

A guard that only ever passes is worthless, so each test was checked by deliberately breaking the thing it watches:

| deliberate breakage | result |
|---|---|
| reintroduced the original `sync_title` bug | `localeStringsAreNotStillEnglish` **FAILED** — `values-fr  sync_title = "Multi-device sync (folder mirror)"` |
| translated fr `version_format`, making its allowlist entry stale | `allowlistEntriesAreStillNeeded` **FAILED** — `values-fr  version_format (now translated)` |

Both files were restored afterwards; the failure messages name the locale, the key, and what to do about it.

## Verification

- Runs in all three unit-test variants (debug / release / benchmark) — 2 tests each, 0 failures, 0 skipped.
- `./gradlew test` and `./gradlew :app:lintRelease` both `BUILD SUCCESSFUL` against current `main` (i.e. with #160 and #162 merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
