### PR TITLE
fix(scripts): make verify-mirror gate on actual mirror divergence

### DIFF
--- a/docs/mirror-runbook.md
+++ b/docs/mirror-runbook.md
@@ -35,7 +35,10 @@ markleaf-android 저장소의 재해 복구(이중 백업) 운영 문서.
   있으므로 사용하지 않는다.
 - 웹 UI 직접 수정이 꼭 필요하면 먼저 해당 원격을 fetch해 로컬에서 이력을 합친 뒤,
   GitHub는 PR로 올리고 머지된 커밋을 GitLab으로 전달한다.
+- 미러 대상은 `refs/heads/main`과 릴리스 태그(`refs/tags/v*`)뿐이다. 기능 브랜치는
+  미러하지 않으므로 한쪽 원격에만 있어도 정상이다.
 - `scripts/verify-mirror.ps1 -IncludeGitHub`가 두 원격의 ref 일치를 판정하는 최종 게이트다.
+  이 스크립트의 비교 범위는 바로 위 미러 대상과 같다 — 한쪽을 바꾸면 다른 쪽도 바꾼다.
 
 ## 평상시 작업
 
@@ -75,10 +78,29 @@ git push github vX.Y.Z
 ## 백업 검증
 
 ```
-pwsh scripts/verify-mirror.ps1
+pwsh scripts/verify-mirror.ps1 -IncludeGitHub
 ```
 
-항상 `-IncludeGitHub`로 로컬·GitLab·GitHub 3자 ref를 대조한다.
+항상 `-IncludeGitHub`로 로컬·GitLab·GitHub 3자 ref를 대조한다. 스위치 없이 실행하면
+로컬 vs GitLab만 보므로 **미러 일치는 판정되지 않는다.**
+
+비교 범위는 위 "동기화 범위"와 같은 `refs/heads/main` + `refs/tags/v*`뿐이다. 기능
+브랜치는 애초에 미러 대상이 아니므로 양쪽 원격 어디에 있든 비교에서 제외한다 —
+범위에 넣으면 작업 브랜치가 남아 있는 정상 작업 사본이 매번 실패해 게이트가
+무의미해진다. 출력의 `95/104`는 "범위 내 95개 / 전체 104개"라는 뜻이다.
+
+종료 코드로 실패 종류를 구분한다:
+
+| 코드 | 의미 | 대응 |
+|---|---|---|
+| 0 | 요청한 검사가 모두 통과 | — |
+| 1 | GitLab ref를 읽지 못함 | 원격·인증 확인 |
+| 2 | 로컬이 GitLab과 불일치 | `git fetch`로 로컬을 최신화. 미러 자체는 정상 |
+| 3 | **GitHub와 GitLab의 미러 ref가 갈라짐** | 아래 "이력이 갈라졌을 때 복구"로 간다 |
+| 4 | `-IncludeGitHub`를 줬으나 GitHub를 읽지 못함 | 미러 상태 미판정. 통과로 취급하지 않는다 |
+
+둘 이상 해당하면 `3 > 4 > 2` 순으로 심각한 쪽을 반환한다. `3`은 사람이 개입해야
+하는 신호이고, `2`는 로컬 사정이라 미러 정합성과는 무관하다.
 
 ## 한쪽 원격 장애 시
 

--- a/scripts/verify-mirror.ps1
+++ b/scripts/verify-mirror.ps1
@@ -1,10 +1,23 @@
 <#
 .SYNOPSIS
-  markleaf-android 미러 백업 검증. 로컬 ref를 GitLab과 대조하고,
-  요청 시(GitHub 복구 후) GitHub와도 대조한다.
+  markleaf-android 미러 백업 검증. 미러 대상 ref를 로컬·GitLab과 대조하고,
+  요청 시 GitHub와도 대조한다.
 .DESCRIPTION
+  비교 범위는 `refs/heads/main` + `refs/tags/v*`뿐이다
+  (docs/mirror-runbook.md "동기화 범위"). 기능 브랜치는 의도적으로 미러하지
+  않으므로 양쪽 어디에 있든 비교에서 제외한다 — 포함하면 정상 작업 사본에서도
+  항상 차이가 잡혀 게이트가 무의미해진다.
+
   GitHub가 flagged/접근 불가인 동안에는 기본적으로 GitHub를 건드리지 않는다.
-  -IncludeGitHub 스위치를 줄 때만 GitHub ref를 읽으며, 접근 불가 시 조용히 건너뛴다.
+  -IncludeGitHub 스위치를 줄 때만 GitHub ref를 읽는다.
+
+  종료 코드:
+    0  요청한 검사가 모두 통과
+    1  실행 오류 (GitLab ref를 읽을 수 없음)
+    2  로컬이 GitLab과 불일치 — 로컬 최신화 필요. 미러 자체는 정상
+    3  GitHub와 GitLab의 미러 ref가 갈라짐 — 이 게이트가 잡으려는 실패
+    4  -IncludeGitHub를 줬으나 GitHub를 읽지 못해 미러 일치를 판정하지 못함
+  둘 이상 해당하면 3 > 4 > 2 순으로 심각한 쪽을 반환한다.
 .EXAMPLE
   pwsh scripts/verify-mirror.ps1
 .EXAMPLE
@@ -19,6 +32,19 @@ param(
 
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
+
+# 미러 대상 = 런북 "동기화 범위"의 main + 릴리스 태그. 그 외는 전부 범위 밖이다.
+function Test-MirrorRef([string]$Ref) {
+    return ($Ref -eq "refs/heads/main") -or ($Ref -like "refs/tags/v*")
+}
+
+function Select-MirrorRefs($Map) {
+    $out = @{}
+    foreach ($k in $Map.Keys) {
+        if (Test-MirrorRef $k) { $out[$k] = $Map[$k] }
+    }
+    return $out
+}
 
 function Get-RemoteRefs([string]$Remote) {
     $lines = & git ls-remote --heads --tags $Remote 2>$null
@@ -56,24 +82,41 @@ function Compare-RefSet($a, $aName, $b, $bName) {
     return $diff
 }
 
-$local  = Get-LocalRefs
-$gitlab = Get-RemoteRefs $GitLabRemote
-if ($null -eq $gitlab) { Write-Error "GitLab을 '$GitLabRemote' 원격으로 읽을 수 없습니다."; exit 1 }
+$localAll = Get-LocalRefs
+$local    = Select-MirrorRefs $localAll
 
-Write-Host "Local refs: $($local.Count)  |  GitLab refs: $($gitlab.Count)"
-$d = Compare-RefSet $local "local" $gitlab "gitlab"
-if ($d -eq 0) { Write-Host "OK: GitLab이 로컬과 일치합니다 ($($local.Count) refs)." -ForegroundColor Green }
-else          { Write-Host "$d 건의 로컬 vs GitLab 차이." -ForegroundColor Red }
+$gitlabAll = Get-RemoteRefs $GitLabRemote
+if ($null -eq $gitlabAll) {
+    Write-Error "GitLab을 '$GitLabRemote' 원격으로 읽을 수 없습니다." -ErrorAction Continue
+    exit 1
+}
+$gitlab = Select-MirrorRefs $gitlabAll
+
+Write-Host "미러 범위: refs/heads/main + refs/tags/v*  (범위 내/전체)"
+Write-Host "  로컬 $($local.Count)/$($localAll.Count)  |  GitLab $($gitlab.Count)/$($gitlabAll.Count)"
+
+$localDiff = Compare-RefSet $local "local" $gitlab "gitlab"
+if ($localDiff -eq 0) { Write-Host "OK: GitLab이 로컬과 일치합니다 ($($local.Count) refs)." -ForegroundColor Green }
+else                  { Write-Host "$localDiff 건의 로컬 vs GitLab 차이 — 로컬 최신화 필요." -ForegroundColor Red }
+
+$mirrorDiff    = 0
+$mirrorUnknown = $false
 
 if ($IncludeGitHub) {
-    $github = Get-RemoteRefs $GitHubRemote
-    if ($null -eq $github) {
-        Write-Host "GitHub 접근 불가(아직 flagged?) — 건너뜀." -ForegroundColor DarkYellow
+    $githubAll = Get-RemoteRefs $GitHubRemote
+    if ($null -eq $githubAll) {
+        $mirrorUnknown = $true
+        Write-Host "GitHub 접근 불가(아직 flagged?) — 미러 일치를 판정하지 못했습니다." -ForegroundColor Red
     } else {
-        $d2 = Compare-RefSet $github "github" $gitlab "gitlab"
-        if ($d2 -eq 0) { Write-Host "OK: GitHub가 GitLab과 일치합니다." -ForegroundColor Green }
-        else           { Write-Host "$d2 건의 GitHub vs GitLab 차이." -ForegroundColor Red }
+        $github = Select-MirrorRefs $githubAll
+        Write-Host "  GitHub $($github.Count)/$($githubAll.Count)"
+        $mirrorDiff = Compare-RefSet $github "github" $gitlab "gitlab"
+        if ($mirrorDiff -eq 0) { Write-Host "OK: GitHub가 GitLab과 일치합니다 ($($github.Count) refs)." -ForegroundColor Green }
+        else                   { Write-Host "$mirrorDiff 건의 GitHub vs GitLab 미러 차이 — 이력이 갈라졌습니다." -ForegroundColor Red }
     }
 }
 
-if ($d -ne 0) { exit 2 }
+if ($mirrorDiff -ne 0) { exit 3 }
+if ($mirrorUnknown)    { exit 4 }
+if ($localDiff -ne 0)  { exit 2 }
+exit 0


### PR DESCRIPTION
## 문제

`scripts/verify-mirror.ps1`은 런북에서 "두 원격의 ref 일치를 판정하는 최종 게이트"로
문서화되어 있지만, 종료 코드가 그 판정을 전혀 반영하지 않았다.

1. **잡아야 할 실패를 놓친다.** `exit 2`는 로컬 vs GitLab 결과(`$d`)만 보고 결정됐다.
   GitHub vs GitLab 결과(`$d2`)는 출력만 하고 버려서, GitHub와 GitLab의 `main`이
   갈라져도 로컬이 GitLab과 맞기만 하면 `0`으로 통과했다.
2. **정상 상태에서 항상 운다.** 두 비교 모두 모든 head를 대상으로 했다. 기능 브랜치는
   의도적으로 미러하지 않으므로(런북 "동기화 범위" — `main` + 릴리스 태그만),
   로컬 브랜치가 있는 작업 사본은 언제나 `2`로 실패했다.

2026-07-20 실측: 로컬 vs GitLab 차이 8건이 전부 미러 대상이 아닌 기능 브랜치였고,
`main`과 태그 94개는 양쪽 원격에서 완전히 일치했다.

## 변경

- 두 비교의 범위를 문서화된 미러 표면(`refs/heads/main` + `refs/tags/v*`)으로 좁혔다.
  **양쪽 다 좁히는 것이 핵심이다** — 로컬 비교만 좁혔다면 새 종료 코드가 GitHub의
  열린 PR 브랜치(현재 4개)에서 바로 오탐을 낸다.
- 종료 코드가 미러 판정을 반영하게 했고, 실패 종류를 구분한다:

  | 코드 | 의미 |
  |---|---|
  | 0 | 요청한 검사 모두 통과 |
  | 1 | GitLab ref를 읽지 못함 |
  | 2 | 로컬이 GitLab과 불일치 (미러 자체는 정상) |
  | 3 | **GitHub와 GitLab의 미러 ref가 갈라짐** |
  | 4 | `-IncludeGitHub`를 줬으나 GitHub 접근 불가 — 미러 미판정 |

  둘 이상이면 `3 > 4 > 2` 순으로 심각한 쪽을 반환한다.
- `docs/mirror-runbook.md`의 "동기화 범위"·"백업 검증"에 비교 범위와 종료 코드 표를 추가.

### 리뷰 포인트 — 명시 요청 범위를 넘는 변경 1건

종료 코드 `4`는 기존의 조용한 건너뛰기를 대체한다. 이전에는 `-IncludeGitHub`를 줬는데
GitHub가 flagged/접근 불가면 경고만 찍고 `0`으로 통과했다 — 요청한 검사가 실행되지
않았는데 초록불이 나오는, 1번과 같은 종류의 결함이다. 검사 없이 통과시키지 않도록
별도 코드로 분리했다. GitHub 장애 중 통과가 필요하면 호출부에서 `4`를 예외 처리하면
된다. **기본 동작(스위치 없음)은 그대로 GitHub를 건드리지 않는다.**

## 검증

실제 원격 + 일회용 로컬 원격으로 9개 경로 전부 실측:

| 시나리오 | 기대 | 실측 |
|---|---|---|
| 실제 원격 (`main` + 태그 94개 양쪽 일치) | 0 | 0 |
| 범위 밖 브랜치가 한쪽에만 존재 | 0 | 0 |
| `main` 갈라짐 | 3 | 3 |
| 릴리스 태그 누락 | 3 | 3 |
| GitHub 접근 불가 | 4 | 4 |
| 로컬만 뒤처짐 | 2 | 2 |
| 로컬 뒤처짐 + 미러 갈라짐 | 3 | 3 |
| 로컬 뒤처짐 + GitHub 불가 | 4 | 4 |
| GitLab 접근 불가 | 1 | 1 |

변경 전에는 이 저장소에서 `-IncludeGitHub` 실행이 `2`로 실패하면서 "3 건의 GitHub vs
GitLab 차이"까지 함께 출력했다. 변경 후:

```
미러 범위: refs/heads/main + refs/tags/v*  (범위 내/전체)
  로컬 95/105  |  GitLab 95/96
OK: GitLab이 로컬과 일치합니다 (95 refs).
  GitHub 95/99
OK: GitHub가 GitLab과 일치합니다 (95 refs).
exit=0
```

태그 비교는 annotated 태그의 tag object SHA 기준으로 양쪽을 대조하므로, 같은 이름의
태그가 다른 객체를 가리키는 경우(F-Droid 픽업에 영향)도 `3`으로 잡힌다 — 검증 중
실측 확인했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
