### PR TITLE
docs: correct the GitHub Release asset list

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -161,16 +161,23 @@ tag pipelines can read the signing variables. Never expose these variables to
 branch or merge-request jobs.
 
 On tag pushes matching `v*`, GitHub Actions runs tests, builds the signed
-release APK and AAB, attaches the R8 mapping file, and creates a GitHub
-Release with all three assets attached:
+release APK and AAB, and creates a GitHub Release with **two** assets attached:
 
-- `markleaf-vX.Y.Z.apk` — signed, R8-shrunk APK for sideload installs and Releases mirror
-- `markleaf-vX.Y.Z.aab` — signed Android App Bundle for Play Store upload
+- `markleaf-vX.Y.Z.apk` — signed, R8-shrunk APK for sideload installs and the Releases mirror
 - `markleaf-vX.Y.Z.mapping.txt` — R8 mapping for deobfuscating crash stack traces
 
-The release job fails before publishing if the keystore secret is missing,
-if the APK certificate SHA-256 digest differs from the fixed production
-certificate, or if any of the three artifacts is missing.
+The signed AAB is built and verified in the same job but is **not** attached to
+the GitHub Release. It is uploaded as the `markleaf-release-aab` workflow
+artifact, and it reaches Play Console through the local
+`exportReleaseToBuildDrive` hand-off (see [Release Artifact Export](../AGENTS.md#release-artifact-export))
+rather than from GitHub. GitLab publishes the AAB to its package registry as
+well, so a permanent download link for it exists there — see
+[GitLab Release Assets](#gitlab-release-assets).
+
+The release job fails before publishing if the keystore secret is missing, if
+the APK certificate SHA-256 digest differs from the fixed production
+certificate, or if the APK, AAB, or mapping file is missing from the build
+outputs.
 
 ## GitLab Release Assets
 


### PR DESCRIPTION
`docs/RELEASE.md` claimed the tag job creates a GitHub Release "with all three assets attached", listing the APK, the AAB, and the R8 mapping. It attaches **two**.

## What the workflow actually does

`gh release create` receives only the APK and the mapping:

```
gh release create "$GITHUB_REF_NAME" \
  "markleaf-${GITHUB_REF_NAME}.apk" \
  "markleaf-${GITHUB_REF_NAME}.mapping.txt" \
  ...
```

The AAB is built and verified in the same job (`Verify Play Console AAB exists`), then uploaded as the `markleaf-release-aab` workflow artifact — not as a release asset.

## Evidence

| Release | Assets |
|---|---|
| v2.26.1 | `markleaf-v2.26.1.apk`, `markleaf-v2.26.1.mapping.txt` |
| v2.26.0 | apk, mapping |
| v2.25.0 | apk, mapping |

Three consecutive releases agree, so this is a stale doc rather than a build regression. Nothing is broken: the AAB reaches Play Console through `exportReleaseToBuildDrive`, and GitLab publishes it to its package registry with a permanent link.

## Change

Corrects the count and the list, states where the AAB actually goes, and rewords the failure condition — the job does verify all three build outputs exist, it just doesn't attach all three.

Anchors used in the new text were checked: `#gitlab-release-assets` and `../AGENTS.md#release-artifact-export` both resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
