### PR TITLE
docs: add GitHub Discussions link to READMEs (6 languages)

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -29,6 +29,7 @@
 
 <p align="center">
   <a href="https://github.com/jeiel85/markleaf-android">GitHub-Repository</a> ·
+  <a href="https://github.com/jeiel85/markleaf-android/discussions">Discussions (Feedback)</a> ·
   <a href="https://gitlab.com/jeiel85/markleaf-android">Öffentlicher GitLab-Mirror</a>
 </p>
 

--- a/README.es.md
+++ b/README.es.md
@@ -29,6 +29,7 @@
 
 <p align="center">
   <a href="https://github.com/jeiel85/markleaf-android">Repositorio de GitHub</a> ·
+  <a href="https://github.com/jeiel85/markleaf-android/discussions">Discussions (sugerencias)</a> ·
   <a href="https://gitlab.com/jeiel85/markleaf-android">Espejo público de GitLab</a>
 </p>
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -29,6 +29,7 @@
 
 <p align="center">
   <a href="https://github.com/jeiel85/markleaf-android">Dépôt GitHub</a> ·
+  <a href="https://github.com/jeiel85/markleaf-android/discussions">Discussions (retours)</a> ·
   <a href="https://gitlab.com/jeiel85/markleaf-android">Miroir public GitLab</a>
 </p>
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -29,6 +29,7 @@
 
 <p align="center">
   <a href="https://github.com/jeiel85/markleaf-android">GitHub リポジトリ</a> ·
+  <a href="https://github.com/jeiel85/markleaf-android/discussions">Discussions（フィードバック）</a> ·
   <a href="https://gitlab.com/jeiel85/markleaf-android">GitLab 公開ミラー</a>
 </p>
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -29,6 +29,7 @@
 
 <p align="center">
   <a href="https://github.com/jeiel85/markleaf-android">GitHub 저장소</a> ·
+  <a href="https://github.com/jeiel85/markleaf-android/discussions">Discussions (피드백)</a> ·
   <a href="https://gitlab.com/jeiel85/markleaf-android">GitLab 공개 미러</a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@
 
 <p align="center">
   <a href="https://github.com/jeiel85/markleaf-android">GitHub repository</a> ·
+  <a href="https://github.com/jeiel85/markleaf-android/discussions">Discussions (feedback)</a> ·
   <a href="https://gitlab.com/jeiel85/markleaf-android">GitLab public mirror</a>
 </p>
 


### PR DESCRIPTION
## What

- Enabled **GitHub Discussions** on the repository as a public, structured feedback channel.
- Added a `Discussions` link to the top repository-links row of all six language READMEs (EN/KO/JA/DE/ES/FR), placed between the GitHub repository and GitLab mirror links.

## Why

Gathering user feedback in a discoverable place, without the "empty room" and moderation cost of standing up a dedicated subreddit for a solo-dev FOSS app. Discussions lives where the code and power users already are, and adds no new account/moderation surface.

## Notes

- Each link label carries a localized "feedback" qualifier (e.g. `Discussions (feedback)` / `Discussions (피드백)` / `Discussions（フィードバック）`) so its purpose is clear.
- Verified the target page returns HTTP 200: https://github.com/jeiel85/markleaf-android/discussions
- Docs-only change; no version strings touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)