### PR TITLE
fix: stop locked notes' tags leaking into search and autocomplete

### DIFF
--- a/app/src/main/java/com/markleaf/notes/data/local/dao/TagDao.kt
+++ b/app/src/main/java/com/markleaf/notes/data/local/dao/TagDao.kt
@@ -28,11 +28,29 @@ interface TagDao {
     @Delete
     suspend fun deleteTag(tag: TagEntity)
 
-    @Query("SELECT * FROM tags ORDER BY name ASC")
-    fun getAllTags(): Flow<List<TagEntity>>
-
-    @Query("SELECT * FROM tags ORDER BY name ASC")
-    fun observeAllTags(): Flow<List<TagEntity>>
+    /**
+     * Tags that at least one visible note still carries. Locked and trashed notes are
+     * excluded, so a tag used only by locked notes never reaches the search chips or
+     * the editor's `#` autocomplete (#169) — the same rule [observeTagsWithCounts]
+     * already applies to the tag overview (#156).
+     *
+     * Orphan rows are excluded by the same predicate: a tag whose notes have all been
+     * retagged away keeps its row in `tags`, and matching the overview's
+     * `HAVING COUNT(notes.id) > 0` means autocomplete stops suggesting names that
+     * lead nowhere.
+     */
+    @Query("""
+        SELECT * FROM tags
+        WHERE EXISTS (
+            SELECT 1 FROM note_tag_cross_ref
+            INNER JOIN notes ON notes.id = note_tag_cross_ref.noteId
+            WHERE note_tag_cross_ref.tagId = tags.id
+              AND notes.trashed = 0
+              AND notes.locked = 0
+        )
+        ORDER BY name ASC
+    """)
+    fun observeVisibleTags(): Flow<List<TagEntity>>
 
     /**
      * Locked notes are excluded from the count so a tag used only by locked notes
@@ -51,6 +69,11 @@ interface TagDao {
     """)
     fun observeTagsWithCounts(): Flow<List<TagWithCount>>
 
+    /**
+     * Unfiltered — includes tags carried only by locked or trashed notes. Used to
+     * assert seeded fixtures in tests; do not surface this to the UI without adding
+     * the [observeVisibleTags] predicate.
+     */
     @Query("SELECT * FROM tags")
     suspend fun getAllTagsList(): List<TagEntity>
 

--- a/app/src/main/java/com/markleaf/notes/data/repository/LocalTagRepository.kt
+++ b/app/src/main/java/com/markleaf/notes/data/repository/LocalTagRepository.kt
@@ -54,14 +54,14 @@ class LocalTagRepository(
             .map { entities -> entities.map { it.toDomainModel() } }
     }
 
-    override suspend fun getAllTags(): List<Tag> {
-        return db.tagDao().getAllTags()
+    override suspend fun getVisibleTags(): List<Tag> {
+        return db.tagDao().observeVisibleTags()
             .map { entities -> entities.map { it.toDomainModel() } }
             .first()
     }
 
-    override fun observeAllTags(): Flow<List<Tag>> {
-        return db.tagDao().getAllTags()
+    override fun observeVisibleTags(): Flow<List<Tag>> {
+        return db.tagDao().observeVisibleTags()
             .map { entities -> entities.map { it.toDomainModel() } }
     }
 

--- a/app/src/main/java/com/markleaf/notes/domain/repository/TagRepository.kt
+++ b/app/src/main/java/com/markleaf/notes/domain/repository/TagRepository.kt
@@ -6,7 +6,11 @@ interface TagRepository {
     suspend fun reindexTagsForNote(noteId: String, content: String)
     suspend fun getTagsForNote(noteId: String): List<Tag>
     fun observeTagsForNote(noteId: String): kotlinx.coroutines.flow.Flow<List<Tag>>
-    suspend fun getAllTags(): List<Tag>
-    fun observeAllTags(): kotlinx.coroutines.flow.Flow<List<Tag>>
+    /**
+     * Tags reachable from a visible note. Locked and trashed notes are excluded, so
+     * these never leak a tag that only a locked note carries (#169).
+     */
+    suspend fun getVisibleTags(): List<Tag>
+    fun observeVisibleTags(): kotlinx.coroutines.flow.Flow<List<Tag>>
     suspend fun getTagByName(name: String): Tag?
 }

--- a/app/src/main/java/com/markleaf/notes/feature/editor/EditorScreen.kt
+++ b/app/src/main/java/com/markleaf/notes/feature/editor/EditorScreen.kt
@@ -179,7 +179,7 @@ fun EditorScreen(
     // surface existing tags. Mirrors the wikilink dropdown but keyed off `#`
     // with TagParser's rules (see detectTagQuery) so URL fragments and `##`
     // never trigger it.
-    val allTags by tagRepo.observeAllTags().collectAsState(initial = emptyList())
+    val allTags by tagRepo.observeVisibleTags().collectAsState(initial = emptyList())
     val tagQuery by remember {
         derivedStateOf { detectTagQuery(editorState) }
     }

--- a/app/src/main/java/com/markleaf/notes/feature/search/SearchScreen.kt
+++ b/app/src/main/java/com/markleaf/notes/feature/search/SearchScreen.kt
@@ -55,7 +55,7 @@ fun SearchScreen(
     val tagRepository = remember { LocalTagRepository(db) }
     val searchQuery by viewModel.searchQuery.collectAsState()
     val searchResults by viewModel.searchResults.collectAsState()
-    val allTags by tagRepository.observeAllTags().collectAsState(initial = emptyList())
+    val allTags by tagRepository.observeVisibleTags().collectAsState(initial = emptyList())
     val matchingTags = remember(searchQuery, allTags) {
         if (searchQuery.isBlank()) emptyList() else allTags.quickFilter(searchQuery) { it.name }.take(12)
     }

--- a/app/src/test/java/com/markleaf/notes/data/repository/LocalTagRepositoryTest.kt
+++ b/app/src/test/java/com/markleaf/notes/data/repository/LocalTagRepositoryTest.kt
@@ -136,6 +136,117 @@ class LocalTagRepositoryTest {
     }
 
     @Test
+    fun `observeVisibleTags excludes tags carried only by locked notes`() = runTest {
+        db.noteDao().insertNote(
+            NoteEntity(
+                id = "visible",
+                title = "Visible",
+                contentMarkdown = "Body #shared",
+                excerpt = "Body",
+                createdAt = 1L,
+                updatedAt = 1L
+            )
+        )
+        db.noteDao().insertNote(
+            NoteEntity(
+                id = "locked",
+                title = "Locked",
+                contentMarkdown = "Body #shared #secret",
+                excerpt = "Body",
+                createdAt = 2L,
+                updatedAt = 2L,
+                locked = true
+            )
+        )
+
+        repository.reindexTagsForNote("visible", "Body #shared")
+        repository.reindexTagsForNote("locked", "Body #shared #secret")
+
+        // The row really is in `tags` — the filter is what hides it, not an empty
+        // table. Without this the assertion below would pass for the wrong reason.
+        assertEquals(
+            setOf("secret", "shared"),
+            db.tagDao().getAllTagsList().map { it.name }.toSet()
+        )
+
+        // "secret" exists only on the locked note. Before #169 it still reached the
+        // search chips and the editor's `#` autocomplete, leaking the name of a tag
+        // the passcode is supposed to hide. "shared" stays because a visible note
+        // carries it too.
+        assertEquals(
+            listOf("shared"),
+            repository.observeVisibleTags().first().map { it.name }
+        )
+    }
+
+    @Test
+    fun `observeVisibleTags drops a tag when its last visible note becomes locked`() = runTest {
+        db.noteDao().insertNote(
+            NoteEntity(
+                id = "note-1",
+                title = "Note",
+                contentMarkdown = "Body #therapy",
+                excerpt = "Body",
+                createdAt = 1L,
+                updatedAt = 1L
+            )
+        )
+        repository.reindexTagsForNote("note-1", "Body #therapy")
+
+        assertEquals(
+            listOf("therapy"),
+            repository.observeVisibleTags().first().map { it.name }
+        )
+
+        // Locking is what the user does to hide the note; the tag index is not
+        // rewritten on that transition, so the filter is the only thing standing
+        // between a locked note and its tag name.
+        db.noteDao().setLocked("note-1", true)
+
+        assertEquals(
+            emptyList<String>(),
+            repository.observeVisibleTags().first().map { it.name }
+        )
+    }
+
+    @Test
+    fun `observeVisibleTags excludes trashed notes and orphan tag rows`() = runTest {
+        db.noteDao().insertNote(
+            NoteEntity(
+                id = "trashed",
+                title = "Trashed",
+                contentMarkdown = "Body #gone",
+                excerpt = "Body",
+                createdAt = 1L,
+                updatedAt = 1L,
+                trashed = true,
+                deletedAt = 2L
+            )
+        )
+        db.noteDao().insertNote(
+            NoteEntity(
+                id = "active",
+                title = "Active",
+                contentMarkdown = "Body #keep #drop",
+                excerpt = "Body",
+                createdAt = 3L,
+                updatedAt = 3L
+            )
+        )
+        repository.reindexTagsForNote("trashed", "Body #gone")
+        repository.reindexTagsForNote("active", "Body #keep #drop")
+
+        // Retagging leaves an orphan `drop` row behind, matching the overview's
+        // HAVING COUNT(...) > 0 rule so autocomplete stops offering dead names.
+        repository.reindexTagsForNote("active", "Body #keep")
+
+        assertEquals(
+            listOf("keep"),
+            repository.observeVisibleTags().first().map { it.name }
+        )
+    }
+
+    @Test
     fun `observeTagSummaries hides tags once their note count drops to zero`() = runTest {
         db.noteDao().insertNote(
             NoteEntity(


### PR DESCRIPTION
Fixes #169.

A tag carried only by locked notes still reached the search screen's tag chips and the editor's `#` autocomplete, so tag names from the Locked space were readable without the passcode.

**Repro:** tag a note `#therapy` → move it to Locked notes → open any unlocked note and type `#t` → `therapy` is suggested.

### Cause

`TagDao` had two queries over `tags` and only one filtered. `observeTagsWithCounts` excluded locked and trashed notes (#156, and its KDoc says so); `getAllTags` was a bare `SELECT * FROM tags` — and that was the one behind both leaking surfaces, via `LocalTagRepository.observeAllTags()` → `SearchScreen.kt:58` and `EditorScreen.kt:182`.

The tag row survives locking because `reindexTagsForNote` runs unconditionally in the editor's autosave (`EditorScreen.kt:324`), unlike the sync-folder mirror write four lines below it which *is* guarded by `!updatedNote.locked`. Nothing prunes it afterwards.

This is the same derived-read-path class as the backlink and tag-count misses fixed in v2.26.0 — in the query immediately above the one that was fixed.

### Change

- One `observeVisibleTags` query gated on an `EXISTS` over a non-trashed, non-locked note, replacing both unfiltered reads.
- Deletes `TagDao.observeAllTags` — a byte-identical unfiltered duplicate with **no callers**, i.e. a trap for the next person.
- Renames the repository methods to `getVisibleTags`/`observeVisibleTags`. Returning a filtered set from something called "all" is the shape of mistake that produced this bug; both call sites now read as what they get. `LocalTagRepository` is the only implementation and there is no test fake, so the rename is contained to 4 files.
- `getAllTagsList` stays unfiltered — its only caller is `StarterNotesSeederTest` — and gains a KDoc saying not to surface it to the UI.

### Behavior change worth flagging

The same predicate also drops **orphan tag rows** (a tag row lingers in `tags` after a note is retagged away). Autocomplete stops offering names that lead nowhere, which matches what the tag overview already does via `HAVING COUNT(notes.id) > 0` — see the existing `observeTagSummaries hides tags once their note count drops to zero` test. Consistent rather than incidental, but it is a user-visible change beyond the leak itself.

### Verification

Ran the full CI hard gate locally:

- `:app:testDebugUnitTest` — **362 tests, 0 failures, 0 errors** across 45 classes
- `:app:lintRelease` — **0 errors** (55 warnings, 5 informational)

Three regression tests added to `LocalTagRepositoryTest`, all confirmed to have actually executed by name in the result XML:

- `observeVisibleTags excludes tags carried only by locked notes`
- `observeVisibleTags drops a tag when its last visible note becomes locked` — drives the real `setLocked` transition, since the tag index is not rewritten on locking and the filter is the only thing in the way
- `observeVisibleTags excludes trashed notes and orphan tag rows`

The first also asserts the tag **is** present in the unfiltered `getAllTagsList` view, so it cannot pass because the table happened to be empty.

### Not in scope

`getNoteById` still intentionally returns locked notes, so the `editor/{noteId}` deep link opens one without a passcode prompt. That is #158's item 4 and needs its own decision about what the route should do — untouched here.