### PR TITLE
fix: keep the chosen file extension when unlocking re-mirrors a note (#181)

### DIFF
--- a/app/src/main/java/com/markleaf/notes/feature/lock/LockedNotesScreen.kt
+++ b/app/src/main/java/com/markleaf/notes/feature/lock/LockedNotesScreen.kt
@@ -350,10 +350,15 @@ private fun LockedNotesList(
                         appSettings.syncFolderUriOrNull()?.let { uri ->
                             scope.launch {
                                 withContext(Dispatchers.IO) {
+                                    // Re-mirror with the user's chosen extension, not
+                                    // writeNote's .md default — otherwise unlocking a
+                                    // note always rewrote it as .md even when .txt was
+                                    // selected (#181).
                                     NoteFolderMirror.writeNote(
                                         context,
                                         uri,
-                                        note.copy(locked = false)
+                                        note.copy(locked = false),
+                                        appSettings.syncFileExtension
                                     )
                                 }
                             }


### PR DESCRIPTION
Closes #181.

## The bug
Locking a note deletes its mirror file; unlocking re-writes it so locking stays reversible (#156). But the unlock call in `LockedNotesScreen` omitted the `extension` argument:

```kotlin
NoteFolderMirror.writeNote(context, uri, note.copy(locked = false))
```

so it fell back to `writeNote`'s `SyncFileExtension.MD` default. A note kept in a `.txt` sync folder therefore came back as `.md` every time it was unlocked.

## The fix
Pass the user's `appSettings.syncFileExtension`, matching every other call site (`EditorScreen` save, `SettingsScreen` export-all, `SyncCenterScreen`). One-line change, `compileDebugKotlin` green.

Not device-verified: the flow needs a real `.txt`-configured SAF sync folder, which isn't practical to drive over adb — but the fix simply reuses the extension the other three write paths already pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)