### PR TITLE
fix: send locked notes' deep links to the passcode gate

### DIFF
--- a/app/src/main/java/com/markleaf/notes/navigation/MarkleafNavHost.kt
+++ b/app/src/main/java/com/markleaf/notes/navigation/MarkleafNavHost.kt
@@ -68,6 +68,8 @@ import com.markleaf.notes.feature.tags.TagRail
 import com.markleaf.notes.feature.tags.TagsScreen
 import com.markleaf.notes.feature.trash.TrashScreen
 import com.markleaf.notes.feature.sync.SyncCenterScreen
+import com.markleaf.notes.data.local.AppDatabase
+import com.markleaf.notes.data.repository.LocalNoteRepository
 import com.markleaf.notes.data.settings.AppSettings
 import com.markleaf.notes.data.settings.AppSettingsRepository
 import com.markleaf.notes.ui.viewmodel.ArchiveViewModel
@@ -99,6 +101,10 @@ fun MarkleafNavHost(
     val context = LocalContext.current
     val settingsRepository = remember { AppSettingsRepository(context.applicationContext) }
     val appSettings by settingsRepository.settings.collectAsState(initial = AppSettings())
+    // Only used to decide where an incoming open-note intent may land; see
+    // resolveOpenNoteRoute. AppDatabase.getInstance is a singleton, so this
+    // shares the instance MainActivity already built the factory from.
+    val noteRepository = remember { LocalNoteRepository(AppDatabase.getInstance(context)) }
 
     // One-shot intent entry points — widget "new note", text/file shared or
     // opened into the app (#139), and a widget tap on a recent note. These must
@@ -125,7 +131,10 @@ fun MarkleafNavHost(
                 navController.navigate(NavRoutes.editorRoute(newNote.id))
             }
             !openNoteId.isNullOrBlank() -> {
-                navController.navigate(NavRoutes.editorRoute(openNoteId))
+                // Not editorRoute directly: this is the one entry point an
+                // external app can reach, and a locked id must land on the
+                // passcode gate instead of the editor (#158).
+                navController.navigate(resolveOpenNoteRoute(openNoteId, noteRepository))
             }
         }
     }

--- a/app/src/main/java/com/markleaf/notes/navigation/OpenNoteRoute.kt
+++ b/app/src/main/java/com/markleaf/notes/navigation/OpenNoteRoute.kt
@@ -1,0 +1,34 @@
+package com.markleaf.notes.navigation
+
+import com.markleaf.notes.domain.repository.NoteRepository
+
+/**
+ * Resolves where an `ACTION_OPEN_NOTE` deep link should land.
+ *
+ * `MainActivity` is `exported="true"` because it carries the LAUNCHER filter, and
+ * the widget's open-note action is a bare note id in an extra. There is no
+ * intent-filter for that action, so it can only arrive as an explicit intent —
+ * but any installed app can send one with an arbitrary id.
+ *
+ * That matters because [NoteRepository.getNote] deliberately returns locked notes:
+ * the Locked space is a visibility gate over shared rows, not row-level access
+ * control, and the editor needs the row to render a note the user just unlocked.
+ * Navigating straight to the editor therefore rendered a locked note without ever
+ * showing the passcode prompt, and without the `FLAG_SECURE` the Locked screen
+ * raises (#158). Every other caller of the editor route sources its id from a
+ * list that already filters `locked`, or from the Locked screen itself after the
+ * passcode is accepted — this entry point was the only external one.
+ *
+ * A locked id is sent to [NavRoutes.LOCKED], which gates itself, rather than being
+ * dropped: a widget whose `RemoteViews` were built before the note was locked can
+ * legitimately still carry that id, and silently ignoring the tap would read as a
+ * dead button. The Locked space asks for the passcode and the note is right there
+ * once it is accepted.
+ *
+ * A missing note keeps the previous behaviour and resolves to the editor route, so
+ * ids that simply no longer exist are unaffected by this gate.
+ */
+suspend fun resolveOpenNoteRoute(noteId: String, noteRepository: NoteRepository): String {
+    val note = noteRepository.getNote(noteId)
+    return if (note?.locked == true) NavRoutes.LOCKED else NavRoutes.editorRoute(noteId)
+}

--- a/app/src/test/java/com/markleaf/notes/navigation/OpenNoteRouteTest.kt
+++ b/app/src/test/java/com/markleaf/notes/navigation/OpenNoteRouteTest.kt
@@ -1,0 +1,96 @@
+package com.markleaf.notes.navigation
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.markleaf.notes.data.local.AppDatabase
+import com.markleaf.notes.data.local.entity.NoteEntity
+import com.markleaf.notes.data.repository.LocalNoteRepository
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class OpenNoteRouteTest {
+    private lateinit var db: AppDatabase
+    private lateinit var repository: LocalNoteRepository
+
+    @Before
+    fun setUp() {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            AppDatabase::class.java
+        ).build()
+        repository = LocalNoteRepository(db)
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    private suspend fun insertNote(id: String, locked: Boolean) {
+        db.noteDao().insertNote(
+            NoteEntity(
+                id = id,
+                title = "Note $id",
+                contentMarkdown = "Body",
+                excerpt = "Body",
+                createdAt = 1L,
+                updatedAt = 1L,
+                locked = locked
+            )
+        )
+    }
+
+    @Test
+    fun `a locked note id lands on the passcode gate, not the editor`() = runTest {
+        insertNote("locked-1", locked = true)
+
+        // The row is readable — getNote intentionally does not filter locked notes,
+        // which is exactly why the editor route would have rendered it.
+        assertNotNull(repository.getNote("locked-1"))
+
+        assertEquals(NavRoutes.LOCKED, resolveOpenNoteRoute("locked-1", repository))
+    }
+
+    @Test
+    fun `an unlocked note id still opens the editor`() = runTest {
+        insertNote("open-1", locked = false)
+
+        assertEquals(
+            NavRoutes.editorRoute("open-1"),
+            resolveOpenNoteRoute("open-1", repository)
+        )
+    }
+
+    @Test
+    fun `a note that becomes locked stops resolving to the editor`() = runTest {
+        insertNote("note-1", locked = false)
+        assertEquals(
+            NavRoutes.editorRoute("note-1"),
+            resolveOpenNoteRoute("note-1", repository)
+        )
+
+        // A widget's RemoteViews can still carry this id after the user locks the
+        // note; the gate has to react to current state, not to what was true when
+        // the intent was built.
+        repository.setLocked("note-1", true)
+
+        assertEquals(NavRoutes.LOCKED, resolveOpenNoteRoute("note-1", repository))
+    }
+
+    @Test
+    fun `an unknown note id keeps the previous editor behaviour`() = runTest {
+        assertEquals(
+            NavRoutes.editorRoute("does-not-exist"),
+            resolveOpenNoteRoute("does-not-exist", repository)
+        )
+    }
+}


### PR DESCRIPTION
Closes the deep-link half of #158's item 4 — "a direct `editor/{noteId}` deep link (e.g. a widget intent) opens one without a passcode prompt".

### The hole

`MainActivity` is `exported="true"` because it carries the LAUNCHER filter, and `QuickNoteWidget.ACTION_OPEN_NOTE` is a bare note id in an extra. There is **no intent-filter** for that action, so it only arrives as an explicit intent — but any installed app can send one naming an arbitrary note.

`MarkleafNavHost` navigated straight to `editor/{noteId}`, and `getNote` deliberately returns locked notes: the Locked space is a visibility gate over shared rows, not row-level access control, and the editor needs the row to render a note the user *just* unlocked. So an external intent rendered a locked note with **no passcode prompt** and without the `FLAG_SECURE` the Locked screen raises.

The only thing standing in the way was that note ids are random UUIDs.

### Why gating this one call site is sufficient

There are 10 callers of the editor route. Nine source their id from a list that already filters `locked` (notes list, search, tags, widget — `QuickNoteWidgetService` reads the filtered `observeNotes()`), or from `LockedNotesScreen` itself *after* the passcode is accepted. `MarkleafNavHost.kt:128` was the only externally reachable one.

This deliberately does **not** hoist unlock state to session scope. Doing so would gate the route against any future in-app caller, but it also means deciding when a session unlock expires — background, process death, timeout — which is a security policy change rather than a fix. Recorded as the residual gap below.

### Behavior

A locked id routes to the Locked space rather than being ignored. A widget whose `RemoteViews` were built *before* the note was locked legitimately still carries that id, and dropping the tap would read as a dead button; the Locked space asks for the passcode and the note is right there once accepted. The oracle this creates is weak — it only tells an attacker who already knows a note UUID that it is locked.

An unknown id keeps resolving to the editor, so ids that simply no longer exist are unaffected.

### Structure

The decision lives in `resolveOpenNoteRoute` rather than inline in the `LaunchedEffect`, so it can be tested against a real database instead of needing a Compose harness.

### Verification

- `:app:testDebugUnitTest` — **366 tests, 0 failures** (was 362; +4 here)
- `:app:lintRelease` — **0 errors**, and the warning count is **unchanged at 55** despite the new `AppDatabase`/`LocalNoteRepository` dependency in the nav host

Four tests, all confirmed executed by name in the result XML:

- `a locked note id lands on the passcode gate, not the editor` — also asserts `getNote` *does* return the row, so it cannot pass because the note was missing
- `an unlocked note id still opens the editor`
- `a note that becomes locked stops resolving to the editor` — the stale-widget path
- `an unknown note id keeps the previous editor behaviour`

Emulator verification of the wiring (`am start` with a locked id landing on the gate rather than the editor) is running against `markleaf-tablet-api36`; I'll post the result on this PR.

### Residual gap for #158

The `editor/{noteId}` route itself is still ungated — an in-app caller navigating there with a locked id would open it. Closing that needs session-scoped unlock state and an expiry policy, which is a separate decision.