### PR TITLE
docs: record that the AAB is deliberately not a GitHub Release asset

### DIFF
--- a/.agent/decisions.md
+++ b/.agent/decisions.md
@@ -7,6 +7,35 @@
 
 ## Confirmed Decisions
 
+### D062 - The AAB Is Not A GitHub Release Asset
+
+The GitHub Release carries exactly two assets — the signed APK and the R8
+mapping. The signed AAB is built and verified in the same tag job, but it is
+published everywhere except the GitHub Release.
+
+Why:
+- The AAB exists for one consumer, Play Console, and that hand-off is local:
+  `:app:exportReleaseToBuildDrive` writes it to `D:\Build` and the maintainer
+  uploads it by hand. A GitHub copy would be a third artifact nobody installs —
+  an `.aab` cannot be sideloaded, so offering it to the people who download from
+  GitHub Releases invites the wrong file.
+- A permanent download link already exists for anyone who needs one: GitLab
+  publishes the AAB to its Generic Package Registry and links it from the GitLab
+  Release (D057). The mirror is what makes the omission safe.
+- CI still verifies the AAB — it is uploaded as the `markleaf-release-aab`
+  workflow artifact, and the release job fails if the APK, AAB, or mapping is
+  missing from the build outputs. Not attaching it is a distribution choice, not
+  a gap in verification.
+
+Decision:
+- `gh release create` attaches `markleaf-vX.Y.Z.apk` and
+  `markleaf-vX.Y.Z.mapping.txt` only. Do not add the AAB.
+- Docs describing the release state the two-asset reality and say where the AAB
+  actually goes. This drifted twice — `docs/RELEASE.md` claimed "all three
+  assets" for two releases (#158, fixed in #168) and `AGENTS.md` claimed both
+  providers publish "APK/AAB 릴리스" until this entry — so treat the asset list
+  as a documented interface, not incidental prose.
+
 ### D061 - Locked Notes Stay Hidden From Every Derived Read Path
 
 The Locked space is a UI-visibility gate, so every surface that derives text

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,9 +145,11 @@ GitLab CI용 산출물은 `-Pmarkleaf.releaseExportDir=<dir>`와 함께
    workflow_dispatch — 로컬 재기록은 폰트 힌팅 차이로 CI verify와 어긋난다).
 3. **F-Droid — 태그 푸시로 자동 배포.** versionCode/versionName bump + `CHANGELOG.md`(영어,
    릴리즈 노트 원본) + `CHANGELOG.ko.md`(한국어판) + fastlane changelog 작성 후 main에
-   푸시하고 `vX.Y.Z` 태그를 GitLab 먼저, GitHub 다음으로 푸시한다. 같은 태그가 양쪽의
-   독립 서명 APK/AAB 릴리스를 만들고 GitHub 태그는 F-Droid 자동 픽업도 발동한다. 별도
-   F-Droid 제출 단계는 없다.
+   푸시하고 `vX.Y.Z` 태그를 GitLab 먼저, GitHub 다음으로 푸시한다. 같은 태그가 양쪽에서
+   독립적으로 서명 빌드를 돌리지만 **릴리스에 붙는 자산은 다르다** — GitHub Release는 APK와
+   R8 mapping 두 개만, GitLab Release는 Generic Package Registry를 통해 AAB까지 포함한다
+   (AAB를 GitHub에 올리지 않는 이유는 D062). GitHub 태그는 F-Droid 자동 픽업도 발동하므로
+   별도 F-Droid 제출 단계는 없다.
    릴리스 커밋은 `git add -A`로 만들지 않는다 — 변경 파일을 명시적으로 stage하거나 커밋 전
    working tree가 릴리스 대상만 담고 있는지 확인한다(무관한 작업이 태그에 섞여 나가는 것을
    막기 위함, v2.24.0에서 landing-i18n 유입 사고 → #154).


### PR DESCRIPTION
Follow-up to #168. That PR corrected `docs/RELEASE.md` to describe the two-asset GitHub Release, but left two things undone: the choice itself was undocumented, and the same overstated claim survived in `AGENTS.md`.

**`AGENTS.md` said the tag produces "양쪽의 독립 서명 APK/AAB 릴리스"** — that both providers publish an APK/AAB release. They don't. GitHub gets the APK and the R8 mapping; GitLab additionally carries the AAB via its Generic Package Registry. Rewritten to state the asymmetry and point at the decision record.

**Adds D062** so the asset list is a documented interface rather than incidental prose. This claim has now drifted twice — `docs/RELEASE.md` said "all three assets" for two releases (#158), and `AGENTS.md` until this PR.

### The decision being recorded

The AAB is **built and verified on every tag** and is not attached to the GitHub Release:

- `Verify Play Console AAB exists` (`android-build.yml:249-254`) fails the release job via `test -f` / `test -s`
- it uploads as the `markleaf-release-aab` workflow artifact with `if-no-files-found: error` (`:264-269`)
- `gh release create` (`:305-310`) attaches only `markleaf-vX.Y.Z.apk` and `markleaf-vX.Y.Z.mapping.txt`

So not attaching it is a distribution choice, not a verification gap. An `.aab` cannot be sideloaded, so it is the wrong file to offer people downloading from GitHub Releases; Play Console gets it through the local `exportReleaseToBuildDrive` hand-off, and anyone needing a permanent link has the GitLab package registry (D057).

### Verification

Docs-only — no build-affecting change. Every factual claim in D062 was checked against `.github/workflows/android-build.yml` rather than carried over from prose, which is how the D057 cross-reference got corrected (it was initially written as D040).

Closes the open question raised in #158's asset-list comment.