### PR TITLE
fix(landing): stop multilingual layouts from overflowing

### DIFF
--- a/docs/index.de.html
+++ b/docs/index.de.html
@@ -85,7 +85,7 @@
             <div class="container hero-grid">
                 <div class="hero-copy-block">
                     <p class="kicker">Android · Markdown · Local-first</p>
-                    <h1 id="hero-title">Notizen auf deinem Gerät.<br><span class="no-break">Gedanken in Markdown.</span></h1>
+                    <h1 id="hero-title">Notizen auf deinem Gerät.<br><span>Gedanken in Markdown.</span></h1>
                     <p class="hero-copy">Schreibe schnell ohne Konto oder Server, verknüpfe Ideen mit Tags und behalte alles als standardisierte <code>.md</code>-Dateien.</p>
                     <div class="hero-actions">
                         <a class="action action-primary" href="https://f-droid.org/packages/com.markleaf.notes/">Über F-Droid installieren</a>
@@ -139,7 +139,7 @@
                 <article class="story">
                     <div class="story-copy">
                         <p class="story-step">01 · Schreiben</p>
-                        <h3>Die Syntax wird lebendig, <span class="no-break">Werkzeuge erscheinen nur bei Bedarf.</span></h3>
+                        <h3>Die Syntax wird lebendig, Werkzeuge erscheinen nur bei Bedarf.</h3>
                         <p>Dein Markdown-Quelltext bleibt unangetastet, während Überschriften und Hervorhebungen schon beim Bearbeiten gut lesbar dargestellt werden. Eine kleine <code>Aa</code>-Schaltfläche, kontextbezogene Auswahlaktionen und der <code>/</code>-Befehl am Zeilenanfang fügen Formatierung ein, ohne den Bildschirm zu überladen.</p>
                         <ul class="feature-points">
                             <li>Live-Markdown mit CommonMark/GFM-Vorschau</li>

--- a/docs/index.es.html
+++ b/docs/index.es.html
@@ -85,7 +85,7 @@
             <div class="container hero-grid">
                 <div class="hero-copy-block">
                     <p class="kicker">Android · Markdown · Local-first</p>
-                    <h1 id="hero-title">Notas en tu dispositivo.<br><span class="no-break">Pensamientos en Markdown.</span></h1>
+                    <h1 id="hero-title">Notas en tu dispositivo.<br><span>Pensamientos en Markdown.</span></h1>
                     <p class="hero-copy">Escribe rápido sin cuenta ni servidor, conecta ideas con etiquetas y conserva todo como archivos <code>.md</code> estándar.</p>
                     <div class="hero-actions">
                         <a class="action action-primary" href="https://f-droid.org/packages/com.markleaf.notes/">Instalar en F-Droid</a>
@@ -139,7 +139,7 @@
                 <article class="story">
                     <div class="story-copy">
                         <p class="story-step">01 · Escribir</p>
-                        <h3>La sintaxis cobra vida, <span class="no-break">y las herramientas aparecen</span> solo cuando se necesitan.</h3>
+                        <h3>La sintaxis cobra vida, y las herramientas aparecen solo cuando se necesitan.</h3>
                         <p>Tu Markdown original permanece intacto mientras los encabezados y el énfasis se muestran con claridad a medida que editas. Un pequeño botón <code>Aa</code>, acciones contextuales de selección y el comando <code>/</code> al inicio de una línea añaden formato sin saturar la pantalla.</p>
                         <ul class="feature-points">
                             <li>Live Markdown con vista previa CommonMark/GFM</li>

--- a/docs/index.fr.html
+++ b/docs/index.fr.html
@@ -85,7 +85,7 @@
             <div class="container hero-grid">
                 <div class="hero-copy-block">
                     <p class="kicker">Android · Markdown · Local-first</p>
-                    <h1 id="hero-title">Notes sur votre appareil.<br><span class="no-break">Pensées en Markdown.</span></h1>
+                    <h1 id="hero-title">Notes sur votre appareil.<br><span>Pensées en Markdown.</span></h1>
                     <p class="hero-copy">Écrivez vite sans compte ni serveur, reliez vos idées avec des étiquettes, et conservez tout au format de fichiers <code>.md</code> standard.</p>
                     <div class="hero-actions">
                         <a class="action action-primary" href="https://f-droid.org/packages/com.markleaf.notes/">Installer sur F-Droid</a>
@@ -139,7 +139,7 @@
                 <article class="story">
                     <div class="story-copy">
                         <p class="story-step">01 · Écrire</p>
-                        <h3>La syntaxe prend vie, <span class="no-break">et les outils n'apparaissent</span> qu'en cas de besoin.</h3>
+                        <h3>La syntaxe prend vie, et les outils n'apparaissent qu'en cas de besoin.</h3>
                         <p>Votre source Markdown reste intacte pendant que les titres et les mises en valeur s'affichent lisiblement au fil de l'édition. Un petit bouton <code>Aa</code>, des actions contextuelles de sélection et la commande <code>/</code> en début de ligne ajoutent la mise en forme sans encombrer l'écran.</p>
                         <ul class="feature-points">
                             <li>Live Markdown avec aperçu CommonMark/GFM</li>

--- a/docs/index.html
+++ b/docs/index.html
@@ -85,7 +85,7 @@
             <div class="container hero-grid">
                 <div class="hero-copy-block">
                     <p class="kicker">Android · Markdown · Local-first</p>
-                    <h1 id="hero-title">Notes on your device.<br><span class="no-break">Thoughts in Markdown.</span></h1>
+                    <h1 id="hero-title">Notes on your device.<br><span>Thoughts in Markdown.</span></h1>
                     <p class="hero-copy">Write fast with no account or server, connect ideas with tags, and keep everything as standard <code>.md</code> files.</p>
                     <div class="hero-actions">
                         <a class="action action-primary" href="https://f-droid.org/packages/com.markleaf.notes/">Install on F-Droid</a>
@@ -139,7 +139,7 @@
                 <article class="story">
                     <div class="story-copy">
                         <p class="story-step">01 · Write</p>
-                        <h3>Syntax comes alive, <span class="no-break">and tools appear only</span> when needed.</h3>
+                        <h3>Syntax comes alive, and tools appear only when needed.</h3>
                         <p>Your Markdown source stays intact while headings and emphasis render legibly as you edit. A small <code>Aa</code> button, selection-context actions, and the <code>/</code> command at the start of a line add formatting without cluttering the screen.</p>
                         <ul class="feature-points">
                             <li>Live Markdown with CommonMark/GFM preview</li>

--- a/docs/index.ja.html
+++ b/docs/index.ja.html
@@ -85,7 +85,7 @@
             <div class="container hero-grid">
                 <div class="hero-copy-block">
                     <p class="kicker">Android · Markdown · Local-first</p>
-                    <h1 id="hero-title">ノートは端末に。<br><span class="no-break">思考は Markdown で。</span></h1>
+                    <h1 id="hero-title">ノートは端末に。<br><span>思考は Markdown で。</span></h1>
                     <p class="hero-copy">アカウントもサーバーもなしにすばやく書き、タグでアイデアをつなぎ、すべてを標準の <code>.md</code> ファイルとして手元に保管できます。</p>
                     <div class="hero-actions">
                         <a class="action action-primary" href="https://f-droid.org/packages/com.markleaf.notes/">F-Droid でインストール</a>
@@ -139,7 +139,7 @@
                 <article class="story">
                     <div class="story-copy">
                         <p class="story-step">01 · 書く</p>
-                        <h3>構文は生きたまま、<span class="no-break">ツールは必要なときだけ</span>現れる。</h3>
+                        <h3>構文は生きたまま、ツールは必要なときだけ現れる。</h3>
                         <p>Markdown の原文はそのままに、見出しや強調は編集中も読みやすく表示されます。小さな <code>Aa</code> ボタン、選択範囲に応じたアクション、行頭の <code>/</code> コマンドで、画面を散らかすことなく書式を追加できます。</p>
                         <ul class="feature-points">
                             <li>Live Markdown と CommonMark/GFM プレビュー</li>

--- a/docs/index.ko.html
+++ b/docs/index.ko.html
@@ -85,7 +85,7 @@
             <div class="container hero-grid">
                 <div class="hero-copy-block">
                     <p class="kicker">Android · Markdown · Local-first</p>
-                    <h1 id="hero-title">메모는 기기에.<br><span class="no-break">생각은 Markdown으로.</span></h1>
+                    <h1 id="hero-title">메모는 기기에.<br><span>생각은 Markdown으로.</span></h1>
                     <p class="hero-copy">계정도 서버도 없이 빠르게 쓰고, 태그로 연결하고, 표준 <code>.md</code> 파일로 직접 보관하세요.</p>
                     <div class="hero-actions">
                         <a class="action action-primary" href="https://f-droid.org/packages/com.markleaf.notes/">F-Droid에서 설치</a>
@@ -139,7 +139,7 @@
                 <article class="story">
                     <div class="story-copy">
                         <p class="story-step">01 · 쓰기</p>
-                        <h3>문법은 살아나고, <span class="no-break">도구는 필요할 때만</span> 나타납니다.</h3>
+                        <h3>문법은 살아나고, 도구는 필요할 때만 나타납니다.</h3>
                         <p>Markdown 원문은 그대로 유지하면서 헤딩과 강조가 편집 중에도 읽기 좋게 표현됩니다. 작은 <code>Aa</code> 버튼과 선택 문맥 액션, 줄 시작의 <code>/</code> 명령으로 화면을 어지럽히지 않고 서식을 넣습니다.</p>
                         <ul class="feature-points">
                             <li>Live Markdown과 CommonMark/GFM 미리보기</li>

--- a/docs/landing.css
+++ b/docs/landing.css
@@ -98,8 +98,8 @@ h2,
 h3 {
     font-family: var(--font-display);
     letter-spacing: -0.035em;
+    overflow-wrap: break-word;
     text-wrap: balance;
-    word-break: keep-all;
 }
 
 h1 {
@@ -111,10 +111,6 @@ h1 {
 
 h1 span {
     color: var(--color-primary);
-}
-
-.no-break {
-    white-space: nowrap;
 }
 
 h2 {
@@ -133,7 +129,15 @@ h3 {
 
 p,
 li {
+    overflow-wrap: break-word;
     text-wrap: pretty;
+}
+
+/* Korean puts spaces between words, so keep-all only suppresses breaks inside a
+   word and still wraps at those spaces. Japanese and Chinese have no such
+   spaces — keep-all there makes a whole sentence one unbreakable run, so they
+   keep the default line-breaking rules. */
+:lang(ko) :is(h1, h2, h3, p, li) {
     word-break: keep-all;
 }
 
@@ -179,16 +183,19 @@ li {
 .site-nav {
     align-items: center;
     display: flex;
+    flex-wrap: wrap;
     justify-content: space-between;
     margin-inline: auto;
     max-width: var(--container);
     padding: var(--space-3) var(--space-6);
+    row-gap: var(--space-2);
 }
 
 .brand {
     align-items: center;
     color: var(--color-primary-ink);
     display: inline-flex;
+    flex-shrink: 0;
     font-family: var(--font-display);
     font-size: 1.25rem;
     font-weight: 750;
@@ -210,6 +217,7 @@ li {
 .nav-links {
     align-items: center;
     display: flex;
+    flex-wrap: wrap;
     gap: var(--space-2);
     list-style: none;
     padding: 0;
@@ -237,12 +245,14 @@ li {
 .nav-cluster {
     align-items: center;
     display: flex;
+    flex-wrap: wrap;
     gap: var(--space-4);
 }
 
 .lang-switch {
     align-items: center;
     display: flex;
+    flex-wrap: wrap;
     gap: var(--space-1);
 }
 

--- a/docs/style.css
+++ b/docs/style.css
@@ -225,6 +225,7 @@ h1,
 h2,
 h3 {
     letter-spacing: 0;
+    overflow-wrap: break-word;
 }
 
 h2 {


### PR DESCRIPTION
Several language versions of the landing page overflowed their containers. Measuring the pages in a browser turned up three shared root causes plus one on the privacy pages — none of them language-specific bugs, all of them layout rules that only held for the copy they were written against.

## What was broken

Measured with a real browser across **6 languages × 9 viewport widths**:

| Root cause | Worst measurement |
|---|---|
| `word-break: keep-all` applied to every language | ja: **207px** horizontal page scroll at 375px, **262px** at 320px |
| `.no-break { white-space: nowrap }` | hero h1 past its column — es **211px**, de **95px**, en **80px** (all 6 affected) |
| Header nav could not wrap | fr brand squeezed **36px** at 900px; fr/de nav links outside the viewport at 320–375px |
| Long German compound in privacy headings | `privacy.de.html` h1 over by **77px** at 320px |

### 1. `keep-all` was disabling Japanese line breaking entirely

`keep-all` forbids breaks between CJK characters. Korean puts spaces between words, so it still wraps at those spaces — that is the rule's intended use. Japanese and Chinese have no such spaces, so an entire sentence became one unbreakable run. Now scoped to `:lang(ko)`; every other language falls back to normal line-breaking.

### 2. `.no-break` overflowed in **all six** languages, not just a few

The `<br>` already starts that phrase on its own line, and `h1/h2/h3` already carry `text-wrap: balance`, so the `nowrap` contributed nothing but overflow risk. Removed.

The German `h3` was the extreme case — it wrapped the *entire* remaining clause (35 chars at up to 2.5rem) where the other languages wrapped only a short fragment.

The `<span>` inside the hero `h1` is kept deliberately: `h1 span { color: var(--color-primary) }` gives the second line its accent green (`#2E7D32` against the h1's `#00390A`). Only the class is dropped, so the two-tone title survives.

### 3. Header could not wrap

`flex-wrap` on the nav rows and `flex-shrink: 0` on the brand, so long labels (`Fonctionnalités`, `Confidentialité`, `Datenschutz`) wrap instead of crushing the logo or leaving the viewport.

## Verification

Re-ran the same measurement harness over **12 pages × 9 widths = 108 combinations**:

- Element overflow: **0** across all 108 combinations
- Horizontal page scroll: **0** at a true 320px viewport in all six languages
- `word-break` computed value: `keep-all` for ko, `normal` for en/ja/de/es/fr
- Wrapping quality re-checked at 390px — ja h3 2 lines, ko h1 3 lines (still breaking at word boundaries), de h3 3 lines, es h1 4 lines, every line ending inside its box
- Hero accent color re-measured in all 6: h1 `rgb(0,57,10)`, span `rgb(46,125,50)`

No CHANGELOG entry: this is website-only with no app impact, matching how previous `docs:`-scoped landing changes were handled.

## Follow-ups (not included)

- **#187 — guard this in CI.** Nothing currently verifies that the rendered pages fit their containers, which is why these three bugs survived since the pages were written. Filed with the measurement approach and two implementation gotchas (skip deliberate scrollers, correct for scrollbar width).
- `:lang(ja) :is(h1,h2,h3) { word-break: auto-phrase }` would break Japanese headings at phrase boundaries rather than anywhere. Chrome 119+ only, degrades cleanly — left out as it is a readability improvement, not part of this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

