### PR TITLE
ci: push merged main to GitLab automatically

### DIFF
--- a/.github/workflows/mirror-push.yml
+++ b/.github/workflows/mirror-push.yml
@@ -1,0 +1,65 @@
+# 머지된 main을 GitLab으로 자동 전달한다 (#167).
+#
+# main이 보호된 뒤로 모든 변경은 GitHub PR 머지로 들어오는데 GitLab 전달만 수동이라,
+# 잊으면 DR 미러가 조용히 뒤처졌다. 실제로 v2.26.1 사이클에서만 두 번(#157·#163),
+# 그리고 mirror-check 첫 실행에서 한 번 더 잡혔다.
+#
+# 범위는 main뿐이다. 태그는 자동화하지 않는다 — 릴리스 태그는 GitLab 먼저,
+# GitHub 다음 순서이고(docs/mirror-runbook.md "원칙"), 이 잡이 GitHub→GitLab으로
+# 태그를 밀면 그 순서가 뒤집혀 양쪽 릴리스가 중복 발동할 수 있다.
+#
+# 이력 재작성은 이 잡으로 전파되지 않는다. GitLab main은 allow_force_push=false라
+# non-fast-forward push를 서버가 거부한다. 즉 이 잡은 GitLab을 fast-forward로
+# 전진시키는 것만 할 수 있고, GitHub 쪽 이력이 재작성되면 push가 실패해 잡이 빨개진다.
+# 그게 올바른 동작이다 — 자동으로 덮어쓰지 않는다.
+
+name: Mirror push
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# 연속 머지 시 push가 서로 앞지르지 않게 직렬화한다.
+# cancel-in-progress는 false — 진행 중인 push를 취소하면 전달이 누락된다.
+concurrency:
+  group: mirror-push
+  cancel-in-progress: false
+
+jobs:
+  push-to-gitlab:
+    name: main → GitLab
+    # fork에서는 돌리지 않는다. upstream GitLab에 밀 이유도, 시크릿도 없다.
+    if: github.repository == 'jeiel85/markleaf-android'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      # fetch-depth: 0 필수 — shallow 클론에서는 push가 거부된다
+      # ("shallow update not allowed").
+      - name: Check out full history
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Push main to GitLab
+        env:
+          GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${GITLAB_TOKEN:-}" ]; then
+            echo "::error::GITLAB_TOKEN 시크릿이 없다. docs/mirror-runbook.md의 '미러 push 자동화 설정'을 따라 GitLab Project Access Token(write_repository)을 만들어 등록할 것."
+            exit 1
+          fi
+
+          # --force 계열을 쓰지 않는다. 기본 push는 fast-forward만 허용하므로,
+          # 이력이 갈라지면 여기서 실패하는 것이 의도된 동작이다.
+          # 토큰은 secrets에서 오므로 Actions 로그에서 자동 마스킹된다.
+          git push "https://oauth2:${GITLAB_TOKEN}@gitlab.com/jeiel85/markleaf-android.git" \
+            "${GITHUB_SHA}:refs/heads/main"
+
+          echo "GitLab main ← ${GITHUB_SHA}"
+          echo "GitLab \`main\` ← \`${GITHUB_SHA:0:7}\`" >> "$GITHUB_STEP_SUMMARY"

--- a/docs/mirror-runbook.md
+++ b/docs/mirror-runbook.md
@@ -30,9 +30,13 @@ markleaf-android 저장소의 재해 복구(이중 백업) 운영 문서.
 - **`main`의 정식 경로: GitHub에서 PR을 머지한 뒤 그 커밋을 GitLab으로 전달한다**
   (GitHub → GitLab). `main`이 보호되기 전에는 GitLab 먼저 push했으나, 이제 GitHub
   `main`은 PR로만 전진하므로 순서가 뒤집혔다. 태그는 여전히 GitLab 먼저다.
+  이 전달은 `mirror-push.yml`이 자동으로 한다 ("미러 push 자동화 설정" 절).
 - GitHub 또는 GitLab 웹 UI에서 직접 만든 커밋은 다른 제공자로 자동 복사되지 않는다.
-- 자동 양방향 mirror는 동시 편집 시 충돌·재전파 루프와 태그 릴리스 중복 실행 위험이
-  있으므로 사용하지 않는다.
+  단 GitHub `main`에 들어온 커밋은 `mirror-push.yml`이 GitLab으로 전달한다.
+- **자동 양방향 mirror는 여전히 쓰지 않는다.** 동시 편집 시 충돌·재전파 루프와 태그
+  릴리스 중복 실행 위험 때문이다. `mirror-push.yml`은 이 원칙과 충돌하지 않는다 —
+  GitHub → GitLab **단방향**이고, `main` 한 갈래만 다루며(태그 제외), fast-forward만
+  가능해 되돌아오는 전파나 릴리스 중복 발동을 만들지 않는다.
 - 웹 UI 직접 수정이 꼭 필요하면 먼저 해당 원격을 fetch해 로컬에서 이력을 합친 뒤,
   GitHub는 PR로 올리고 머지된 커밋을 GitLab으로 전달한다.
 - 미러 대상은 `refs/heads/main`과 릴리스 태그(`refs/tags/v*`)뿐이다. 기능 브랜치는
@@ -60,20 +64,51 @@ merge commit이다. 미러 정합성에는 어느 쪽도 영향이 없으므로 
 `--merge`를 예시로 쓴다. 방식을 통일하고 싶으면 저장소 설정에서 하나만 남기는 편이
 문서로 강제하는 것보다 확실하다.
 
-머지된 `main`을 GitLab으로 전달한다. 로컬 `main`을 checkout하지 않고 원격 추적
-ref를 그대로 밀면 다른 워크트리의 체크아웃을 건드리지 않는다:
+**머지된 `main`의 GitLab 전달은 자동이다.** `.github/workflows/mirror-push.yml`이
+`main`에 push가 들어올 때마다 그 커밋을 GitLab `main`으로 민다 (#167). 평상시에는
+머지 후 아무것도 하지 않아도 된다.
+
+수동 전달은 자동화가 실패했을 때의 폴백으로 남긴다. 로컬 `main`을 checkout하지 않고
+원격 추적 ref를 그대로 밀면 다른 워크트리의 체크아웃을 건드리지 않는다:
 
 ```
 git fetch github
 git push gitlab github/main:refs/heads/main
 ```
 
-릴리스 태그는 브랜치 보호와 무관하므로 종전대로 GitLab 먼저, GitHub 다음이다:
+릴리스 태그는 브랜치 보호와 무관하므로 종전대로 GitLab 먼저, GitHub 다음이다.
+**태그는 자동화 대상이 아니다** — 이 순서를 뒤집으면 양쪽 릴리스가 중복 발동한다:
 
 ```
 git push gitlab vX.Y.Z
 git push github vX.Y.Z
 ```
+
+## 미러 push 자동화 설정
+
+`.github/workflows/mirror-push.yml`은 GitLab에 쓸 수 있는 자격증명이 필요하다. 읽기
+전용인 미러 *검사*와 달리 push는 익명으로 할 수 없다. 아래는 **사람이 직접 해야 하는
+설정이다** — 토큰 값은 저장소에 커밋하지 않는다.
+
+1. **GitLab에서 Project Access Token 발급.** 프로젝트 → Settings → Access Tokens.
+   - Role: **Maintainer** (보호된 `main`에 push하려면 필요하다)
+   - Scope: **`write_repository`** 하나만
+   - Expiry: GitLab이 만료일을 강제한다(최대 1년). **날짜를 적어 둘 것** — 아래 갱신 항목 참조.
+2. **GitHub에 시크릿 등록.** 저장소 → Settings → Secrets and variables → Actions →
+   New repository secret. 이름은 정확히 **`GITLAB_TOKEN`**.
+3. **확인.** Actions 탭 → **Mirror push** → Run workflow. 또는 아무 PR이나 머지하면
+   자동으로 돈다. 성공하면 job summary에 `GitLab main ← <sha>`가 찍힌다.
+
+**만료 시 동작: 조용히 멈추지 않고 시끄럽게 실패한다.** 토큰이 만료되면 push가 인증
+오류로 실패하고 잡이 빨개진다. 미러가 뒤처지기 시작하면 매일 도는 `mirror-check`도
+함께 빨개진다. 두 신호가 같이 뜨면 토큰 만료를 먼저 의심할 것.
+
+**이 자동화가 할 수 없는 일.** `--force` 계열을 쓰지 않으므로 GitLab을 fast-forward로
+전진시키는 것만 가능하다. GitHub 쪽 이력이 재작성되면 push가 거부되고(GitLab
+`main`의 `allow_force_push=false`도 서버에서 같은 것을 막는다) 잡이 실패한다. 즉
+**재작성된 이력은 자동으로 전파되지 않는다** — 그때는 "이력이 갈라졌을 때 복구"를
+사람이 따라야 한다. 되감기 push가 거부되고 대상 ref가 그대로 유지되는 것은 실측으로
+확인했다.
 
 ## 백업 검증
 


### PR DESCRIPTION
`main` 머지 후 GitLab 전달을 자동화한다. #167의 첫 항목.

> [!IMPORTANT]
> **머지 전에 `GITLAB_TOKEN` 시크릿을 먼저 만들어야 한다.** 이 워크플로는 `main`에
> push가 들어오면 도는데, **이 PR의 머지 자체가 첫 트리거다.** 시크릿이 없으면 그
> 실행이 빨갛게 실패한다(설정 안내를 가리키는 명확한 에러로). 순서를 지키면 첫 실행부터
> 초록이다.
>
> 토큰은 내가 만들 수 없다 — 자격증명은 취급하지 않는다. 절차는 런북
> "미러 push 자동화 설정" 절에 적어 뒀다: GitLab Project Access Token
> (Role **Maintainer**, scope **`write_repository`** 하나) → GitHub 시크릿 이름 정확히 **`GITLAB_TOKEN`**.

## 왜

`main`이 보호된 뒤 모든 변경은 GitHub PR 머지로 들어오는데 GitLab 전달만 수동이라,
잊으면 DR 미러가 조용히 뒤처졌다. v2.26.1 사이클에서 두 번(#157·#163), 그리고 **오늘
mirror-check 첫 실행에서 한 번 더** — #174가 손으로 전달되는 사이 GitLab이 한 머지
뒤처져 있었다.

## 범위와 안전 장치

| | |
|---|---|
| 트리거 | `push: [main]` + `workflow_dispatch` |
| 미는 것 | 트리거된 커밋 → GitLab `main`. **그것뿐** |
| 태그 | **자동화 안 함** (아래) |
| force | **안 씀.** fast-forward만 가능 |
| 동시성 | `group: mirror-push`, `cancel-in-progress: false` |
| fork | `if: github.repository == ...`로 건너뜀 |

**태그를 제외한 이유.** 릴리스 태그는 GitLab 먼저, GitHub 다음 순서다 — 각 제공자가
자기 릴리스를 발동한다. GitHub→GitLab으로 태그를 밀면 그 순서가 뒤집혀 한 태그에
양쪽 릴리스가 중복 발동할 수 있다.

**이력 재작성은 전파되지 않는다.** `--force` 계열을 쓰지 않으므로 push는 fast-forward만
성공한다. GitHub 쪽이 재작성되면 push가 거부되고 잡이 실패한다(GitLab `main`의
`allow_force_push=false`도 서버에서 같은 것을 막는다). 갈라짐 해소는 계속 사람의
판단으로 남는다.

**"자동 양방향 mirror 금지" 원칙과 충돌하지 않는다.** 단방향, 브랜치 하나, 태그 제외,
fast-forward 전용 — 그 원칙이 막으려는 충돌·재전파 루프·릴리스 중복 어느 것도 만들지
않는다. 런북 해당 항목에 이 근거를 적어 뒀다.

## 검증

run 블록을 YAML에서 그대로 추출해(재타이핑 없이) 로컬 bare 저장소에 대고 실행:

| 시나리오 | 기대 | 실측 |
|---|---|---|
| `GITLAB_TOKEN` 없음 | exit 1 + 설정 안내 `::error::` | exit 1, 안내 출력 |
| fast-forward push | 성공, 대상 전진 | exit 0, `53d8a34` → `5ad89c0` |
| 되감기(non-fast-forward) | **거부, 대상 불변** | `! [rejected] (non-fast-forward)`, exit 1, 대상 `5ad89c0` 유지 |

세 번째가 핵심이다 — 이 잡이 GitLab을 되돌리거나 덮어쓸 수 없다는 것이 실측으로 확인됐다.
YAML 파싱과 bash 문법도 검사했고, 실제 명령 줄에 `--force`나 태그 push가 없음을 주석과
구분해 확인했다.

실제 GitLab push는 토큰이 있어야 하므로 이 PR에서는 검증하지 못했다. 시크릿 등록 후
**Mirror push → Run workflow**로 확인할 수 있다.

## 남는 운영 부담

토큰 만료(GitLab이 최대 1년 강제). 만료되면 **조용히 멈추지 않고** push가 인증 오류로
실패해 잡이 빨개지고, 미러가 뒤처지기 시작하면 `mirror-check`도 함께 빨개진다.
런북에 만료일을 적어 두라고 명시했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
