### PR TITLE
ci: run the mirror check daily on GitHub Actions

### DIFF
--- a/.github/workflows/mirror-check.yml
+++ b/.github/workflows/mirror-check.yml
@@ -1,0 +1,58 @@
+# GitHub ↔ GitLab 미러 정합성 감시.
+#
+# 사람이 실행을 기억해야만 도는 게이트를 자동화한다 (#172). 판정 기준과 종료 코드는
+# docs/mirror-runbook.md "백업 검증" 절에 있다. 빌드와 무관하므로 android-build.yml과
+# 분리한다 — 같은 워크플로에 넣으면 required check("build") 구성이 얽힌다.
+
+name: Mirror check
+
+on:
+  schedule:
+    # 매일 03:17 UTC. 정시(:00)는 러너가 붐벼 지연되므로 피한다.
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  mirror:
+    name: GitHub vs GitLab refs
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      # 검증 스크립트만 있으면 된다. 기본 shallow 체크아웃으로 충분하다 —
+      # -MirrorOnly는 로컬 ref를 읽지 않는다. (로컬 비교를 켜면 러너에는 태그가
+      # 없어 미러가 멀쩡해도 항상 실패한다. #172 참조.)
+      - name: Check out verification script
+        uses: actions/checkout@v5
+
+      - name: Compare mirror refs
+        shell: pwsh
+        run: |
+          # 원격은 docs/mirror-runbook.md "원격 구성" 표와 같다. 두 저장소 모두
+          # 익명 HTTPS로 읽히므로 시크릿도, git remote 설정도 필요 없다.
+          $gitlab = "https://gitlab.com/jeiel85/markleaf-android.git"
+          $github = "https://github.com/jeiel85/markleaf-android.git"
+
+          ./scripts/verify-mirror.ps1 -MirrorOnly -GitLabRemote $gitlab -GitHubRemote $github
+          $code = $LASTEXITCODE
+
+          # ::error:: 주석(annotation)이 진단을 전달하는 통로다. 종료 코드가 아니다.
+          #
+          # Actions의 pwsh 셸은 스텝을 `pwsh -command ". '<file>'"` 로 실행하는데, 이
+          # 형태에서는 dot-source된 스크립트의 `exit 3`이 프로세스 종료 코드 1로 뭉개진다
+          # (실측: -command는 1, -File은 3). 따라서 잡의 성공/실패(0 vs 非0)는 정확하지만
+          # 3/4/1의 구분은 여기서 사라진다. 무엇이 잘못됐는지는 아래 주석만이 알려주므로
+          # 종료 코드로 충분하다고 보고 지우지 말 것.
+          #
+          # exit $code 자체는 그대로 둔다 — 0은 0으로, 실패는 전부 非0으로 보존된다.
+          switch ($code) {
+              0 { Write-Host "미러 일치 — GitHub와 GitLab의 main·릴리스 태그가 같다." }
+              3 { Write-Host "::error::GitHub와 GitLab의 미러 ref가 갈라졌다. docs/mirror-runbook.md의 '이력이 갈라졌을 때 복구' 절을 따를 것 (재작성이 아니라 전진 수정)." }
+              4 { Write-Host "::error::GitHub를 읽지 못해 미러를 판정하지 못했다. 검사를 수행하지 못한 것이므로 통과가 아니다." }
+              1 { Write-Host "::error::GitLab ref를 읽지 못했다. 원격 URL과 GitLab 접근성을 확인할 것." }
+              default { Write-Host "::error::verify-mirror.ps1이 예상치 못한 종료 코드 $code 로 끝났다. -MirrorOnly에서는 0/1/3/4만 나와야 한다." }
+          }
+
+          exit $code

--- a/docs/mirror-runbook.md
+++ b/docs/mirror-runbook.md
@@ -126,7 +126,23 @@ pwsh scripts/verify-mirror.ps1 -MirrorOnly `
   -GitHubRemote https://github.com/jeiel85/markleaf-android.git
 ```
 
-이 검사를 실제 CI 잡으로 거는 작업은 아직 미완이다 (#172).
+### 자동 감시 (`.github/workflows/mirror-check.yml`)
+
+같은 검사를 매일 03:17 UTC에 GitHub Actions가 돌린다. 수동 실행은 Actions 탭의
+**Mirror check → Run workflow**(`workflow_dispatch`)로 한다. 시크릿이 없으므로 fork나
+다른 체크아웃에서도 그대로 동작한다.
+
+잡이 실패하면 무엇이 잘못됐는지는 **`::error::` 주석**에 있다. Actions의 pwsh 셸은
+스텝을 `pwsh -command ". '<file>'"`로 실행하는데 이 형태에서는 `exit 3`이 프로세스
+종료 코드 1로 뭉개져서, 잡의 성공/실패는 정확해도 3·4·1의 구분은 종료 코드에 남지
+않는다. 실행 로그의 주석을 읽을 것.
+
+**한계: GitHub가 내려가면 이 감시도 함께 멈춘다.** 감시자를 감시 대상 위에 올린
+대가다. 2026-07-10 flagged 사례처럼 GitHub가 장기간 막히면 미러 상태를 알려줄 주체가
+없어진다 — 그 구간에는 로컬에서 `pwsh scripts/verify-mirror.ps1 -IncludeGitHub`를
+직접 돌린다. GitLab CI에 같은 잡을 두면 이 사각지대가 사라지지만(그쪽은 GitHub 장애
+중에도 돌아 `4`를 보고할 수 있다), 스케줄을 GitLab UI에서 따로 만들어야 해서 저장소에
+남지 않는다. 지금은 단순함을 택했다.
 
 ## 한쪽 원격 장애 시
 


### PR DESCRIPTION
`.github/workflows/mirror-check.yml` — the scheduled job that #172 was opened for. Closes #172.

미러 게이트는 #171에서 판정이 정확해졌고 #173에서 CI 호출이 가능해졌지만, 여전히
**사람이 명령을 기억할 때만** 돌았다. 이 PR이 그 마지막 조각이다.

## 구성

| | |
|---|---|
| 트리거 | 매일 `17 3 * * *` (03:17 UTC) + `workflow_dispatch` |
| 러너 | `ubuntu-latest` (pwsh 기본 탑재), `timeout-minutes: 10` |
| 권한 | `contents: read` |
| 시크릿 | **없음** — 두 저장소 모두 익명 HTTPS로 읽힌다 |
| 체크아웃 | 기본 shallow로 충분 (`-MirrorOnly`는 로컬 ref를 읽지 않는다) |

`android-build.yml`에 잡을 추가하지 않고 **별도 워크플로**로 뒀다. 빌드와 무관하고,
같은 워크플로에 넣으면 `main`의 required check(`build`) 구성이 얽힌다.

## 검증 중 발견 — `::error::` 주석은 장식이 아니다

종료 코드가 CI 경계를 넘는지 실측하다가 알아냈다. Actions의 pwsh 셸은 스텝을
`pwsh -command ". '<file>'"` 형태로 실행하는데, **이 형태에서는 dot-source된
스크립트의 `exit 3`이 프로세스 종료 코드 1로 뭉개진다.**

| 호출 형태 | `exit 3` 결과 |
|---|---|
| `pwsh -command ". 'x.ps1'"` (Actions가 쓰는 형태) | **1** |
| `pwsh -File x.ps1` | 3 |

`$LASTEXITCODE`는 스텝 안에서 3으로 정확히 읽힌다 — 코드가 사라지는 건 프로세스
경계에서다. 결과적으로 **성공/실패는 정확하지만**(0은 0, 실패는 전부 非0) `3`·`4`·`1`의
구분은 종료 코드에 남지 않는다.

그래서 무엇이 잘못됐는지는 `::error::` 주석만이 알려준다. 파일 안에 "종료 코드로
충분하다고 보고 지우지 말 것"이라고 근거와 함께 적어 뒀다. 처음 커밋에는 "셸 래퍼에
기대지 않고 명시적으로 넘긴다"는 **틀린 주석**이 있었고, 이 실측으로 바로잡았다.

## 검증

run 블록을 YAML에서 그대로 추출해(재타이핑 없이) Actions와 **동일한 래퍼 형태**로
일회용 원격에 대고 실행:

| 시나리오 | 잡 결과 | 주석 |
|---|---|---|
| 정상 미러 | PASS (0) | 없음 |
| `main` 갈라짐 | FAIL (1) | `::error::` 1건 |
| GitHub 접근 불가 | FAIL (1) | `::error::` 1건 |
| GitLab 접근 불가 | FAIL (1) | `::error::` 1건 |

YAML 파싱과 필드(트리거·cron·권한·러너·shell)도 확인했다.

## 받아들인 한계

**GitHub가 내려가면 이 감시도 함께 멈춘다.** 감시자를 감시 대상 위에 올린 대가이고,
2026-07-10 flagged 같은 상황에서는 미러 상태를 알려줄 주체가 없어진다. GitLab CI에
같은 잡을 두면 사각지대가 사라지지만(그쪽은 GitHub 장애 중에도 `4`를 보고할 수 있다)
스케줄을 GitLab UI에서 만들어야 해서 저장소에 남지 않는다. 단순함을 택했고, 한계와
그 구간의 우회(로컬 수동 실행)를 `docs/mirror-runbook.md`에 적어 뒀다.

머지 후 Actions 탭에서 **Mirror check → Run workflow**로 한 번 돌려 보면 실제 러너에서의
동작까지 확인된다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
