### PR TITLE
feat(scripts): add -MirrorOnly to verify-mirror for CI use

### DIFF
--- a/docs/mirror-runbook.md
+++ b/docs/mirror-runbook.md
@@ -97,10 +97,36 @@ pwsh scripts/verify-mirror.ps1 -IncludeGitHub
 | 1 | GitLab ref를 읽지 못함 | 원격·인증 확인 |
 | 2 | 로컬이 GitLab과 불일치 | `git fetch`로 로컬을 최신화. 미러 자체는 정상 |
 | 3 | **GitHub와 GitLab의 미러 ref가 갈라짐** | 아래 "이력이 갈라졌을 때 복구"로 간다 |
-| 4 | `-IncludeGitHub`를 줬으나 GitHub를 읽지 못함 | 미러 상태 미판정. 통과로 취급하지 않는다 |
+| 4 | GitHub를 읽지 못해 미러를 판정하지 못함 | 미러 상태 미판정. 통과로 취급하지 않는다 |
 
 둘 이상 해당하면 `3 > 4 > 2` 순으로 심각한 쪽을 반환한다. `3`은 사람이 개입해야
 하는 신호이고, `2`는 로컬 사정이라 미러 정합성과는 무관하다.
+
+### 자동화·CI에서 (`-MirrorOnly`)
+
+```
+pwsh scripts/verify-mirror.ps1 -MirrorOnly
+```
+
+로컬 비교를 건너뛰고 GitHub vs GitLab만 판정한다. 미러를 보려면 GitHub를 읽어야
+하므로 이 스위치는 `-IncludeGitHub`를 함축한다 — 단독으로 완결된 호출이다. 종료
+코드는 `0`/`1`/`3`/`4`만 나오고 `2`는 발생하지 않는다.
+
+CI 러너에서는 이 스위치가 **필수다.** `actions/checkout`은 기본이 shallow라 태그를
+가져오지 않으므로, 로컬 비교를 켜면 러너의 ref 1개가 GitLab의 95개와 대조되어
+미러가 멀쩡해도 매번 `2`로 실패한다(실측: 태그 94건이 전부 `<missing>`). 로컬 ref는
+작업 사본이 아니라 체크아웃 설정의 부산물이므로 비교 자체가 무의미하다.
+
+두 원격 모두 익명 HTTPS로 읽히므로 시크릿이 필요 없다. 원격 이름 대신 URL을 직접
+넘길 수 있어 원격이 설정되지 않은 러너에서도 그대로 동작한다:
+
+```
+pwsh scripts/verify-mirror.ps1 -MirrorOnly `
+  -GitLabRemote https://gitlab.com/jeiel85/markleaf-android.git `
+  -GitHubRemote https://github.com/jeiel85/markleaf-android.git
+```
+
+이 검사를 실제 CI 잡으로 거는 작업은 아직 미완이다 (#172).
 
 ## 한쪽 원격 장애 시
 

--- a/scripts/verify-mirror.ps1
+++ b/scripts/verify-mirror.ps1
@@ -11,23 +11,34 @@
   GitHub가 flagged/접근 불가인 동안에는 기본적으로 GitHub를 건드리지 않는다.
   -IncludeGitHub 스위치를 줄 때만 GitHub ref를 읽는다.
 
+  -MirrorOnly는 로컬 비교를 통째로 건너뛰고 GitHub vs GitLab만 본다. CI 러너처럼
+  로컬 ref가 작업 사본이 아니라 체크아웃 설정의 부산물인 환경을 위한 것이다
+  (shallow checkout은 태그가 없어 로컬 비교가 항상 어긋난다). GitHub를 읽지 않고는
+  미러를 판정할 수 없으므로 -MirrorOnly는 -IncludeGitHub를 함축한다 — 스위치 하나만
+  줘도 완결된 호출이다.
+
   종료 코드:
     0  요청한 검사가 모두 통과
     1  실행 오류 (GitLab ref를 읽을 수 없음)
     2  로컬이 GitLab과 불일치 — 로컬 최신화 필요. 미러 자체는 정상
+       (-MirrorOnly에서는 로컬을 보지 않으므로 발생하지 않는다)
     3  GitHub와 GitLab의 미러 ref가 갈라짐 — 이 게이트가 잡으려는 실패
-    4  -IncludeGitHub를 줬으나 GitHub를 읽지 못해 미러 일치를 판정하지 못함
+    4  GitHub를 읽지 못해 미러 일치를 판정하지 못함
   둘 이상 해당하면 3 > 4 > 2 순으로 심각한 쪽을 반환한다.
 .EXAMPLE
   pwsh scripts/verify-mirror.ps1
 .EXAMPLE
   pwsh scripts/verify-mirror.ps1 -IncludeGitHub
+.EXAMPLE
+  # CI: 로컬 ref가 없는 러너에서 미러 정합성만 본다
+  pwsh scripts/verify-mirror.ps1 -MirrorOnly
 #>
 [CmdletBinding()]
 param(
     [string]$GitLabRemote = "gitlab",
     [string]$GitHubRemote = "github",
-    [switch]$IncludeGitHub
+    [switch]$IncludeGitHub,
+    [switch]$MirrorOnly
 )
 
 $ErrorActionPreference = "Stop"
@@ -82,8 +93,9 @@ function Compare-RefSet($a, $aName, $b, $bName) {
     return $diff
 }
 
-$localAll = Get-LocalRefs
-$local    = Select-MirrorRefs $localAll
+# 미러를 판정하려면 GitHub를 읽어야 하므로 -MirrorOnly는 -IncludeGitHub를 함축한다.
+# (함축하지 않으면 -MirrorOnly 단독 호출이 아무것도 비교하지 않고 0으로 통과한다.)
+$checkGitHub = $IncludeGitHub -or $MirrorOnly
 
 $gitlabAll = Get-RemoteRefs $GitLabRemote
 if ($null -eq $gitlabAll) {
@@ -93,16 +105,24 @@ if ($null -eq $gitlabAll) {
 $gitlab = Select-MirrorRefs $gitlabAll
 
 Write-Host "미러 범위: refs/heads/main + refs/tags/v*  (범위 내/전체)"
-Write-Host "  로컬 $($local.Count)/$($localAll.Count)  |  GitLab $($gitlab.Count)/$($gitlabAll.Count)"
 
-$localDiff = Compare-RefSet $local "local" $gitlab "gitlab"
-if ($localDiff -eq 0) { Write-Host "OK: GitLab이 로컬과 일치합니다 ($($local.Count) refs)." -ForegroundColor Green }
-else                  { Write-Host "$localDiff 건의 로컬 vs GitLab 차이 — 로컬 최신화 필요." -ForegroundColor Red }
+$localDiff = 0
+if ($MirrorOnly) {
+    Write-Host "  GitLab $($gitlab.Count)/$($gitlabAll.Count)  |  로컬 비교 생략 (-MirrorOnly)"
+} else {
+    $localAll = Get-LocalRefs
+    $local    = Select-MirrorRefs $localAll
+    Write-Host "  로컬 $($local.Count)/$($localAll.Count)  |  GitLab $($gitlab.Count)/$($gitlabAll.Count)"
+
+    $localDiff = Compare-RefSet $local "local" $gitlab "gitlab"
+    if ($localDiff -eq 0) { Write-Host "OK: GitLab이 로컬과 일치합니다 ($($local.Count) refs)." -ForegroundColor Green }
+    else                  { Write-Host "$localDiff 건의 로컬 vs GitLab 차이 — 로컬 최신화 필요." -ForegroundColor Red }
+}
 
 $mirrorDiff    = 0
 $mirrorUnknown = $false
 
-if ($IncludeGitHub) {
+if ($checkGitHub) {
     $githubAll = Get-RemoteRefs $GitHubRemote
     if ($null -eq $githubAll) {
         $mirrorUnknown = $true


### PR DESCRIPTION
`-MirrorOnly` skips the local comparison and judges only GitHub vs GitLab. This is the first option from #172 — the blocker that has to clear before the mirror check can run in CI at all.

## 왜 필요한가

CI 러너에서 지금 스크립트를 그대로 부르면 **미러가 멀쩡해도 매번 실패한다.**
`actions/checkout`은 기본이 shallow이고 태그를 가져오지 않으므로, 로컬 비교가
러너의 ref 1개를 GitLab의 95개와 대조한다. 실측하면 릴리스 태그 94건이 전부
`<missing>`으로 잡히고 `2`로 끝난다.

러너의 로컬 ref는 작업 사본이 아니라 체크아웃 설정의 부산물이다. 비교가 불편한
게 아니라 **의미가 없다.** 그대로 CI에 걸었다면 #171에서 막 고친 "게이트가 늑대를
외친다" 상태를 새 자리에 그대로 재현했을 것이다.

## 설계 판단: `-IncludeGitHub`를 함축한다

미러를 판정하려면 GitHub를 읽어야 한다. 함축하지 않으면 `-MirrorOnly` 단독 호출이
아무것도 비교하지 않고 **영원히 `0`으로 통과한다** — #171에서 고친 조용한 통과와
정확히 같은 실패 유형이다. 스위치 하나로 완결된 호출이 되게 했고, 둘 다 줘도
중복일 뿐 오류가 아니다.

종료 코드는 `0`/`1`/`3`/`4`만 나오고 `2`는 발생하지 않는다.

## 부수 확인 — 시크릿 불필요

두 저장소 모두 익명 HTTPS로 읽힌다. 런북의 SSH 인증 기술은 *push* 에 대한 것이고
이 스크립트가 하는 read-only `ls-remote` 에는 해당하지 않는다. 원격 *이름* 대신
URL을 직접 넘길 수 있어 원격이 설정되지 않은 러너에서도 그대로 돈다.

## 검증

CI ref 형태를 그대로 재현한 shallow `--no-tags` 클론(heads 1, tags 0)에서, 원격
설정 없이 익명 HTTPS URL만으로 구동:

| | 기대 | 실측 |
|---|---|---|
| 기본 모드 (`-IncludeGitHub`) | 2 (팬텀 태그 94건) | 2 |
| **`-MirrorOnly`** | **0** | **0** |

`-MirrorOnly` 실패 경로 재확인:

| 시나리오 | 기대 | 실측 |
|---|---|---|
| 정상 미러 | 0 | 0 |
| `-MirrorOnly -IncludeGitHub` (중복) | 0 | 0 |
| `main` 갈라짐 | 3 | 3 |
| 릴리스 태그 누락 | 3 | 3 |
| GitHub 접근 불가 | 4 | 4 |
| GitLab 접근 불가 | 1 | 1 |
| 범위 밖 ref만 존재 (heads 8개 + 비-`v*` 태그) | 0 | 0 |

기본 모드 동작은 변경 없음(회귀 확인 완료).

> 검증 중 한 케이스가 `3`으로 나와 확인했더니 스크립트가 아니라 **테스트 쪽 결함**이었다
> — 앞 단계에서 지운 태그를 복구하지 않은 채 다음 케이스를 돌렸다. 깨끗한 fake로
> 다시 돌려 `0`을 확인했고, annotated 태그를 tag object SHA 그대로 복구하면 `0`,
> lightweight로 잘못 복구하면 `3`이 나오는 것까지 확인했다.

## 남은 일

이 PR은 #172을 닫지 않는다. 실제 CI 잡(스케줄·호스팅 위치 결정 포함)은 아직 없다.
`docs/mirror-runbook.md`에도 그 사실을 명시해 뒀다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
