### PR TITLE
feat: add "open notes in preview" lock (#200)

### DIFF
--- a/app/src/main/java/com/markleaf/notes/data/settings/AppSettings.kt
+++ b/app/src/main/java/com/markleaf/notes/data/settings/AppSettings.kt
@@ -36,8 +36,9 @@ data class AppSettings(
     /** Open existing notes in preview mode instead of the edit surface, so
      *  browsing note to note keeps showing the rendered view without toggling
      *  the eye icon each time. Off by default (notes open in edit). Toggled from
-     *  Settings or by long-pressing the editor's view-toggle icon; a brand-new
-     *  note still opens in edit regardless (#200). */
+     *  Settings or by long-pressing the editor's view-toggle icon; a note with
+     *  no content yet (a just-created note) still opens in edit so you can start
+     *  typing (#200). */
     val openNotesInPreview: Boolean = false
 )
 

--- a/app/src/main/java/com/markleaf/notes/data/settings/AppSettings.kt
+++ b/app/src/main/java/com/markleaf/notes/data/settings/AppSettings.kt
@@ -32,7 +32,13 @@ data class AppSettings(
     /** Id of the note most recently opened in the editor. Only consulted when
      *  [reopenLastNote] is on; stale ids (deleted/trashed notes) are ignored at
      *  launch rather than eagerly cleared. */
-    val lastOpenedNoteId: String? = null
+    val lastOpenedNoteId: String? = null,
+    /** Open existing notes in preview mode instead of the edit surface, so
+     *  browsing note to note keeps showing the rendered view without toggling
+     *  the eye icon each time. Off by default (notes open in edit). Toggled from
+     *  Settings or by long-pressing the editor's view-toggle icon; a brand-new
+     *  note still opens in edit regardless (#200). */
+    val openNotesInPreview: Boolean = false
 )
 
 /** Notes-list sort orders offered by the top-bar sort menu (#191). */

--- a/app/src/main/java/com/markleaf/notes/data/settings/AppSettingsRepository.kt
+++ b/app/src/main/java/com/markleaf/notes/data/settings/AppSettingsRepository.kt
@@ -71,7 +71,8 @@ class AppSettingsRepository internal constructor(
                 ?.let { value -> enumValueOrDefault(value, NotesSortMode.UPDATED_DESC) }
                 ?: NotesSortMode.UPDATED_DESC,
             searchTitlesOnly = preferences[SEARCH_TITLES_ONLY] ?: false,
-            lastOpenedNoteId = preferences[LAST_OPENED_NOTE_ID]
+            lastOpenedNoteId = preferences[LAST_OPENED_NOTE_ID],
+            openNotesInPreview = preferences[OPEN_NOTES_IN_PREVIEW] ?: false
         )
     }
 
@@ -256,6 +257,12 @@ class AppSettingsRepository internal constructor(
         }
     }
 
+    suspend fun setOpenNotesInPreview(enabled: Boolean) {
+        persist { preferences ->
+            preferences[OPEN_NOTES_IN_PREVIEW] = enabled
+        }
+    }
+
     /**
      * Every write funnels through here inside [NonCancellable]. Settings writes
      * are typically launched from a screen's `rememberCoroutineScope`, and a
@@ -295,5 +302,6 @@ class AppSettingsRepository internal constructor(
         val NOTES_SORT_MODE = stringPreferencesKey("notes_sort_mode")
         val SEARCH_TITLES_ONLY = booleanPreferencesKey("search_titles_only")
         val LAST_OPENED_NOTE_ID = stringPreferencesKey("last_opened_note_id")
+        val OPEN_NOTES_IN_PREVIEW = booleanPreferencesKey("open_notes_in_preview")
     }
 }

--- a/app/src/main/java/com/markleaf/notes/feature/editor/EditorScreen.kt
+++ b/app/src/main/java/com/markleaf/notes/feature/editor/EditorScreen.kt
@@ -101,6 +101,7 @@ import com.markleaf.notes.util.HapticFeedback
 import com.markleaf.notes.util.ExportPdf
 import com.markleaf.notes.util.ShareNoteUtil
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -302,9 +303,15 @@ fun EditorScreen(
         if (noteId == null) {
             isLoaded = true
         } else {
+            // Read the persisted setting directly (not the collectAsState
+            // snapshot, which starts on the default before DataStore emits) so
+            // an existing note honours "open notes in preview" on its very first
+            // frame instead of flashing edit (#200). New notes stay in edit.
+            val openInPreview = settingsRepository.settings.first().openNotesInPreview
             val loadedNote = repo.getNote(noteId)
             val content = loadedNote?.contentMarkdown.orEmpty()
             editorState = TextFieldValue(content)
+            isPreviewMode = openInPreview
             shouldRequestEditorFocus = content.isEmpty()
             isLoaded = true
             // Remember this note as the launch target for the opt-in
@@ -413,6 +420,24 @@ fun EditorScreen(
                     val returningToEdit = isPreviewMode
                     isPreviewMode = !isPreviewMode
                     if (returningToEdit) shouldRequestEditorFocus = true
+                },
+                isViewModeLocked = appSettings.openNotesInPreview,
+                onToggleLock = {
+                    // Long-press flips the persistent lock and mirrors it onto
+                    // this note straight away: locking jumps to preview and makes
+                    // it stick across notes; unlocking drops back to edit (#200).
+                    val nowLocked = !appSettings.openNotesInPreview
+                    coroutineScope.launch {
+                        settingsRepository.setOpenNotesInPreview(nowLocked)
+                    }
+                    isPreviewMode = nowLocked
+                    if (!nowLocked) shouldRequestEditorFocus = true
+                    HapticFeedback.light(context)
+                    Toast.makeText(
+                        context,
+                        if (nowLocked) R.string.view_mode_locked else R.string.view_mode_unlocked,
+                        Toast.LENGTH_SHORT
+                    ).show()
                 },
                 onExitFocusMode = { isFocusMode = false },
                 onOpenInfo = {

--- a/app/src/main/java/com/markleaf/notes/feature/editor/EditorScreen.kt
+++ b/app/src/main/java/com/markleaf/notes/feature/editor/EditorScreen.kt
@@ -311,7 +311,12 @@ fun EditorScreen(
             val loadedNote = repo.getNote(noteId)
             val content = loadedNote?.contentMarkdown.orEmpty()
             editorState = TextFieldValue(content)
-            isPreviewMode = openInPreview
+            // Only land in preview when there is something to preview. A
+            // brand-new note is created first and then opened with a real id
+            // (the FAB path in MarkleafNavHost), so `noteId != null` alone would
+            // drop an empty note into preview with no editor/IME — honour "new
+            // notes still open for editing" by gating on content (#200).
+            isPreviewMode = openInPreview && content.isNotEmpty()
             shouldRequestEditorFocus = content.isEmpty()
             isLoaded = true
             // Remember this note as the launch target for the opt-in

--- a/app/src/main/java/com/markleaf/notes/feature/editor/EditorTopAppBar.kt
+++ b/app/src/main/java/com/markleaf/notes/feature/editor/EditorTopAppBar.kt
@@ -1,5 +1,8 @@
 package com.markleaf.notes.feature.editor
 
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.waitForUpOrCancellation
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.material.icons.Icons
@@ -16,11 +19,25 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.PointerEventTimeoutCancellationException
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.onLongClick
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import com.markleaf.notes.R
+
+/** Tint applied to the view-toggle icon while "open notes in preview" is locked
+ *  on, signalling the sticky mode. A fixed amber that stays legible on both the
+ *  light and dark top-bar backgrounds — it's a status colour, not a theme
+ *  role, so it deliberately sits outside the colour scheme (#200). */
+private val ViewModeLockedTint = Color(0xFFF57C00)
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -37,7 +54,9 @@ internal fun EditorTopAppBar(
     onOpenMore: () -> Unit,
     onDismissMore: () -> Unit,
     moreMenuContent: @Composable ColumnScope.() -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    isViewModeLocked: Boolean = false,
+    onToggleLock: () -> Unit = {}
 ) {
     TopAppBar(
         title = {
@@ -63,13 +82,51 @@ internal fun EditorTopAppBar(
                     )
                 }
             } else {
-                IconButton(onClick = onTogglePreview) {
+                // IconButton exposes no long-press hook, so the persistent lock
+                // rides on a pointerInput watching the Initial pass: it fires the
+                // toggle once the press crosses the long-press threshold, then
+                // consumes the release so the IconButton's own Main-pass tap
+                // (onTogglePreview) never also fires. The matching a11y action is
+                // published via semantics.onLongClick. Locking recolours the icon
+                // amber to signal the sticky mode (#200).
+                val lockLabel = stringResource(R.string.lock_view_mode)
+                val currentOnToggleLock by rememberUpdatedState(onToggleLock)
+                IconButton(
+                    onClick = onTogglePreview,
+                    modifier = Modifier
+                        .semantics {
+                            onLongClick(label = lockLabel) {
+                                currentOnToggleLock()
+                                true
+                            }
+                        }
+                        .pointerInput(Unit) {
+                            awaitEachGesture {
+                                awaitFirstDown(
+                                    requireUnconsumed = false,
+                                    pass = PointerEventPass.Initial
+                                )
+                                try {
+                                    withTimeout(viewConfiguration.longPressTimeoutMillis) {
+                                        waitForUpOrCancellation(PointerEventPass.Initial)
+                                    }
+                                } catch (_: PointerEventTimeoutCancellationException) {
+                                    currentOnToggleLock()
+                                    waitForUpOrCancellation(PointerEventPass.Initial)?.consume()
+                                }
+                            }
+                        }
+                ) {
                     Icon(
                         imageVector = if (isPreviewMode) Icons.Default.Edit else Icons.Default.Visibility,
                         contentDescription = stringResource(
                             if (isPreviewMode) R.string.edit else R.string.preview
                         ),
-                        tint = MaterialTheme.colorScheme.primary
+                        tint = if (isViewModeLocked) {
+                            ViewModeLockedTint
+                        } else {
+                            MaterialTheme.colorScheme.primary
+                        }
                     )
                 }
                 IconButton(onClick = onOpenInfo) {

--- a/app/src/main/java/com/markleaf/notes/feature/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/markleaf/notes/feature/settings/SettingsScreen.kt
@@ -302,6 +302,18 @@ fun SettingsScreen(
                                 }
                             }
                         )
+                        Spacer(Modifier.height(12.dp))
+                        SettingsSwitchRow(
+                            title = stringResource(R.string.open_notes_in_preview),
+                            description = stringResource(R.string.open_notes_in_preview_description),
+                            checked = appSettings.openNotesInPreview,
+                            onCheckedChange = { checked ->
+                                HapticFeedback.light(context)
+                                scope.launch {
+                                    settingsRepository.setOpenNotesInPreview(checked)
+                                }
+                            }
+                        )
                     }
 
                     SettingsSection(title = stringResource(R.string.settings_privacy)) {

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -179,6 +179,11 @@
     <string name="show_note_previews_description">Zeigt unter jedem Titel einen Ausschnitt und die Bearbeitungszeit. Ausschalten, um mehr Notizen auf dem Bildschirm zu sehen.</string>
     <string name="reopen_last_note">Letzte Notiz beim Start öffnen</string>
     <string name="reopen_last_note_description">Beim Start direkt in der zuletzt bearbeiteten Notiz beginnen statt in der Notizenliste.</string>
+    <string name="open_notes_in_preview">Notizen in der Vorschau öffnen</string>
+    <string name="open_notes_in_preview_description">Beim Öffnen einer Notiz die gerenderte Vorschau statt der Bearbeitungsansicht anzeigen. Neue Notizen öffnen weiterhin zum Bearbeiten. Tipp: Vorschau-/Bearbeiten-Symbol in einer Notiz lange drücken, um dies umzuschalten.</string>
+    <string name="view_mode_locked">Notizen öffnen jetzt in der Vorschau</string>
+    <string name="view_mode_unlocked">Notizen öffnen jetzt zum Bearbeiten</string>
+    <string name="lock_view_mode">Ansichtsmodus sperren</string>
     <string name="settings_privacy">Datenschutz</string>
     <string name="privacy_no_tracking">Kein Konto, keine Analytik, keine Werbung, keine Remote-Konfiguration und kein proprietäres Crash-Reporting-SDK.</string>
     <string name="privacy_no_internet">Für das MVP wird die INTERNET-Berechtigung nicht deklariert.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -179,6 +179,11 @@
     <string name="show_note_previews_description">Muestra un fragmento y la hora de edición bajo cada título. Desactívalo para ver más notas en pantalla.</string>
     <string name="reopen_last_note">Reabrir la última nota al iniciar</string>
     <string name="reopen_last_note_description">Empieza en la nota que editaste por última vez en lugar de la lista de notas.</string>
+    <string name="open_notes_in_preview">Abrir notas en vista previa</string>
+    <string name="open_notes_in_preview_description">Muestra la vista previa renderizada al abrir una nota en lugar de la vista de edición. Las notas nuevas se abren para editar. Consejo: mantén pulsado el icono de vista previa/editar en una nota para cambiarlo.</string>
+    <string name="view_mode_locked">Las notas ahora se abren en vista previa</string>
+    <string name="view_mode_unlocked">Las notas ahora se abren en edición</string>
+    <string name="lock_view_mode">Bloquear modo de vista</string>
     <string name="settings_privacy">Privacidad</string>
     <string name="privacy_no_tracking">Sin cuenta, analíticas, anuncios, configuración remota ni SDK propietario de fallos.</string>
     <string name="privacy_no_internet">El MVP no declara permiso INTERNET.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -179,6 +179,11 @@
     <string name="show_note_previews_description">Affiche un extrait et l\'heure de modification sous chaque titre. Désactivez pour afficher plus de notes à l\'écran.</string>
     <string name="reopen_last_note">Rouvrir la dernière note au démarrage</string>
     <string name="reopen_last_note_description">Démarre dans la dernière note modifiée plutôt que dans la liste des notes.</string>
+    <string name="open_notes_in_preview">Ouvrir les notes en aperçu</string>
+    <string name="open_notes_in_preview_description">Afficher l\'aperçu rendu à l\'ouverture d\'une note au lieu de la vue d\'édition. Les nouvelles notes s\'ouvrent toujours en édition. Astuce : appui long sur l\'icône aperçu/modifier dans une note pour basculer.</string>
+    <string name="view_mode_locked">Les notes s\'ouvrent désormais en aperçu</string>
+    <string name="view_mode_unlocked">Les notes s\'ouvrent désormais en édition</string>
+    <string name="lock_view_mode">Verrouiller le mode d\'affichage</string>
     <string name="settings_privacy">Confidentialité</string>
     <string name="privacy_no_tracking">Aucun compte, aucune analyse, aucune publicité, aucune configuration à distance, aucun SDK propriétaire de rapport d\'erreurs.</string>
     <string name="privacy_no_internet">Aucune autorisation INTERNET n\'est déclarée pour la version MVP.</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -177,6 +177,11 @@
     <string name="show_note_previews_description">タイトルの下に本文の一部と編集時刻を表示します。オフにすると画面により多くのノートが収まります。</string>
     <string name="reopen_last_note">起動時に最後のノートを開く</string>
     <string name="reopen_last_note_description">起動時にノート一覧ではなく、最後に編集したノートから始めます。</string>
+    <string name="open_notes_in_preview">ノートをプレビューで開く</string>
+    <string name="open_notes_in_preview_description">ノートを開いたときに編集画面ではなくプレビューを表示します。新しいノートは編集で開きます。ノート内でプレビュー/編集アイコンを長押しすると切り替えられます。</string>
+    <string name="view_mode_locked">ノートはプレビューで開きます</string>
+    <string name="view_mode_unlocked">ノートは編集で開きます</string>
+    <string name="lock_view_mode">表示モードをロック</string>
     <string name="settings_privacy">プライバシー</string>
     <string name="privacy_no_tracking">アカウント・アナリティクス・広告・リモート設定・独自クラッシュ報告 SDK は一切ありません。</string>
     <string name="privacy_no_internet">MVP では INTERNET 権限を宣言していません。</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -177,6 +177,11 @@
     <string name="show_note_previews_description">제목 아래에 본문 일부와 수정 시각을 표시합니다. 끄면 화면에 더 많은 노트가 보입니다.</string>
     <string name="reopen_last_note">시작 시 마지막 노트 열기</string>
     <string name="reopen_last_note_description">앱을 열 때 노트 목록 대신 마지막으로 편집한 노트에서 시작합니다.</string>
+    <string name="open_notes_in_preview">노트를 미리보기로 열기</string>
+    <string name="open_notes_in_preview_description">노트를 열 때 편집 화면 대신 미리보기를 표시합니다. 새 노트는 편집으로 열립니다. 노트에서 미리보기/편집 아이콘을 길게 누르면 이 설정을 바꿀 수 있습니다.</string>
+    <string name="view_mode_locked">이제 노트가 미리보기로 열립니다</string>
+    <string name="view_mode_unlocked">이제 노트가 편집으로 열립니다</string>
+    <string name="lock_view_mode">보기 모드 잠금</string>
     <string name="settings_privacy">개인정보</string>
     <string name="privacy_no_tracking">계정, 분석, 광고, 원격 설정, 독점 크래시 리포팅 SDK가 없습니다.</string>
     <string name="privacy_no_internet">이 앱은 INTERNET 권한을 사용하지 않습니다.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -183,6 +183,11 @@
     <string name="show_note_previews_description">Show a snippet and edit time under each title. Turn off to fit more notes on screen.</string>
     <string name="reopen_last_note">Reopen last note on launch</string>
     <string name="reopen_last_note_description">Start in the note you last edited instead of the notes list.</string>
+    <string name="open_notes_in_preview">Open notes in preview</string>
+    <string name="open_notes_in_preview_description">Show a note\'s rendered preview when you open it instead of the edit view. New notes still open for editing. Tip: long-press the preview/edit icon in a note to toggle this.</string>
+    <string name="view_mode_locked">Notes now open in preview</string>
+    <string name="view_mode_unlocked">Notes now open in edit</string>
+    <string name="lock_view_mode">Lock view mode</string>
     <string name="settings_privacy">Privacy</string>
     <string name="privacy_no_tracking">No account, analytics, ads, remote config, or proprietary crash reporting SDK.</string>
     <string name="privacy_no_internet">No INTERNET permission is declared for the MVP.</string>

--- a/app/src/testDebug/java/com/markleaf/notes/feature/editor/EditorTopAppBarLockTest.kt
+++ b/app/src/testDebug/java/com/markleaf/notes/feature/editor/EditorTopAppBarLockTest.kt
@@ -1,0 +1,65 @@
+package com.markleaf.notes.feature.editor
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.longClick
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.markleaf.notes.ui.theme.MarkleafTheme
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * The view-toggle icon carries two gestures (#200): a tap flips this note's
+ * preview mode, a long-press flips the persistent lock. They must stay
+ * independent — a tap must never fire the lock, and vice versa.
+ */
+@RunWith(AndroidJUnit4::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(sdk = [33], qualifiers = "w360dp-h80dp-mdpi")
+class EditorTopAppBarLockTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun tapFlipsPreviewAndLongPressFlipsLockIndependently() {
+        var previewToggles = 0
+        var lockToggles = 0
+        composeRule.setContent {
+            MarkleafTheme(dynamicColor = false) {
+                EditorTopAppBar(
+                    title = "New Note",
+                    isPreviewMode = false,
+                    isFocusMode = false,
+                    showMore = true,
+                    moreExpanded = false,
+                    onBack = {},
+                    onTogglePreview = { previewToggles++ },
+                    onExitFocusMode = {},
+                    onOpenInfo = {},
+                    onOpenMore = {},
+                    onDismissMore = {},
+                    moreMenuContent = {},
+                    isViewModeLocked = false,
+                    onToggleLock = { lockToggles++ }
+                )
+            }
+        }
+
+        // While in edit mode the toggle offers "Preview".
+        val toggle = composeRule.onNodeWithContentDescription("Preview")
+
+        toggle.performClick()
+        assertEquals(1, previewToggles)
+        assertEquals(0, lockToggles)
+
+        toggle.performTouchInput { longClick() }
+        assertEquals(1, lockToggles)
+        assertEquals(1, previewToggles)
+    }
+}


### PR DESCRIPTION
Closes #200.

## What & why
Notes open in the edit surface by default, so browsing note to note in preview meant tapping the eye icon on every note (as reported by @Me-2u). This adds an opt-in **"Open notes in preview"** setting: existing notes open in the rendered preview and stay there while browsing; brand-new notes still open in edit.

## How it works
- **`AppSettings.openNotesInPreview`** — persisted via DataStore, default off.
- **Editor** reads the setting directly on note load (`settings.first()`) so an existing note honours it on the first frame instead of flashing edit.
- **Long-press the view-toggle icon** to flip the lock in-context: the icon turns **amber** while locked, with a toast + haptic. A plain `IconButton` has no long-press hook, so it rides on a `pointerInput` watching the **Initial pass** — it fires the lock once the press crosses the long-press threshold and consumes the release, so the tap (toggle *this* note) and the long-press (flip the *persistent* lock) stay independent. The matching a11y action is published via `semantics.onLongClick`.
- **Settings toggle** mirrors the same flag (Notes & search section).
- Strings added in all six locales; a Robolectric interaction test covers tap-vs-long-press independence.

## Design notes (intentional deviations from the issue)
- The issue asked to lock *either* mode; since edit is already the default open mode, "lock to edit" ≡ default-off, so the whole useful space is one boolean.
- Uses the platform-standard long-press (~0.5s) rather than a custom 2s hold, for discoverability and consistency with the rest of the app.

## Verification
Verified end-to-end on the `markleaf-phone-api36` emulator: default edit → long-press locks to amber preview → other notes open in preview → long-press unlocks → edit + keyboard focus, the setting survives an app restart, and the Settings toggle drives the same behaviour. CI is green: tests, `verifyRoborazziDebug`, release lint, and the R8 release build all pass.

## Roborazzi goldens — no update needed
Adding parameters to `EditorTopAppBar` shifts the `editor_top_appbar` snapshots by sub-pixel anti-aliasing **on Windows only** (a Compose-compiler quirk in local font rendering). A fresh Linux re-record on this branch produced goldens byte-identical to the committed set (48/48), and CI's `verifyRoborazziDebug` passes — so no golden change is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)