### PR TITLE
i18n: settle terminology drift in ko, fr, de, ja, es

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -115,7 +115,7 @@
     <string name="callout_caution">Achtung</string>
 
     <string name="pin">Anheften</string>
-    <string name="unpin">Lösen</string>
+    <string name="unpin">Anheften aufheben</string>
     <string name="pinned">Angeheftet</string>
     <string name="section_pinned">Angeheftet</string>
     <string name="section_today">Heute</string>
@@ -124,7 +124,7 @@
     <string name="section_older">Älter</string>
     <string name="relative_today">Heute %1$s</string>
     <string name="relative_yesterday">Gestern %1$s</string>
-    <string name="relative_days_ago">vor %1$d Tagen</string>
+    <string name="relative_days_ago">Vor %1$d Tagen</string>
 
     <string name="search_notes_hint">Notizen durchsuchen…</string>
     <string name="type_to_search_notes">Tippen, um Notizen zu durchsuchen</string>
@@ -168,7 +168,7 @@
     <string name="line_width_wide">Breit</string>
     <string name="settings_privacy">Datenschutz</string>
     <string name="privacy_no_tracking">Kein Konto, keine Analytik, keine Werbung, keine Remote-Konfiguration und kein proprietäres Crash-Reporting-SDK.</string>
-    <string name="privacy_no_internet">Für das MVP wird die INTERNET-Berechtigung nicht angefordert.</string>
+    <string name="privacy_no_internet">Für das MVP wird die INTERNET-Berechtigung nicht deklariert.</string>
     <string name="privacy_local_first">Notizen verlassen das Gerät nur, wenn du sie explizit exportierst oder teilst.</string>
     <string name="settings_data">Daten</string>
     <string name="export_all_notes">Alle Notizen exportieren…</string>
@@ -204,7 +204,7 @@
     <string name="sync_done_with_conflicts_format">Synchronisiert – %1$d aktualisiert, %2$d neu, %3$d als Duplikate behalten (Konflikt), %4$d unverändert.</string>
     <string name="sync_stopped">Synchronisierung deaktiviert.</string>
     <string name="screenshot_protection">Screenshots und Vorschau in „Zuletzt verwendet“ blockieren</string>
-    <string name="screenshot_protection_description">Verbirgt Notizinhalte in Screenshots und im „Zuletzt verwendet“-Bildschirm. Editor neu öffnen, damit die Änderung wirksam wird.</string>
+    <string name="screenshot_protection_description">Verbirgt Notizinhalte in Screenshots und auf dem „Zuletzt verwendet“-Bildschirm. Editor neu öffnen, damit die Änderung wirksam wird.</string>
     <string name="settings_app">App</string>
     <string name="version_format">Version %1$s</string>
     <string name="application_id_format">Application ID %1$s</string>
@@ -228,7 +228,7 @@
     <string name="onboarding_title_markdown">In Markdown schreiben</string>
     <string name="onboarding_body_markdown">Nutze **fett**, _kursiv_, # Überschriften, Listen, Code und Zitate. Tippe oben auf Vorschau, um das Ergebnis jederzeit zu sehen.</string>
     <string name="onboarding_title_tags">Mit #Tags organisieren</string>
-    <string name="onboarding_body_tags">Schreibe #projekt oder #meeting irgendwo in eine Notiz. Tags werden automatisch erkannt und im Tags-Bildschirm angezeigt.</string>
+    <string name="onboarding_body_tags">Schreibe #projekt oder #meeting irgendwo in eine Notiz. Tags werden automatisch erkannt und auf dem Tags-Bildschirm angezeigt.</string>
     <string name="onboarding_title_local">Deine Daten bleiben lokal</string>
     <string name="onboarding_body_local">Kein Konto, keine Analytik, keine Cloud. Exportiere jede Notiz als .md-Datei oder zeige Markleaf einen synchronisierten Ordner (Dropbox / Drive / Syncthing) für die Nutzung auf mehreren Geräten.</string>
     <string name="onboarding_next">Weiter</string>
@@ -248,7 +248,7 @@
 
     <!-- Locked notes (#155) -->
     <string name="locked_notes_title">Gesperrte Notizen</string>
-    <string name="move_to_locked">Zu Gesperrt verschieben</string>
+    <string name="move_to_locked">Nach Gesperrt verschieben</string>
     <string name="remove_from_locked">Aus Gesperrt entfernen</string>
     <string name="locked_notes_empty">Keine gesperrten Notizen</string>
     <string name="locked_notes_empty_hint">Notizen, die du nach Gesperrt verschiebst, erscheinen hier hinter deinem Passcode.</string>
@@ -300,7 +300,7 @@
     <string name="privacy_data_storage_desc">Alle Notizen und Tags werden lokal auf deinem Gerät in Androids sicherer Room-Datenbank gespeichert. Keine Cloud-Server, keine Daten-Uploads.</string>
     <string name="privacy_no_cloud_title">Keine Cloud-Abhängigkeiten</string>
     <string name="privacy_no_cloud_desc">Wir nutzen für die Kernfunktionen keine Cloud-Dienste. Keine Google-Drive-Synchronisation, keine Dropbox-Integration, keine proprietären Backend-Server.</string>
-    <string name="privacy_no_tracking_title">Null Tracking</string>
+    <string name="privacy_no_tracking_title">Kein Tracking</string>
     <string name="privacy_no_tracking_desc">Keine Analytik, keine Crash-Reporting-SDKs, keine Werbenetzwerke. Wir haben keine Ahnung, wie du die App benutzt – und das ist Absicht.</string>
     <string name="privacy_verification_title">Datenschutz-Prüfung</string>
     <string name="privacy_verify_no_internet">Keine INTERNET-Berechtigung deklariert</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -186,7 +186,7 @@
     <string name="sync_status_last_synced_format">Última sincronización: %1$s</string>
     <string name="sync_status_last_synced_never">Última sincronización: nunca</string>
     <string name="sync_behavior_summary">· Guarda en la carpeta ~1 segundo después de cada edición.\n· \"Sincronizar ahora\" trae los cambios de otros dispositivos.\n· Conflictos: gana la edición más reciente.\n· Los borrados no se sincronizan — gestiona la papelera en cada dispositivo.</string>
-    <string name="sync_pick_folder">Elegir carpeta</string>
+    <string name="sync_pick_folder">Elegir carpeta de sincronización</string>
     <string name="sync_change_folder">Cambiar carpeta</string>
     <string name="sync_now">Sincronizar ahora</string>
     <string name="sync_stop">Desactivar sincronización</string>
@@ -250,11 +250,11 @@
     <string name="onboarding_title_welcome">Bienvenido a Markleaf</string>
     <string name="onboarding_body_welcome">Una aplicación tranquila de notas Markdown, con almacenamiento local primero, para Android. Tu texto se queda en este dispositivo a menos que decidas compartirlo o exportarlo.</string>
     <string name="onboarding_title_markdown">Escribe en Markdown</string>
-    <string name="onboarding_body_markdown">Usa **negrita**, _cursiva_, # títulos, listas, código y citas. Toca Vista previa en la barra superior para ver el resultado renderizado en cualquier momento.</string>
+    <string name="onboarding_body_markdown">Usa **negrita**, _cursiva_, # encabezados, listas, código y citas. Toca Vista previa en la barra superior para ver el resultado renderizado en cualquier momento.</string>
     <string name="onboarding_title_tags">Organiza con #etiquetas</string>
     <string name="onboarding_body_tags">Escribe #proyecto o #reunión en cualquier parte de una nota. Las etiquetas se detectan automáticamente y aparecen en la pantalla de Etiquetas.</string>
     <string name="onboarding_title_local">Tus datos se quedan locales</string>
-    <string name="onboarding_body_local">Sin cuenta, sin analíticas, sin nube. Exporta cualquier nota como archivo .md, o apunta Markleaf a una carpeta sincronizada (Dropbox / Drive / Syncthing) para multi-dispositivo.</string>
+    <string name="onboarding_body_local">Sin cuenta, sin analíticas, sin nube. Exporta cualquier nota como archivo .md, o apunta Markleaf a una carpeta sincronizada (Dropbox / Drive / Syncthing) para usarla entre dispositivos.</string>
     <string name="onboarding_next">Siguiente</string>
     <string name="onboarding_done">Empezar</string>
     <string name="onboarding_skip">Omitir</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -124,7 +124,7 @@
     <string name="section_older">Plus anciennes</string>
     <string name="relative_today">Aujourd\'hui %1$s</string>
     <string name="relative_yesterday">Hier %1$s</string>
-    <string name="relative_days_ago">il y a %1$d jours</string>
+    <string name="relative_days_ago">Il y a %1$d jours</string>
 
     <string name="search_notes_hint">Rechercher des notes...</string>
     <string name="type_to_search_notes">Saisissez du texte pour rechercher des notes</string>
@@ -167,7 +167,7 @@
     <string name="line_width_comfortable">Confortable</string>
     <string name="line_width_wide">Large</string>
     <string name="settings_privacy">Confidentialité</string>
-    <string name="privacy_no_tracking">Aucun compte, outil d\'analyse, publicité, configuration à distance ou SDK propriétaire de rapport d\'erreurs.</string>
+    <string name="privacy_no_tracking">Aucun compte, aucune analyse, aucune publicité, aucune configuration à distance, aucun SDK propriétaire de rapport d\'erreurs.</string>
     <string name="privacy_no_internet">Aucune autorisation INTERNET n\'est déclarée pour la version MVP.</string>
     <string name="privacy_local_first">Les notes ne quittent l\'appareil que lorsque vous les exportez ou les partagez explicitement.</string>
     <string name="settings_data">Données</string>
@@ -230,7 +230,7 @@
     <string name="onboarding_title_tags">Organisez avec des #étiquettes</string>
     <string name="onboarding_body_tags">Saisissez des #étiquettes n\'importe où dans une note. Elles sont détectées automatiquement et affichées sur l\'écran Étiquettes.</string>
     <string name="onboarding_title_local">Vos données restent locales</string>
-    <string name="onboarding_body_local">Aucun compte, aucun outil d\'analyse, aucun cloud. Exportez n\'importe quelle note au format .md, ou connectez Markleaf à un dossier synchronisé (Dropbox / Drive / Syncthing) pour l\'utiliser sur plusieurs appareils.</string>
+    <string name="onboarding_body_local">Aucun compte, aucune analyse, aucun cloud. Exportez n\'importe quelle note au format .md, ou connectez Markleaf à un dossier synchronisé (Dropbox / Drive / Syncthing) pour l\'utiliser sur plusieurs appareils.</string>
     <string name="onboarding_next">Suivant</string>
     <string name="onboarding_done">Commencer</string>
     <string name="onboarding_skip">Passer</string>
@@ -242,7 +242,7 @@
     <string name="biometric_lock_prompt_title">Déverrouiller Markleaf</string>
     <string name="biometric_lock_prompt_subtitle">Authentifiez-vous pour accéder à vos notes</string>
     <string name="biometric_lock_cancel">Annuler</string>
-    <string name="biometric_lock_unavailable">L\'authentification biométrique n\'est pas disponible sur cet appareil. Configurez une empreinte digitale ou un visage dans les paramètres du système pour utiliser le verrouillage de l\'application.</string>
+    <string name="biometric_lock_unavailable">L\'authentification biométrique n\'est pas disponible sur cet appareil. Configurez une empreinte digitale ou la reconnaissance faciale dans les paramètres du système pour utiliser le verrouillage de l\'application.</string>
     <string name="biometric_lock_retry">Réessayer</string>
     <string name="biometric_lock_locked_message">Markleaf est verrouillé.</string>
 

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -141,15 +141,15 @@
     <string name="trash_empty_hint">削除したノートはここに表示されます</string>
     <string name="restore">復元</string>
     <string name="delete">削除</string>
-    <string name="delete_forever_title">完全に削除しますか?</string>
+    <string name="delete_forever_title">完全に削除しますか？</string>
     <string name="delete_forever_message">このノートは完全に削除され、復元できません。</string>
     <string name="delete_forever">完全に削除</string>
     <string name="cancel">キャンセル</string>
 
     <string name="move_to_trash">ゴミ箱へ移動</string>
-    <string name="move_to_trash_title">ゴミ箱へ移動しますか?</string>
-    <string name="move_to_trash_message">\"%1$s\" をゴミ箱へ移動しますか? あとでゴミ箱から復元できます。</string>
-    <string name="move_to_trash_editor_message">このノートをゴミ箱へ移動しますか? あとでゴミ箱から復元できます。</string>
+    <string name="move_to_trash_title">ゴミ箱へ移動しますか？</string>
+    <string name="move_to_trash_message">\"%1$s\" をゴミ箱へ移動しますか？あとでゴミ箱から復元できます。</string>
+    <string name="move_to_trash_editor_message">このノートをゴミ箱へ移動しますか？あとでゴミ箱から復元できます。</string>
 
     <string name="settings_appearance">外観</string>
     <string name="theme_label">テーマ</string>
@@ -165,7 +165,7 @@
     <string name="line_width_comfortable">標準</string>
     <string name="line_width_wide">広め</string>
     <string name="settings_privacy">プライバシー</string>
-    <string name="privacy_no_tracking">アカウント・分析・広告・リモート設定・独自クラッシュ報告 SDK は一切ありません。</string>
+    <string name="privacy_no_tracking">アカウント・アナリティクス・広告・リモート設定・独自クラッシュ報告 SDK は一切ありません。</string>
     <string name="privacy_no_internet">MVP では INTERNET 権限を宣言していません。</string>
     <string name="privacy_local_first">ノートはユーザーが明示的に書き出し / 共有しない限り端末外へ出ません。</string>
     <string name="settings_data">データ</string>
@@ -198,7 +198,7 @@
     <string name="sync_done_format">同期完了 — %1$d 件更新、%2$d 件新規、%3$d 件変更なし。</string>
     <string name="sync_done_with_conflicts_format">同期完了 — %1$d 件更新、%2$d 件新規、%3$d 件は重複として保持 (競合)、%4$d 件変更なし。</string>
     <string name="sync_stopped">同期を停止しました。</string>
-    <string name="screenshot_protection">スクリーンショットと履歴のプレビューを禁止</string>
+    <string name="screenshot_protection">スクリーンショットと最近使ったアプリのプレビューを禁止</string>
     <string name="screenshot_protection_description">スクリーンショットや最近使ったアプリ画面でノート内容を非表示にします。変更を反映するにはエディタを開き直してください。</string>
     <string name="settings_app">アプリ</string>
     <string name="version_format">バージョン %1$s</string>
@@ -251,7 +251,7 @@
     <string name="locked_passcode_label">パスコード</string>
     <string name="locked_unlock_button">ロック解除</string>
     <string name="locked_wrong_passcode">パスコードが正しくありません。</string>
-    <string name="locked_too_many_attempts">試行回数が多すぎます。%1$s後にもう一度お試しください。</string>
+    <string name="locked_too_many_attempts">試行回数が多すぎます。%1$s 後にもう一度お試しください。</string>
     <string name="wikilink_target_locked">このノートはロック済みノートにあります。</string>
     <string name="locked_no_passcode_title">パスコード未設定</string>
     <string name="locked_no_passcode_hint">ロックされたノートを保護するには、設定でパスコードを設定してください。</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -151,7 +151,7 @@
     <string name="move_to_trash_message">\"%1$s\" 노트를 휴지통으로 옮길까요? 나중에 다시 꺼낼 수 있습니다.</string>
     <string name="move_to_trash_editor_message">이 노트를 휴지통으로 옮길까요? 나중에 다시 꺼낼 수 있습니다.</string>
 
-    <string name="settings_appearance">테마</string>
+    <string name="settings_appearance">외관</string>
     <string name="theme_label">테마</string>
     <string name="theme_markleaf_green">Markleaf 그린</string>
     <string name="theme_material_you">Material You</string>
@@ -219,7 +219,7 @@
 
     <!-- Onboarding -->
     <string name="onboarding_title_welcome">Markleaf에 오신 것을 환영합니다</string>
-    <string name="onboarding_body_welcome">조용하고 로컬 우선인 안드로이드 마크다운 노트 앱입니다. 사용자가 직접 공유하거나 내보내지 않는 한 텍스트는 이 기기에만 머뭅니다.</string>
+    <string name="onboarding_body_welcome">조용하고 로컬 우선인 Android Markdown 노트 앱입니다. 사용자가 직접 공유하거나 내보내지 않는 한 텍스트는 이 기기에만 머뭅니다.</string>
     <string name="onboarding_title_markdown">Markdown으로 쓰세요</string>
     <string name="onboarding_body_markdown">**굵게**, _기울임_, # 제목, 목록, 코드, 인용을 자유롭게 사용하세요. 상단의 미리보기를 탭하면 언제든 렌더링된 화면을 볼 수 있습니다.</string>
     <string name="onboarding_title_tags">#태그로 정리하세요</string>
@@ -309,7 +309,7 @@
 
     <!-- Sync & Conflict Center -->
     <string name="sync_center_title">동기화 센터</string>
-    <string name="conflict_center_title">충돌 보관함</string>
+    <string name="conflict_center_title">충돌 센터</string>
     <string name="conflict_center_desc">여러 기기에서 동시에 수정되어 생성된 충돌 사본 목록입니다. 사본을 탭하여 비교/편집하거나, 불필요한 사본을 삭제하세요.</string>
     <string name="conflict_center_empty">감지된 충돌이 없습니다</string>
     <string name="conflict_center_empty_desc">모든 미러링 노트가 완벽히 동기화되어 있습니다.</string>


### PR DESCRIPTION
Closes #161. Section 3 (terminology and style drift) was the last open part — Section 1 landed in #164, Section 2 across #160 and #165.

## What these are

Consistency defects rather than mistranslations: one concept named two ways inside a single screen, or a convention followed everywhere except once. 24 strings across five locales.

### ko

| Key | Was | Now | Why |
|---|---|---|---|
| `settings_appearance` | 테마 | 외관 | The section header was the same word as the theme row sitting inside it. en `Appearance`, ja `外観`. |
| `conflict_center_title` | 충돌 보관함 | 충돌 센터 | `보관함` already means Archive, and `sync_center_title` uses `센터`. The other four locales pair Sync/Conflict Center consistently. |
| `onboarding_body_welcome` | 안드로이드 마크다운 | Android Markdown | The other nine occurrences in the file use Latin. |

The issue also listed `잠금 해제` as shared by three actions. That is already resolved — `remove_from_locked` became `잠금에서 제거` in #160, leaving `locked_unlock_button` as the only string with that exact value. Nothing to do.

### fr

| Key | Change |
|---|---|
| `privacy_no_tracking` | Repeat the determiner (`aucune publicité`, not `aucun … publicité`), and use `analyse` rather than `outil d'analyse` so the privacy screen names analytics one way. Matches the shape `onboarding_body_local` already had. |
| `onboarding_body_local` | `aucun outil d'analyse` → `aucune analyse`, same reason. |
| `biometric_lock_unavailable` | `ou un visage` → `ou la reconnaissance faciale`, matching its sibling string. |
| `relative_days_ago` | Capitalised, beside `Aujourd'hui` / `Hier` in the same slot. |

### de

| Key | Change |
|---|---|
| `unpin` | `Lösen` → `Anheften aufheben`. `Lösen` shares no stem with `Anheften` and reads as "solve". `unarchive` and `remove_from_locked` both keep the noun (`Aus Archiv holen`, `Aus Gesperrt entfernen`). |
| `move_to_locked` | `Zu Gesperrt` → `Nach Gesperrt`, matching the two strings that describe the same action. |
| `privacy_no_internet` | `angefordert` (requested) → `deklariert`. The manifest declares, and `privacy_verify_no_internet` already said so. |
| `privacy_no_tracking_title` | `Null Tracking` → `Kein Tracking`. Every other locale translates the phrase rather than keeping the loanword. |
| `screenshot_protection_description`, `onboarding_body_tags` | `im …-Bildschirm` → `auf dem …-Bildschirm`. |
| `relative_days_ago` | Capitalised, as fr. |

### ja

| Key | Change |
|---|---|
| `delete_forever_title`, `move_to_trash_title`, `move_to_trash_message`, `move_to_trash_editor_message` | Half-width `?` → full-width `？`, which two other strings already used. The space that followed the half-width form goes with it, since the full-width character carries its own. |
| `privacy_no_tracking` | `分析` → `アナリティクス`, matching three siblings. |
| `screenshot_protection` | `履歴` → `最近使ったアプリ`, matching its own description. |
| `locked_too_many_attempts` | Space between placeholder and unit; it rendered `0:45後に`. |

### es

| Key | Change |
|---|---|
| `onboarding_body_markdown` | `títulos` → `encabezados`. `heading` and every `quick_insert_heading_*` say Encabezado, and `título` means title elsewhere in the file. |
| `onboarding_body_local` | `multi-dispositivo` → `entre dispositivos`, matching `sync_title`. |
| `sync_pick_folder` | Restores the sync qualifier. Without it, "Elegir carpeta" and "Cambiar carpeta" read as the same scope; the other five locales keep it. |

## Gates that could have broken, and did not

- **`ResourceParityTest`** — no keys added, removed, or renamed. Values only.
- **`UntranslatedStringTest`** — none of the 24 keys is allowlisted. `settings_markdown` and `theme_material_you` are, and both sit adjacent to this work; both left alone. No edit lands a locale value on its English string either, which would trip the check from the other direction.
- **Roborazzi** — three snapshots render in `ko-rKR`. None of the touched keys appears in them, so no golden needs re-recording on the Linux runner.

## Verification

- `:app:testDebugUnitTest` — BUILD SUCCESSFUL
- `:app:lintRelease` — 0 errors, 55 warnings, the same count as before

Closes #161.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
