### PR TITLE
ci: make the release job wait for the build gate

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -180,6 +180,11 @@ jobs:
 
   release:
     if: startsWith(github.ref, 'refs/tags/v')
+    # 태그 push 에서도 build 가 돌지만, needs 가 없으면 둘이 병렬로 달려서 게이트가
+    # 빨개져도 릴리스가 그대로 발행된다. release 는 자체적으로 test 만 재실행하므로
+    # lintRelease·verifyRoborazziDebug·버전 표기 검사는 아무도 확인하지 않은 채
+    # 지나간다. 릴리스가 몇 분 늦어지는 대신 게이트를 실제 게이트로 만든다 (#184).
+    needs: build
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
Closes the first candidate in #184.

## The problem

On a tag push, `build` and `release` started at the same time. Nothing connected them, so:

- `release` re-ran `./gradlew test` and nothing else from the gate
- `lintRelease`, `verifyRoborazziDebug`, and the two release checks from #178 ran only in `build`, whose result no one waited for
- a tagged commit that failed the gate published anyway

v2.26.2 shipped exactly that way — the tag workflow and the main workflow ran as independent graphs, neither waiting for the other.

## The change

One line: `needs: build` on the `release` job.

GitHub Actions treats a job with `needs` and a plain `if` as requiring `success()` on its dependencies, so a red gate now **skips** `release` rather than racing it. The cost is the gate's wall-clock added to every release, roughly six minutes.

## Job graph after the change

| job | needs | continue-on-error | if |
|---|---|---|---|
| `build` | — | false | — |
| `launch-smoke` | `build` | **true** | — |
| `record-roborazzi` | — | false | dispatch only |
| `release` | **`build`** | false | tag only |

`launch-smoke` also depends on `build`, but `release` depends on `build` rather than on `launch-smoke`, so emulator flakiness still cannot block a release. That was the reason it was marked `continue-on-error` in the first place, and this preserves it.

## What is deliberately not changed

`release` keeps its own `./gradlew test`. With `needs: build` that run is redundant — `build` already ran the same task on the same commit. Removing it would change what the release job verifies independently of the gate, which is a different decision from wiring the dependency, so it is left alone.

## Verification

Parsed the workflow and asserted the graph: `release` needs `build`, the tag condition is intact, `launch-smoke` is still `continue-on-error`, and `build` still carries all six gate steps (version strings, release notes, debug APK, tests, Roborazzi, release lint).

**The dependency itself only exercises on a tag push**, so this PR's own CI cannot prove it — `release` is skipped here because the ref is a branch. It stays unproven until the next release tag.

Refs #184.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
