### PR TITLE
fix(i18n): restore three claims that translation had changed

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -58,8 +58,8 @@
     <string name="formatting_inline">Inline</string>
     <string name="formatting_structure">Struktur</string>
     <string name="formatting_block_media">Blöcke und Medien</string>
-    <string name="expanded">Erweitert</string>
-    <string name="collapsed">Reduziert</string>
+    <string name="expanded">Ausgeklappt</string>
+    <string name="collapsed">Eingeklappt</string>
     <string name="italic">Kursiv</string>
     <string name="strikethrough">Durchgestrichen</string>
     <string name="inline_code">Inline-Code</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -297,7 +297,7 @@
     <string name="privacy_guarantee_title">Vos données restent locales</string>
     <string name="privacy_guarantee_desc">Markleaf est conçu avec la confidentialité au cœur de ses priorités. Vos notes ne quittent jamais votre appareil, sauf si vous choisissez explicitement de les exporter ou de les partager.</string>
     <string name="privacy_data_storage_title">Stockage local en priorité</string>
-    <string name="privacy_data_storage_desc">Toutes vos notes et étiquettes sont stockées localement sur votre appareil à l\'aide de la base de données sécurisée Room d\'Android. Aucun serveur cloud, aucun téléchargement de données.</string>
+    <string name="privacy_data_storage_desc">Toutes vos notes et étiquettes sont stockées localement sur votre appareil à l\'aide de la base de données sécurisée Room d\'Android. Aucun serveur cloud, aucun envoi de données.</string>
     <string name="privacy_no_cloud_title">Aucune dépendance au cloud</string>
     <string name="privacy_no_cloud_desc">Nous n\'utilisons aucun service cloud pour les fonctionnalités de base. Pas de synchronisation Google Drive, pas d\'intégration Dropbox, pas de serveurs dorsaux propriétaires.</string>
     <string name="privacy_no_tracking_title">Zéro suivi</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -52,7 +52,7 @@
     <string name="back">뒤로</string>
     <string name="note_content">노트 본문</string>
     <string name="editor_empty_title">새 노트가 준비됐어요</string>
-    <string name="editor_empty_hint">Markdown, #태그, 링크, 체크박스를 쓸 수 있고, 작성하는 동안 자동으로 저장됩니다.</string>
+    <string name="editor_empty_hint">Markdown, #태그, 링크, 체크박스를 쓸 수 있고, 작성하는 동안 기기에 자동으로 저장됩니다.</string>
     <string name="bold">굵게</string>
     <string name="formatting">서식</string>
     <string name="formatting_inline">인라인</string>


### PR DESCRIPTION
The last three verified user-visible bugs from #161. Unlike the four fixed in #160, these are not structural — each string is wired correctly and simply **says something different from the English it was translated from**, which is why they were held back for a wording decision rather than bundled in.

## 1. fr `privacy_data_storage_desc` — a privacy guarantee pointing the wrong way

EN says *"No cloud servers, no data **uploads**."* French rendered it `aucun **téléchargement** de données`, and in French `téléchargement` is normally read as **download**. The guarantee being made is that nothing *leaves* the device; as translated it reads as a claim about nothing *arriving*.

French was the only locale to lose the direction:

| locale | value | direction |
|---|---|---|
| de | `keine Daten-Uploads` | up ✅ |
| es | `sin subidas de datos` | up ✅ |
| ja | `アップロードもありません` | up ✅ |
| ko | `데이터 업로드 없음` | up ✅ |
| **fr** | `aucun téléchargement de données` | **down** ❌ |

→ `aucun envoi de données` — unambiguous about direction, and plainer French than `téléversement`.

## 2. ko `editor_empty_hint` — dropped the local-first claim

EN: *"Markleaf saves **locally** as you write."* → ko: `작성하는 동안 **자동으로** 저장됩니다` (*saves automatically*). That is a weaker and different promise, and local-first is the app's core positioning — stated correctly elsewhere in the same file as `로컬 우선 저장`. Every other locale kept it: `localement`, `lokal`, `localmente`, `端末内へ`.

→ insert `기기에`: `작성하는 동안 기기에 자동으로 저장됩니다`. Minimal — it restores what was lost without discarding the auto-save nuance, which the Japanese translation also carries (`端末内へ自動保存`).

## 3. de `expanded` / `collapsed` — misleading as TalkBack state

These are Compose `stateDescription` values (`EditorFormattingControls.kt:175`, `:239`), so a screen reader announces them as the control's state. `Erweitert` reads as *advanced* and `Reduziert` as *reduced* or *discounted* — neither describes a disclosure state.

The same file already uses the `einklappen`/`ausklappen` stem for the corresponding verbs (`collapse_note_list` = `Notizliste einklappen`, `expand_note_list` = `Notizliste ausklappen`), so the participles were simply off-stem:

| | was | now |
|---|---|---|
| `expanded` | `Erweitert` | `Ausgeklappt` |
| `collapsed` | `Reduziert` | `Eingeklappt` |

## Notes

No interaction with the guard in #164 — none of these keys is allowlisted, and every change moves the value *further* from English, so neither `localeStringsAreNotStillEnglish` nor `allowlistEntriesAreStillNeeded` is affected.

With this merged, all seven verified user-visible bugs in #161 are closed; what remains there is terminology and style drift only.

**Verified:** all six resource files parse; `./gradlew test` and `./gradlew :app:lintRelease` both `BUILD SUCCESSFUL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
