### PR TITLE
refactor: extract the sync-folder URI unwrap into one helper

### DIFF
--- a/app/src/main/java/com/markleaf/notes/MainActivity.kt
+++ b/app/src/main/java/com/markleaf/notes/MainActivity.kt
@@ -27,6 +27,7 @@ import com.markleaf.notes.data.settings.ColorPalette
 import com.markleaf.notes.data.settings.EditorFont
 import com.markleaf.notes.data.sync.NoteFolderMirror
 import com.markleaf.notes.data.sync.NoteImporter
+import com.markleaf.notes.data.sync.syncFolderUriOrNull
 import com.markleaf.notes.feature.lock.BiometricLockGate
 import com.markleaf.notes.feature.onboarding.WelcomeOnboardingSheet
 import com.markleaf.notes.navigation.MarkleafNavHost
@@ -74,9 +75,7 @@ class MainActivity : FragmentActivity() {
                 if (now - lastReconcileMs < THROTTLE_MS) return@repeatOnLifecycle
                 lastReconcileMs = now
                 val settings = settingsRepository.settings.first()
-                val uriString = settings.syncFolderUri ?: return@repeatOnLifecycle
-                val uri = runCatching { android.net.Uri.parse(uriString) }.getOrNull()
-                    ?: return@repeatOnLifecycle
+                val uri = settings.syncFolderUriOrNull() ?: return@repeatOnLifecycle
                 val notes = withContext(Dispatchers.IO) {
                     // Full set (incl. trashed/archived) so the reconcile can't
                     // re-import a hidden note as a brand-new one — see #148.

--- a/app/src/main/java/com/markleaf/notes/data/sync/NoteFolderMirror.kt
+++ b/app/src/main/java/com/markleaf/notes/data/sync/NoteFolderMirror.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.net.Uri
 import androidx.documentfile.provider.DocumentFile
 import com.markleaf.notes.core.text.TitleExtractor
+import com.markleaf.notes.data.settings.AppSettings
 import com.markleaf.notes.data.settings.SyncFileExtension
 import com.markleaf.notes.domain.model.Note
 import java.io.BufferedWriter
@@ -458,3 +459,16 @@ object NoteFolderMirror {
     private const val ATTACHMENTS_DIR = "attachments"
     private const val FRONTMATTER_PEEK_BYTES = 4096
 }
+
+/**
+ * The sync folder as a [Uri], or null when folder sync is off or the persisted
+ * value no longer parses.
+ *
+ * Both guards are needed wherever the folder is touched: sync may be
+ * unconfigured, and the stored string is opaque text that a revoked or
+ * rewritten SAF grant can leave unparseable. Nine call sites spelled them out
+ * separately, in three different shapes, which made the one call site carrying
+ * an *extra* condition (the editor's `!note.locked`) hard to pick out (#158).
+ */
+fun AppSettings.syncFolderUriOrNull(): Uri? =
+    syncFolderUri?.let { raw -> runCatching { Uri.parse(raw) }.getOrNull() }

--- a/app/src/main/java/com/markleaf/notes/feature/archive/ArchiveScreen.kt
+++ b/app/src/main/java/com/markleaf/notes/feature/archive/ArchiveScreen.kt
@@ -91,32 +91,32 @@ fun ArchiveScreen(
             color = MaterialTheme.colorScheme.background
         ) {
             if (notes.isEmpty()) {
-            EmptyState(
-                icon = Icons.Outlined.Archive,
-                title = stringResource(R.string.archive_empty),
-                hint = stringResource(R.string.archive_empty_hint)
-            )
-        } else {
-            LazyColumn(modifier = Modifier.fillMaxSize()) {
-                items(notes, key = { it.id }) { note ->
-                    ArchiveRow(
-                        note = note,
-                        onClick = { onNoteClick(note.id) },
-                        onUnarchive = {
-                            haptics.performHapticFeedback(HapticFeedbackType.LongPress)
-                            viewModel.unarchive(note.id)
-                        },
-                        onMoveToTrash = {
-                            haptics.performHapticFeedback(HapticFeedbackType.LongPress)
-                            viewModel.moveToTrash(note.id)
-                        },
-                        onLongPress = {
-                            haptics.performHapticFeedback(HapticFeedbackType.LongPress)
-                        }
-                    )
+                EmptyState(
+                    icon = Icons.Outlined.Archive,
+                    title = stringResource(R.string.archive_empty),
+                    hint = stringResource(R.string.archive_empty_hint)
+                )
+            } else {
+                LazyColumn(modifier = Modifier.fillMaxSize()) {
+                    items(notes, key = { it.id }) { note ->
+                        ArchiveRow(
+                            note = note,
+                            onClick = { onNoteClick(note.id) },
+                            onUnarchive = {
+                                haptics.performHapticFeedback(HapticFeedbackType.LongPress)
+                                viewModel.unarchive(note.id)
+                            },
+                            onMoveToTrash = {
+                                haptics.performHapticFeedback(HapticFeedbackType.LongPress)
+                                viewModel.moveToTrash(note.id)
+                            },
+                            onLongPress = {
+                                haptics.performHapticFeedback(HapticFeedbackType.LongPress)
+                            }
+                        )
+                    }
                 }
             }
-        }
         }
     }
 }

--- a/app/src/main/java/com/markleaf/notes/feature/editor/EditorScreen.kt
+++ b/app/src/main/java/com/markleaf/notes/feature/editor/EditorScreen.kt
@@ -93,6 +93,7 @@ import com.markleaf.notes.data.settings.AppSettings
 import com.markleaf.notes.data.settings.AppSettingsRepository
 import com.markleaf.notes.data.settings.MarkdownSyntaxVisibility
 import com.markleaf.notes.data.sync.NoteFolderMirror
+import com.markleaf.notes.data.sync.syncFolderUriOrNull
 import com.markleaf.notes.domain.model.Note
 import com.markleaf.notes.util.AttachmentManager
 import com.markleaf.notes.util.ExportUtil
@@ -323,12 +324,11 @@ fun EditorScreen(
                 repo.updateNote(updatedNote)
                 tagRepo.reindexTagsForNote(noteId, content)
                 linkRepo.reindexLinksForNote(noteId, content)
-                appSettings.syncFolderUri?.let { uriString ->
-                    val uri = runCatching { android.net.Uri.parse(uriString) }.getOrNull()
+                appSettings.syncFolderUriOrNull()?.let { uri ->
                     // Never mirror a locked note to the sync folder — the Locked
                     // space is meant to stay on-device, and the mirror writes plain
                     // text (#155). Removing the lock re-includes it on the next save.
-                    if (uri != null && !updatedNote.locked) {
+                    if (!updatedNote.locked) {
                         val ok = withContext(Dispatchers.IO) {
                             val wrote = NoteFolderMirror.writeNote(context, uri, updatedNote, appSettings.syncFileExtension)
                             if (wrote) {

--- a/app/src/main/java/com/markleaf/notes/feature/lock/LockedNotesScreen.kt
+++ b/app/src/main/java/com/markleaf/notes/feature/lock/LockedNotesScreen.kt
@@ -64,6 +64,7 @@ import com.markleaf.notes.data.settings.AppSettings
 import com.markleaf.notes.data.settings.AppSettingsRepository
 import com.markleaf.notes.data.settings.LockPasscodeAttempt
 import com.markleaf.notes.data.sync.NoteFolderMirror
+import com.markleaf.notes.data.sync.syncFolderUriOrNull
 import com.markleaf.notes.domain.model.Note
 import com.markleaf.notes.ui.component.EmptyState
 import com.markleaf.notes.ui.viewmodel.LockedNotesViewModel
@@ -346,19 +347,14 @@ private fun LockedNotesList(
                         // Locking deleted the note's mirror file, so unlocking has to
                         // put it back — otherwise the note would stay missing from the
                         // sync folder until its next edit (#156).
-                        appSettings.syncFolderUri?.let { uriString ->
-                            val uri = runCatching {
-                                android.net.Uri.parse(uriString)
-                            }.getOrNull()
-                            if (uri != null) {
-                                scope.launch {
-                                    withContext(Dispatchers.IO) {
-                                        NoteFolderMirror.writeNote(
-                                            context,
-                                            uri,
-                                            note.copy(locked = false)
-                                        )
-                                    }
+                        appSettings.syncFolderUriOrNull()?.let { uri ->
+                            scope.launch {
+                                withContext(Dispatchers.IO) {
+                                    NoteFolderMirror.writeNote(
+                                        context,
+                                        uri,
+                                        note.copy(locked = false)
+                                    )
                                 }
                             }
                         }

--- a/app/src/main/java/com/markleaf/notes/feature/notes/NotesListScreen.kt
+++ b/app/src/main/java/com/markleaf/notes/feature/notes/NotesListScreen.kt
@@ -77,6 +77,7 @@ import com.markleaf.notes.R
 import com.markleaf.notes.data.settings.AppSettings
 import com.markleaf.notes.data.settings.AppSettingsRepository
 import com.markleaf.notes.data.sync.NoteFolderMirror
+import com.markleaf.notes.data.sync.syncFolderUriOrNull
 import com.markleaf.notes.domain.model.Note
 import com.markleaf.notes.navigation.LocalNavAnimatedVisibilityScope
 import com.markleaf.notes.navigation.LocalSharedTransitionScope
@@ -409,15 +410,10 @@ fun NotesListScreen(
                                     // plaintext copy in the sync folder. Remove it now, or
                                     // the Locked space's privacy promise is only skin deep.
                                     // LockedNotesScreen re-mirrors on unlock (#156).
-                                    appSettings.syncFolderUri?.let { uriString ->
-                                        val uri = runCatching {
-                                            android.net.Uri.parse(uriString)
-                                        }.getOrNull()
-                                        if (uri != null) {
-                                            scope.launch {
-                                                withContext(Dispatchers.IO) {
-                                                    NoteFolderMirror.deleteNote(context, uri, note.id)
-                                                }
+                                    appSettings.syncFolderUriOrNull()?.let { uri ->
+                                        scope.launch {
+                                            withContext(Dispatchers.IO) {
+                                                NoteFolderMirror.deleteNote(context, uri, note.id)
                                             }
                                         }
                                     }

--- a/app/src/main/java/com/markleaf/notes/feature/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/markleaf/notes/feature/settings/SettingsScreen.kt
@@ -65,6 +65,7 @@ import com.markleaf.notes.data.settings.EditorLineWidth
 import com.markleaf.notes.data.settings.MarkdownSyntaxVisibility
 import com.markleaf.notes.data.sync.NoteFolderMirror
 import com.markleaf.notes.data.sync.NoteImporter
+import com.markleaf.notes.data.sync.syncFolderUriOrNull
 import com.markleaf.notes.feature.lock.canUseBiometric
 import com.markleaf.notes.util.ExportAllNotes
 import com.markleaf.notes.util.HapticFeedback
@@ -365,8 +366,7 @@ fun SettingsScreen(
                         lastSyncedAt = appSettings.syncLastSyncedAt,
                         onPickFolder = { syncFolderLauncher.launch(null) },
                         onSyncNow = {
-                            val uriString = appSettings.syncFolderUri ?: return@SyncSection
-                            val uri = runCatching { Uri.parse(uriString) }.getOrNull() ?: return@SyncSection
+                            val uri = appSettings.syncFolderUriOrNull() ?: return@SyncSection
                             scope.launch {
                                 val notes = withContext(Dispatchers.IO) {
                                     // Full set (incl. trashed/archived) so a hidden note

--- a/app/src/main/java/com/markleaf/notes/feature/sync/SyncCenterScreen.kt
+++ b/app/src/main/java/com/markleaf/notes/feature/sync/SyncCenterScreen.kt
@@ -1,7 +1,6 @@
 package com.markleaf.notes.feature.sync
 
 import android.content.Intent
-import android.net.Uri
 import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -34,6 +33,7 @@ import com.markleaf.notes.data.settings.AppSettingsRepository
 import com.markleaf.notes.data.settings.SyncFileExtension
 import com.markleaf.notes.data.sync.NoteFolderMirror
 import com.markleaf.notes.data.sync.NoteImporter
+import com.markleaf.notes.data.sync.syncFolderUriOrNull
 import com.markleaf.notes.domain.model.Note
 import com.markleaf.notes.ui.viewmodel.SyncCenterViewModel
 import com.markleaf.notes.util.HapticFeedback
@@ -197,8 +197,7 @@ fun SyncCenterScreen(
                                 
                                 Button(
                                     onClick = {
-                                        val uriString = appSettings.syncFolderUri ?: return@Button
-                                        val uri = runCatching { Uri.parse(uriString) }.getOrNull() ?: return@Button
+                                        val uri = appSettings.syncFolderUriOrNull() ?: return@Button
                                         isSyncing = true
                                         scope.launch {
                                             val notes = withContext(Dispatchers.IO) {
@@ -267,9 +266,7 @@ fun SyncCenterScreen(
 
                                 OutlinedButton(
                                     onClick = {
-                                        val uriString = appSettings.syncFolderUri ?: return@OutlinedButton
-                                        val uri = runCatching { Uri.parse(uriString) }.getOrNull()
-                                            ?: return@OutlinedButton
+                                        val uri = appSettings.syncFolderUriOrNull() ?: return@OutlinedButton
                                         scope.launch {
                                             val notes = withContext(Dispatchers.IO) {
                                                 noteRepository.observeNotes().first()
@@ -464,13 +461,10 @@ fun SyncCenterScreen(
                             scope.launch(Dispatchers.IO) {
                                 com.markleaf.notes.util.AttachmentManager.deleteAllForNote(context, note.id)
                             }
-                            appSettings.syncFolderUri?.let { uriString ->
-                                val uri = runCatching { Uri.parse(uriString) }.getOrNull()
-                                if (uri != null) {
-                                    scope.launch {
-                                        withContext(Dispatchers.IO) {
-                                            NoteFolderMirror.deleteNote(context, uri, note.id)
-                                        }
+                            appSettings.syncFolderUriOrNull()?.let { uri ->
+                                scope.launch {
+                                    withContext(Dispatchers.IO) {
+                                        NoteFolderMirror.deleteNote(context, uri, note.id)
                                     }
                                 }
                             }

--- a/app/src/main/java/com/markleaf/notes/feature/trash/TrashScreen.kt
+++ b/app/src/main/java/com/markleaf/notes/feature/trash/TrashScreen.kt
@@ -46,6 +46,7 @@ import com.markleaf.notes.ui.component.EmptyState
 import com.markleaf.notes.data.settings.AppSettings
 import com.markleaf.notes.data.settings.AppSettingsRepository
 import com.markleaf.notes.data.sync.NoteFolderMirror
+import com.markleaf.notes.data.sync.syncFolderUriOrNull
 import com.markleaf.notes.domain.model.Note
 import com.markleaf.notes.ui.viewmodel.TrashViewModel
 import com.markleaf.notes.util.AttachmentManager
@@ -172,15 +173,10 @@ fun TrashScreen(
                             AttachmentManager.deleteAllForNote(context, note.id)
                         }
                         // Mirror DB-side delete to the sync folder if configured.
-                        appSettings.syncFolderUri?.let { uriString ->
-                            val uri = runCatching {
-                                android.net.Uri.parse(uriString)
-                            }.getOrNull()
-                            if (uri != null) {
-                                scope.launch {
-                                    withContext(Dispatchers.IO) {
-                                        NoteFolderMirror.deleteNote(context, uri, note.id)
-                                    }
+                        appSettings.syncFolderUriOrNull()?.let { uri ->
+                            scope.launch {
+                                withContext(Dispatchers.IO) {
+                                    NoteFolderMirror.deleteNote(context, uri, note.id)
                                 }
                             }
                         }


### PR DESCRIPTION
Closes two of the seven hardening candidates in #158.

## `AppSettings.syncFolderUriOrNull()`

The issue counted five call sites re-implementing `syncFolderUri?.let { Uri.parse }`. The sweep found **nine**, in three shapes:

| Shape | Sites |
|---|---|
| `?: return@X`, twice | `MainActivity`, `SyncCenterScreen` ×2, `SettingsScreen` |
| `?.let` + nested `if (uri != null)` | `EditorScreen`, `TrashScreen`, `SyncCenterScreen`, `NotesListScreen`, `LockedNotesScreen` |

Four used the fully-qualified `android.net.Uri.parse`, five the imported one.

The helper carries both guards — folder sync may be off, and the persisted string is opaque text that a revoked or rewritten SAF grant can leave unparseable. Call sites keep whichever shape their context wants (`?: return@X` inside a lambda, `?.let` otherwise), so no control flow changed.

The payoff is the one site that was *not* like the others: the editor additionally refuses to mirror a locked note (#155). That read as `if (uri != null && !updatedNote.locked)` — a domain rule wearing a null check — and now reads as `if (!updatedNote.locked)`.

`SyncCenterScreen`'s `android.net.Uri` import became unused and is removed.

## ArchiveScreen indentation

`c04c6f4` wrapped the empty state in a `Surface` without re-indenting its children, so lines 94–119 sat one level short and the `if`/`else` closing brace lined up with the `Surface`'s own. It is the same artifact #154 flagged in Settings, still present here.

## Verification

- `:app:testDebugUnitTest` — BUILD SUCCESSFUL
- `:app:lintRelease` — 0 errors, 55 warnings, the same count as before this change
- `git diff -w --stat` — `ArchiveScreen.kt` is absent from it, confirming that nothing but whitespace moved in that file

## Noticed while here, deliberately left out

`LockedNotesScreen`'s unlock re-mirror calls `NoteFolderMirror.writeNote(context, uri, note.copy(locked = false))` without the `extension` argument, so it falls back to the `SyncFileExtension.MD` default. A user who chose `.txt` gets a `.md` file back when unlocking, while `EditorScreen` passes `appSettings.syncFileExtension` correctly. That is a behaviour bug rather than the consistency cleanup this PR is scoped to, so it is filed separately.

Refs #158.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
