### PR TITLE
ci: verify public version strings and release notes on every build

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -31,6 +31,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
+      # 버전 표기·릴리스 노트 검사는 Gradle 앞에 둔다. 초 단위로 끝나고, 릴리스
+      # 준비 커밋에서 빠뜨리기 가장 쉬운 것들이라 먼저 실패하는 편이 낫다.
+      - name: Verify public version strings (landing + README)
+        run: pwsh -File scripts/verify-landing-versions.ps1
+
+      - name: Verify release notes (fastlane changelogs + CHANGELOG parity)
+        run: pwsh -File scripts/verify-release-notes.ps1
+
       - name: Set up JDK 17
         uses: actions/setup-java@v5
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,6 +153,10 @@ GitLab CI용 산출물은 `-Pmarkleaf.releaseExportDir=<dir>`와 함께
    릴리스 커밋은 `git add -A`로 만들지 않는다 — 변경 파일을 명시적으로 stage하거나 커밋 전
    working tree가 릴리스 대상만 담고 있는지 확인한다(무관한 작업이 태그에 섞여 나가는 것을
    막기 위함, v2.24.0에서 landing-i18n 유입 사고 → #154).
+   버전 bump에 딸린 손 편집(CHANGELOG 두 판, fastlane changelog 6개, 랜딩·README 버전 표기)은
+   `build` 워크플로가 `scripts/verify-release-notes.ps1`과 `scripts/verify-landing-versions.ps1`로
+   검사한다. 기준은 `app/build.gradle.kts`의 versionName/versionCode이므로, bump만 하고 나머지를
+   빠뜨리면 태그를 밀기 전에 PR 단계에서 실패한다(#167).
 4. **Play Store — 산출물 핸드오프.** [Release Artifact Export](#release-artifact-export)에 따라
    Play 제출용 서명 AAB와 릴리즈 노트 TXT를 내보낸다(서명 AAB는 CI 릴리스 산출물 기준).
    업로드는 메인테이너가 수동으로 한다.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -74,11 +74,17 @@ rule in `app/proguard-rules.pro` — not to disable R8.
 
 Every push to `main` and every pull request runs:
 
+- `pwsh -File scripts/verify-landing-versions.ps1` — public version strings match `versionName`
+- `pwsh -File scripts/verify-release-notes.ps1` — fastlane changelogs exist and fit, CHANGELOG editions agree
 - `./gradlew assembleDebug`
 - `./gradlew test`
 - `./gradlew verifyRoborazziDebug`
 - `./gradlew :app:lintRelease` — fails on any Error-severity lint issue in the release variant
 - `./gradlew :app:assembleRelease` — proves R8 still produces a valid APK
+
+The two script checks run ahead of Gradle. They finish in seconds and cover what
+a release-preparation commit most often forgets, so failing on them first costs
+nothing. See [Release Version and Notes Checks](#release-version-and-notes-checks).
 
 The `launch-smoke` job (emulator-based) currently runs on a debug APK and is
 marked `continue-on-error: true` because of historical emulator flakiness on
@@ -92,29 +98,65 @@ mapping and six-locale notes, and verifies the APK certificate before
 publishing. GitHub remains the canonical Roborazzi and emulator-smoke runner;
 GitLab is an independent build and binary-distribution path.
 
-## Localized Landing Version Check
+## Release Version and Notes Checks
 
-The landing page ships in six languages: `docs/index.html` (English, the
-canonical / x-default), `docs/index.ko.html`, `docs/index.ja.html`,
-`docs/index.de.html`, `docs/index.es.html`, and `docs/index.fr.html`. Their
-"current release" version must match across all six before a release. It
-appears in three places per file — the JSON-LD `softwareVersion`, the hero
-`release-line`, and the trust-ledger `<strong>`.
+Two PowerShell checks guard the parts of a release that are maintained by hand.
+Both run in CI on every push and pull request, and both take their expected
+version from `app/build.gradle.kts`. `versionName` and `versionCode` are the
+source of truth rather than the latest git tag, because these checks run *before*
+the tag is pushed — during release preparation the newest tag still points at the
+previous version.
 
-Run the check before pushing a release tag:
+### Public version strings
 
 ```powershell
 pwsh scripts/verify-landing-versions.ps1
 ```
 
-It prints each language's release and screenshot versions and exits non-zero if
-the release version differs between languages. The hero `figcaption` screenshot
-version is tracked separately (it lags until screenshots are re-taken) but must
-also stay consistent across the six languages. When the check fails, update the
-lagging language file — not the check.
+The landing page ships in six languages: `docs/index.html` (English, the
+canonical / x-default), `docs/index.ko.html`, `docs/index.ja.html`,
+`docs/index.de.html`, `docs/index.es.html`, and `docs/index.fr.html`. The
+"current release" version appears in three places per file — the JSON-LD
+`softwareVersion`, the hero `release-line`, and the trust-ledger `<strong>`.
+
+The six READMEs are checked as well. There the target is any line carrying a
+release link (`releases/tag/vX.Y.Z` or `-/releases/vX.Y.Z`), and every version
+string on such a line must match — so a stale link label is caught even when the
+URL beside it was updated. Roadmap entries such as `- [x] v1.0.0 stable release`
+carry no release link and are out of scope.
+
+The hero `figcaption` screenshot version is tracked separately. It lags until
+screenshots are re-taken, so it only has to stay consistent across the six
+languages, not to equal the release version.
+
+Missing files and missing version strings now fail. The earlier version of this
+script compared the languages only against each other and merely warned when a
+string was absent, so six equally-stale files passed: version-bump omissions went
+unnoticed through v2.25.0 and v2.26.0 (#167).
+
+When the check fails, update the lagging file — not the check.
 
 The privacy pages (`docs/privacy*.html`) ship in the same six languages and
 carry no version string, so they are outside this check.
+
+### Release notes
+
+```powershell
+pwsh scripts/verify-release-notes.ps1
+```
+
+Three assertions:
+
+- All six store locales have
+  `fastlane/metadata/android/<locale>/changelogs/<versionCode>.txt`.
+- Each stays within Play Console's 500-character-per-locale limit.
+  `:app:exportReleaseToBuildDrive` enforces the same limit, but it runs at
+  release time, after the release commit already exists — de-DE and fr-FR were
+  once written at 526 and 525 characters and were caught only by counting them
+  by hand (#167).
+- `CHANGELOG.md` and `CHANGELOG.ko.md` carry the same version sections in the
+  same order with the same dates, and both have a section for the current
+  `versionName`. Titles are translations, so they are not compared.
 
 ## Release Notes Source and Language
 

--- a/scripts/verify-landing-versions.ps1
+++ b/scripts/verify-landing-versions.ps1
@@ -1,99 +1,165 @@
 <#
 .SYNOPSIS
-  다국어 랜딩 페이지(docs/index*.html)의 릴리스 버전 표기가 언어 간에 일치하는지 검증한다.
+  공개 표면(랜딩 페이지 6개 + README 6개)의 릴리스 버전 표기가 실제 릴리스 버전과
+  일치하는지 검증한다.
 .DESCRIPTION
-  각 언어 랜딩 페이지에는 "현재 릴리스"를 가리키는 버전 표기가 세 곳 있다:
-  JSON-LD 의 softwareVersion, hero 의 release-line, trust-ledger 의 <strong>.
-  이 세 값은 여섯 언어(en/ko/ja/de/es/fr) 전부에서 동일해야 한다.
+  기대 버전은 `app/build.gradle.kts` 의 versionName 이다. 최신 릴리스 태그가 아니라
+  versionName 을 기준으로 삼는 이유는 이 검사가 태그 푸시 "전"에 도는 것이기 때문이다
+  (docs/RELEASE.md). 태그는 versionName 에서 파생되므로 릴리스를 준비하는 시점에는
+  아직 이전 버전을 가리킨다.
 
-  스크린샷을 가리키는 hero figcaption 버전은 릴리스 버전과 별개다(스크린샷을
-  다시 찍기 전까지 이전 버전으로 남는다). 릴리스 버전과 달라도 정상이지만,
-  여섯 언어 사이에서는 서로 일치해야 한다(모두 같은 스크린샷을 쓰므로).
+  검사 대상은 두 종류다.
 
-  어느 그룹이든 언어 간에 어긋나면 어긋난 값을 보고하고 exit 2 로 종료한다.
-  릴리스 직전(태그 푸시 전)에 실행해 언어별 버전 표기 누락을 잡는다.
+  1. 다국어 랜딩 페이지(docs/index*.html) — "현재 릴리스"를 가리키는 표기가 세 곳 있다:
+     JSON-LD 의 softwareVersion, hero 의 release-line, trust-ledger 의 <strong>.
+  2. 다국어 README(README*.md) — 릴리스 링크(releases/tag/vX.Y.Z 또는 -/releases/vX.Y.Z)가
+     들어 있는 줄. 그 줄 안의 모든 vX.Y.Z 표기를 검사하므로 링크 URL 과 링크 텍스트가
+     따로 낡는 경우도 잡힌다. 로드맵의 과거 마일스톤("v1.0.0 stable release" 등)은
+     릴리스 링크가 없는 줄이라 대상에서 빠진다.
+
+  스크린샷을 가리키는 hero figcaption 버전은 릴리스 버전과 별개다(스크린샷을 다시 찍기
+  전까지 이전 버전으로 남는다). 릴리스 버전과 달라도 정상이지만, 여섯 언어 사이에서는
+  서로 일치해야 한다(모두 같은 스크린샷을 쓰므로).
+
+  대상 파일이 없거나 버전 표기를 찾지 못하면 실패로 처리한다. 이전 판은 경고만 하고
+  넘어간 데다 언어끼리만 비교해서, 여섯 언어가 "똑같이" 낡으면 통과했다 — v2.25.0 과
+  v2.26.0 두 번 연속으로 누락이 이 검사를 통과했다(#167).
 .EXAMPLE
   pwsh scripts/verify-landing-versions.ps1
 .EXAMPLE
-  pwsh scripts/verify-landing-versions.ps1 -DocsDir docs
+  pwsh scripts/verify-landing-versions.ps1 -ExpectedVersion 2.27.0
 #>
 [CmdletBinding()]
 param(
-    [string]$DocsDir = "docs"
+    [string]$RepoRoot = (Split-Path -Parent $PSScriptRoot),
+    [string]$DocsDir = "docs",
+    [string]$ExpectedVersion = ""
 )
 
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
 
-$files = @("index.html", "index.ko.html", "index.ja.html", "index.de.html", "index.es.html", "index.fr.html")
-
-function Get-Version([string]$Text, [string]$Pattern, [string]$Label, [string]$File) {
-    $m = [regex]::Match($Text, $Pattern)
-    if (-not $m.Success) {
-        Write-Host "WARN  ${File}: '$Label' 버전 표기를 찾지 못했습니다." -ForegroundColor Yellow
-        return $null
-    }
-    return $m.Groups[1].Value
+function Resolve-UnderRoot([string]$Path) {
+    if ([System.IO.Path]::IsPathRooted($Path)) { return $Path }
+    return (Join-Path $RepoRoot $Path)
 }
 
-$rows = @()
-$missingFiles = 0
-foreach ($f in $files) {
-    $path = Join-Path $DocsDir $f
+$fail = 0
+function Add-Failure([string]$Message) {
+    Write-Host $Message -ForegroundColor Red
+    $script:fail++
+}
+
+# ---- 기대 버전: app/build.gradle.kts 의 versionName ----
+if (-not $ExpectedVersion) {
+    $gradlePath = Resolve-UnderRoot "app/build.gradle.kts"
+    if (-not (Test-Path -LiteralPath $gradlePath)) {
+        Write-Error "기대 버전을 읽을 app/build.gradle.kts 를 찾지 못했습니다: $gradlePath"
+        exit 1
+    }
+    $gradleMatch = [regex]::Match(
+        (Get-Content -Raw -Encoding utf8 -LiteralPath $gradlePath),
+        'versionName\s*=\s*"([0-9]+\.[0-9]+\.[0-9]+)"')
+    if (-not $gradleMatch.Success) {
+        Write-Error "app/build.gradle.kts 에서 versionName 을 찾지 못했습니다."
+        exit 1
+    }
+    $ExpectedVersion = $gradleMatch.Groups[1].Value
+}
+
+Write-Host "기대 버전: v$ExpectedVersion (app/build.gradle.kts versionName)"
+
+# ---- 랜딩 페이지 ----
+$docsPath = Resolve-UnderRoot $DocsDir
+$landingFiles = @("index.html", "index.ko.html", "index.ja.html", "index.de.html", "index.es.html", "index.fr.html")
+$releasePatterns = [ordered]@{
+    'softwareVersion' = '"softwareVersion":\s*"([0-9]+\.[0-9]+\.[0-9]+)"'
+    'release-line'    = 'class="release-line">[^<]*?v([0-9]+\.[0-9]+\.[0-9]+)'
+    'trust-ledger'    = '<strong>v([0-9]+\.[0-9]+\.[0-9]+)</strong>'
+}
+
+Write-Host "`n랜딩 페이지 ($($landingFiles.Count)개, $DocsDir/)"
+$screenshotVersions = @()
+foreach ($file in $landingFiles) {
+    $path = Join-Path $docsPath $file
     if (-not (Test-Path -LiteralPath $path)) {
-        Write-Host "WARN  $path 이(가) 없습니다 — 건너뜀." -ForegroundColor Yellow
-        $missingFiles++
+        Add-Failure ("  FAIL  {0,-16} 파일이 없습니다." -f $file)
         continue
     }
     $text = Get-Content -Raw -Encoding utf8 -LiteralPath $path
 
-    $rows += [pscustomobject]@{
-        File            = $f
-        SoftwareVersion = Get-Version $text '"softwareVersion":\s*"([0-9]+\.[0-9]+\.[0-9]+)"' "softwareVersion" $f
-        ReleaseLine     = Get-Version $text 'class="release-line">[^<]*?v([0-9]+\.[0-9]+\.[0-9]+)' "release-line" $f
-        TrustLedger     = Get-Version $text '<strong>v([0-9]+\.[0-9]+\.[0-9]+)</strong>' "trust-ledger" $f
-        Screenshot      = Get-Version $text '<figcaption>[^<]*v([0-9]+\.[0-9]+\.[0-9]+)' "figcaption" $f
+    $ok = $true
+    foreach ($label in $releasePatterns.Keys) {
+        $match = [regex]::Match($text, $releasePatterns[$label])
+        if (-not $match.Success) {
+            Add-Failure ("  FAIL  {0,-16} '{1}' 버전 표기를 찾지 못했습니다." -f $file, $label)
+            $ok = $false
+        } elseif ($match.Groups[1].Value -ne $ExpectedVersion) {
+            Add-Failure ("  FAIL  {0,-16} '{1}' = v{2} (기대 v{3})" -f $file, $label, $match.Groups[1].Value, $ExpectedVersion)
+            $ok = $false
+        }
+    }
+
+    $screenshot = [regex]::Match($text, '<figcaption>[^<]*v([0-9]+\.[0-9]+\.[0-9]+)')
+    if (-not $screenshot.Success) {
+        Add-Failure ("  FAIL  {0,-16} figcaption 스크린샷 버전 표기를 찾지 못했습니다." -f $file)
+        $ok = $false
+    } else {
+        $screenshotVersions += $screenshot.Groups[1].Value
+    }
+
+    if ($ok) {
+        Write-Host ("  OK    {0,-16} release=v{1}  screenshot=v{2}" -f $file, $ExpectedVersion, $screenshot.Groups[1].Value) -ForegroundColor Green
     }
 }
 
-if ($rows.Count -eq 0) { Write-Error "검사할 랜딩 페이지가 없습니다."; exit 1 }
+# ---- README ----
+$readmeFiles = @("README.md", "README.ko.md", "README.ja.md", "README.de.md", "README.es.md", "README.fr.md")
+$releaseLinkPattern = '(?:releases/tag/|-/releases/)v[0-9]+\.[0-9]+\.[0-9]+'
 
-Write-Host "Landing pages: $($rows.Count)"
-foreach ($r in $rows) {
-    Write-Host ("  {0,-16} release[sw={1} line={2} trust={3}]  screenshot={4}" -f `
-        $r.File, $r.SoftwareVersion, $r.ReleaseLine, $r.TrustLedger, $r.Screenshot)
+Write-Host "`nREADME ($($readmeFiles.Count)개)"
+foreach ($file in $readmeFiles) {
+    $path = Resolve-UnderRoot $file
+    if (-not (Test-Path -LiteralPath $path)) {
+        Add-Failure ("  FAIL  {0,-16} 파일이 없습니다." -f $file)
+        continue
+    }
+    $lines = @(Get-Content -Encoding utf8 -LiteralPath $path)
+
+    $linkLines = 0
+    $stale = @()
+    for ($i = 0; $i -lt $lines.Count; $i++) {
+        if ($lines[$i] -notmatch $releaseLinkPattern) { continue }
+        $linkLines++
+        foreach ($match in [regex]::Matches($lines[$i], 'v([0-9]+\.[0-9]+\.[0-9]+)')) {
+            if ($match.Groups[1].Value -ne $ExpectedVersion) {
+                $stale += "L$($i + 1) v$($match.Groups[1].Value)"
+            }
+        }
+    }
+
+    if ($linkLines -eq 0) {
+        Add-Failure ("  FAIL  {0,-16} 릴리스 링크(releases/tag/vX.Y.Z)가 있는 줄을 찾지 못했습니다." -f $file)
+    } elseif ($stale.Count -gt 0) {
+        # 한 줄에 같은 버전이 링크 텍스트와 URL 로 여러 번 나오므로 줄 단위로 묶는다.
+        $staleUnique = @($stale | Sort-Object -Unique)
+        Add-Failure ("  FAIL  {0,-16} 기대 v{1} 과 다른 표기 -> {2}" -f $file, $ExpectedVersion, ($staleUnique -join ', '))
+    } else {
+        Write-Host ("  OK    {0,-16} 릴리스 링크 {1}줄 모두 v{2}" -f $file, $linkLines, $ExpectedVersion) -ForegroundColor Green
+    }
 }
 
-# 릴리스 버전: 모든 파일의 sw/line/trust 가 단일 값이어야 한다.
-$releaseValues = foreach ($r in $rows) { $r.SoftwareVersion; $r.ReleaseLine; $r.TrustLedger }
-$releaseUnique = @($releaseValues | Where-Object { $_ } | Sort-Object -Unique)
-
-# 스크린샷 버전: 모든 파일의 figcaption 이 단일 값이어야 한다(릴리스 버전과는 별개).
-$screenshotUnique = @($rows | ForEach-Object { $_.Screenshot } | Where-Object { $_ } | Sort-Object -Unique)
-
-$fail = 0
-
-if ($releaseUnique.Count -eq 1) {
-    Write-Host "OK: 릴리스 버전이 모든 언어에서 일치합니다 (v$($releaseUnique[0]))." -ForegroundColor Green
-} elseif ($releaseUnique.Count -eq 0) {
-    Write-Host "MISMATCH: 릴리스 버전 표기를 하나도 찾지 못했습니다." -ForegroundColor Red
-    $fail++
-} else {
-    Write-Host "MISMATCH: 릴리스 버전이 언어 간에 어긋납니다 -> $($releaseUnique -join ', ')" -ForegroundColor Red
-    $fail++
-}
-
+# ---- 스크린샷(figcaption): 릴리스 버전과 별개, 언어 간 일치만 확인 ----
+$screenshotUnique = @($screenshotVersions | Sort-Object -Unique)
 if ($screenshotUnique.Count -le 1) {
-    $shot = if ($screenshotUnique.Count -eq 1) { "v$($screenshotUnique[0])" } else { "표기 없음" }
-    Write-Host "OK: 스크린샷(figcaption) 버전이 일치합니다 ($shot)." -ForegroundColor Green
+    $shown = if ($screenshotUnique.Count -eq 1) { "v$($screenshotUnique[0])" } else { "표기 없음" }
+    Write-Host "`nOK: 스크린샷(figcaption) 버전이 여섯 언어에서 일치합니다 ($shown)." -ForegroundColor Green
 } else {
-    Write-Host "MISMATCH: 스크린샷(figcaption) 버전이 언어 간에 어긋납니다 -> $($screenshotUnique -join ', ')" -ForegroundColor Red
-    $fail++
+    Add-Failure "`nMISMATCH: 스크린샷(figcaption) 버전이 언어 간에 어긋납니다 -> $($screenshotUnique -join ', ')"
 }
 
-if ($missingFiles -gt 0) {
-    Write-Host "참고: 랜딩 파일 $missingFiles 개를 읽지 못했습니다." -ForegroundColor DarkYellow
+if ($fail -ne 0) {
+    Write-Host "`n실패 $fail 건. 낡은 표기를 갱신하세요 — 검사를 고치지 마세요." -ForegroundColor Red
+    exit 2
 }
-
-if ($fail -ne 0) { exit 2 }
-Write-Host "모든 랜딩 버전 검사를 통과했습니다." -ForegroundColor Green
+Write-Host "`n모든 공개 표면 버전 검사를 통과했습니다 (v$ExpectedVersion)." -ForegroundColor Green

--- a/scripts/verify-release-notes.ps1
+++ b/scripts/verify-release-notes.ps1
@@ -1,0 +1,173 @@
+<#
+.SYNOPSIS
+  릴리스 노트 자산(fastlane changelog, CHANGELOG 두 판)의 정합성을 검증한다.
+.DESCRIPTION
+  기대 버전은 `app/build.gradle.kts` 의 versionName / versionCode 다. 검사는 세 가지다.
+
+  1. fastlane changelog 존재 — 여섯 스토어 로케일 전부에
+     `fastlane/metadata/android/<locale>/changelogs/<versionCode>.txt` 가 있어야 한다.
+  2. fastlane changelog 길이 — 로케일당 Play Console 상한인 500자 이하여야 한다.
+     같은 불변식이 `:app:exportReleaseToBuildDrive` 에도 있지만 그건 릴리스 커밋이
+     이미 만들어진 뒤 릴리스 시점에 돈다. de-DE / fr-FR 이 526 / 525자로 작성된 것을
+     손으로 세어서야 발견한 적이 있어(#167), 같은 검사를 CI 로 앞당긴다.
+  3. CHANGELOG.md ↔ CHANGELOG.ko.md 동기화 — 영어판이 GitHub 릴리즈 노트의 원본이고
+     한국어판은 번역이라, 한쪽에만 있는 버전 섹션은 아무 것도 실패시키지 않은 채
+     남는다(#167). 버전 섹션의 순서와 날짜가 두 파일에서 같은지, 그리고 이번 버전
+     섹션이 양쪽에 있는지 확인한다. 제목은 번역이므로 비교하지 않는다.
+
+  길이는 `writeReleaseArtifacts` 와 같은 방식으로 센다(trim 후 문자 수).
+.EXAMPLE
+  pwsh scripts/verify-release-notes.ps1
+.EXAMPLE
+  pwsh scripts/verify-release-notes.ps1 -ExpectedVersion 2.27.0 -ExpectedVersionCode 110
+#>
+[CmdletBinding()]
+param(
+    [string]$RepoRoot = (Split-Path -Parent $PSScriptRoot),
+    [string]$ExpectedVersion = "",
+    [int]$ExpectedVersionCode = 0
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+# Play Console 은 릴리스 노트를 로케일당 500자로 제한한다.
+# app/build.gradle.kts 의 playLimit 과 같은 값이어야 한다.
+$PlayNoteLimit = 500
+
+# app/build.gradle.kts 의 noteLocales 와 같은 목록이어야 한다.
+$StoreLocales = @("ko-KR", "en-US", "ja-JP", "de-DE", "fr-FR", "es-ES")
+
+function Resolve-UnderRoot([string]$Path) {
+    if ([System.IO.Path]::IsPathRooted($Path)) { return $Path }
+    return (Join-Path $RepoRoot $Path)
+}
+
+$fail = 0
+function Add-Failure([string]$Message) {
+    Write-Host $Message -ForegroundColor Red
+    $script:fail++
+}
+
+# ---- 기대 버전: app/build.gradle.kts ----
+if (-not $ExpectedVersion -or $ExpectedVersionCode -le 0) {
+    $gradlePath = Resolve-UnderRoot "app/build.gradle.kts"
+    if (-not (Test-Path -LiteralPath $gradlePath)) {
+        Write-Error "기대 버전을 읽을 app/build.gradle.kts 를 찾지 못했습니다: $gradlePath"
+        exit 1
+    }
+    $gradleText = Get-Content -Raw -Encoding utf8 -LiteralPath $gradlePath
+
+    if (-not $ExpectedVersion) {
+        $nameMatch = [regex]::Match($gradleText, 'versionName\s*=\s*"([0-9]+\.[0-9]+\.[0-9]+)"')
+        if (-not $nameMatch.Success) {
+            Write-Error "app/build.gradle.kts 에서 versionName 을 찾지 못했습니다."
+            exit 1
+        }
+        $ExpectedVersion = $nameMatch.Groups[1].Value
+    }
+    if ($ExpectedVersionCode -le 0) {
+        $codeMatch = [regex]::Match($gradleText, 'versionCode\s*=\s*([0-9]+)')
+        if (-not $codeMatch.Success) {
+            Write-Error "app/build.gradle.kts 에서 versionCode 를 찾지 못했습니다."
+            exit 1
+        }
+        $ExpectedVersionCode = [int]$codeMatch.Groups[1].Value
+    }
+}
+
+Write-Host "기대 버전: v$ExpectedVersion (versionCode $ExpectedVersionCode)"
+
+# ---- 1·2. fastlane changelog: 존재 + 500자 상한 ----
+Write-Host "`nfastlane changelog ($($StoreLocales.Count)개 로케일, ${ExpectedVersionCode}.txt)"
+foreach ($locale in $StoreLocales) {
+    $relative = "fastlane/metadata/android/$locale/changelogs/$ExpectedVersionCode.txt"
+    $path = Resolve-UnderRoot $relative
+    if (-not (Test-Path -LiteralPath $path)) {
+        Add-Failure ("  FAIL  {0,-6} {1} 이(가) 없습니다." -f $locale, $relative)
+        continue
+    }
+
+    $length = (Get-Content -Raw -Encoding utf8 -LiteralPath $path).Trim().Length
+    if ($length -gt $PlayNoteLimit) {
+        Add-Failure ("  FAIL  {0,-6} {1,4}자 — Play 상한 {2}자를 {3}자 초과" -f $locale, $length, $PlayNoteLimit, ($length - $PlayNoteLimit))
+    } else {
+        Write-Host ("  OK    {0,-6} {1,4}자 / {2}" -f $locale, $length, $PlayNoteLimit) -ForegroundColor Green
+    }
+}
+
+# ---- 3. CHANGELOG.md ↔ CHANGELOG.ko.md ----
+Write-Host "`nCHANGELOG 동기화"
+$changelogPaths = [ordered]@{
+    'CHANGELOG.md'    = Resolve-UnderRoot "CHANGELOG.md"
+    'CHANGELOG.ko.md' = Resolve-UnderRoot "CHANGELOG.ko.md"
+}
+
+$sections = [ordered]@{}
+$readable = $true
+foreach ($name in $changelogPaths.Keys) {
+    $path = $changelogPaths[$name]
+    if (-not (Test-Path -LiteralPath $path)) {
+        Add-Failure "  FAIL  $name 이(가) 없습니다."
+        $readable = $false
+        continue
+    }
+    # 헤딩 형식은 '## vX.Y.Z - 제목 - YYYY-MM-DD' 다(docs/RELEASE.md).
+    # 제목은 번역이라 비교하지 않고 버전과 날짜만 뽑는다. 날짜 뒤에 '(Release Failed)'
+    # 같은 꼬리표가 붙은 항목이 있어 줄 끝에 앵커를 걸지 않는다.
+    $sections[$name] = @(
+        @(Get-Content -Encoding utf8 -LiteralPath $path) |
+            Where-Object { $_ -match '^## v[0-9]+\.[0-9]+\.[0-9]+' } |
+            ForEach-Object {
+                [pscustomobject]@{
+                    Version = [regex]::Match($_, '^## v([0-9]+\.[0-9]+\.[0-9]+)').Groups[1].Value
+                    Date    = $(
+                        $dateMatch = [regex]::Match($_, '([0-9]{4}-[0-9]{2}-[0-9]{2})')
+                        if ($dateMatch.Success) { $dateMatch.Groups[1].Value } else { "" }
+                    )
+                }
+            }
+    )
+}
+
+if ($readable) {
+    $en = $sections['CHANGELOG.md']
+    $ko = $sections['CHANGELOG.ko.md']
+
+    if ($en.Count -ne $ko.Count) {
+        $enVersions = @($en | ForEach-Object { $_.Version })
+        $koVersions = @($ko | ForEach-Object { $_.Version })
+        $enOnly = @($enVersions | Where-Object { $koVersions -notcontains $_ })
+        $koOnly = @($koVersions | Where-Object { $enVersions -notcontains $_ })
+        Add-Failure "  FAIL  버전 섹션 수가 다릅니다 — CHANGELOG.md $($en.Count)개, CHANGELOG.ko.md $($ko.Count)개."
+        if ($enOnly.Count -gt 0) { Add-Failure "        영어판에만: $($enOnly -join ', ')" }
+        if ($koOnly.Count -gt 0) { Add-Failure "        한국어판에만: $($koOnly -join ', ')" }
+    } else {
+        $drift = @()
+        for ($i = 0; $i -lt $en.Count; $i++) {
+            if ($en[$i].Version -ne $ko[$i].Version) {
+                $drift += "#$($i + 1): 영어판 v$($en[$i].Version) / 한국어판 v$($ko[$i].Version)"
+            } elseif ($en[$i].Date -ne $ko[$i].Date) {
+                $drift += "v$($en[$i].Version): 날짜 영어판 $($en[$i].Date) / 한국어판 $($ko[$i].Date)"
+            }
+        }
+        if ($drift.Count -gt 0) {
+            Add-Failure "  FAIL  버전 섹션이 어긋납니다:"
+            foreach ($item in $drift) { Add-Failure "        $item" }
+        } else {
+            Write-Host ("  OK    두 판의 버전 섹션 {0}개가 순서·날짜까지 일치합니다." -f $en.Count) -ForegroundColor Green
+        }
+    }
+
+    foreach ($name in $changelogPaths.Keys) {
+        if (@($sections[$name] | Where-Object { $_.Version -eq $ExpectedVersion }).Count -eq 0) {
+            Add-Failure "  FAIL  $name 에 이번 버전(v$ExpectedVersion) 섹션이 없습니다."
+        }
+    }
+}
+
+if ($fail -ne 0) {
+    Write-Host "`n실패 $fail 건. 릴리스 노트를 갱신하세요 — 검사를 고치지 마세요." -ForegroundColor Red
+    exit 2
+}
+Write-Host "`n모든 릴리스 노트 검사를 통과했습니다 (v$ExpectedVersion / vc$ExpectedVersionCode)." -ForegroundColor Green


### PR DESCRIPTION
Implements three of the five hardening candidates in #167.

## What changed

**`scripts/verify-landing-versions.ps1`** — catches staleness now, not just disagreement.

- The expected version comes from `app/build.gradle.kts` `versionName`; a mismatch fails.
- The six READMEs are checked alongside the six landing pages.
- A missing file or a missing version string is a failure, not a warning.

**`scripts/verify-release-notes.ps1`** (new)

- The six fastlane changelogs for the current `versionCode` must exist.
- Each must fit Play Console's 500-character-per-locale limit.
- `CHANGELOG.md` and `CHANGELOG.ko.md` must carry the same version sections, in the same order, with the same dates, and both must have a section for the current `versionName`. Titles are translations and are not compared.

**CI** — both run in the `build` job ahead of Gradle. They take seconds, so failing on them first costs nothing.

## Note on "compare against the latest tag"

The issue suggested comparing against the latest git tag. I used `versionName` instead: the check runs *before* the tag is pushed (`docs/RELEASE.md`), so during release preparation the newest tag still points at the previous version and every run would fail. `versionName` is what the tag is derived from, which makes it the earlier and stricter source.

## Verification

Current tree: both scripts exit 0.

Deliberate breakage:

- `-ExpectedVersion 2.27.0` (bumped, nothing propagated — the v2.25.0 / v2.26.0 situation) → 24 failures across landing pages and READMEs, exit 2.
- `-ExpectedVersionCode 110` → all six fastlane locales reported missing, both CHANGELOGs reported missing the section, exit 2.

Five-case fixture covering the README line logic:

| Case | Expected | Result |
|---|---|---|
| Normal, roadmap `v1.0.0` / `v2.0.0` present | pass | pass |
| README link *label* stale, URL fresh | fail | fail |
| Landing trust-ledger stale | fail | fail |
| Target file missing | fail | fail |
| Screenshot version drifts between languages | fail | fail |

The workflow YAML parses and the two steps land at positions 2 and 3 of the `build` job.

## Noticed while here, deliberately left out

- `fastlane/metadata/android/fr-FR/changelogs/89.txt` is 607 characters. It is a past release already submitted to Play, so the check stays scoped to the current `versionCode` — the same scope `:app:exportReleaseToBuildDrive` already uses.
- The `release` job has no `needs: build`. On a tag push it runs in parallel with the gate and re-runs only `test`, so `lintRelease`, `verifyRoborazziDebug`, and these two checks do not block a release. Filed separately rather than widened into this PR.

Part of #167.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
