### PR TITLE
fix: lay out RTL note content right-to-left in editor and preview (#146)

### DIFF
--- a/app/src/main/java/com/markleaf/notes/ui/theme/Theme.kt
+++ b/app/src/main/java/com/markleaf/notes/ui/theme/Theme.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDirection
 import androidx.compose.ui.unit.sp
 import androidx.core.view.WindowCompat
 
@@ -132,6 +133,34 @@ val Typography = androidx.compose.material3.Typography(
         lineHeight = 16.sp,
         letterSpacing = 0.sp
     )
+).withContentTextDirection()
+
+/**
+ * Returns a copy of this type scale that lays each paragraph out based on its
+ * own content: a paragraph starting with a strong right-to-left character
+ * (Arabic, Hebrew, Persian, …) becomes right-to-left even while the app UI
+ * stays left-to-right, and Latin-first paragraphs are unchanged. Applied once
+ * to the whole scale so both the editor and the Markdown preview honour the
+ * direction of what you actually typed (#146). Left-to-right text renders
+ * identically, so existing snapshots are unaffected.
+ */
+private fun androidx.compose.material3.Typography.withContentTextDirection():
+    androidx.compose.material3.Typography = copy(
+    displayLarge = displayLarge.copy(textDirection = TextDirection.Content),
+    displayMedium = displayMedium.copy(textDirection = TextDirection.Content),
+    displaySmall = displaySmall.copy(textDirection = TextDirection.Content),
+    headlineLarge = headlineLarge.copy(textDirection = TextDirection.Content),
+    headlineMedium = headlineMedium.copy(textDirection = TextDirection.Content),
+    headlineSmall = headlineSmall.copy(textDirection = TextDirection.Content),
+    titleLarge = titleLarge.copy(textDirection = TextDirection.Content),
+    titleMedium = titleMedium.copy(textDirection = TextDirection.Content),
+    titleSmall = titleSmall.copy(textDirection = TextDirection.Content),
+    bodyLarge = bodyLarge.copy(textDirection = TextDirection.Content),
+    bodyMedium = bodyMedium.copy(textDirection = TextDirection.Content),
+    bodySmall = bodySmall.copy(textDirection = TextDirection.Content),
+    labelLarge = labelLarge.copy(textDirection = TextDirection.Content),
+    labelMedium = labelMedium.copy(textDirection = TextDirection.Content),
+    labelSmall = labelSmall.copy(textDirection = TextDirection.Content),
 )
 
 /**


### PR DESCRIPTION
Reopens and fixes #146.

## The bug
@miladmp73 reported (with a Persian screenshot) that notes written in a right-to-left script are laid out **left-to-right** — left-aligned, with sentence punctuation on the wrong side — in both the editor and the preview. The earlier reply assumed note content already followed its own direction; it did not.

**Cause:** the editor's `BasicTextField` and every preview `Text` inherit the app's layout direction (LTR for the English UI), and nothing in the codebase set a content-based text direction (`grep` for `TextDirection`/`LayoutDirection` found nothing).

## The fix
Apply `TextDirection.Content` across the whole type scale — one helper on the `Typography` in `Theme.kt`. Each paragraph's direction is then decided by its first strong character:
- Right-to-left content (Arabic, Hebrew, Persian, …) lays out right-to-left.
- Latin-first content is unchanged, so the LTR UI and existing snapshots are unaffected (LTR text renders identically under `Content`).

Both the editor (`bodyLarge`) and every preview role read from this scale, so a single change fixes both surfaces (and note-list rows) at once.

## Verification
On the `markleaf-phone-api36` emulator, a Persian paragraph now right-aligns correctly in **both** the edit and preview views — the exact screen from the report:

| | Before (#146) | After |
|---|---|---|
| Alignment | left, LTR | right, RTL ✓ |
| Sentence period | wrong side | logical end ✓ |

Follow-up idea (not in this PR): a Roborazzi golden with an RTL sample for regression protection — it needs a Linux record run to add.

🤖 Generated with [Claude Code](https://claude.com/claude-code)