### PR TITLE
docs: point CHANGELOG readers to GitHub Discussions for feedback

### DIFF
--- a/CHANGELOG.ko.md
+++ b/CHANGELOG.ko.md
@@ -2,6 +2,8 @@
 
 Markleaf의 주요 변경 사항을 기록합니다. 영어판이 기본이며 GitHub 릴리즈 노트의 원본입니다 — [CHANGELOG.md](CHANGELOG.md).
 
+> 💬 **질문이나 피드백이 있으신가요?** [GitHub Discussions](https://github.com/jeiel85/markleaf-android/discussions)에서 이야기 나눠 주세요. 버그 제보는 [Issues](https://github.com/jeiel85/markleaf-android/issues)로 남겨 주세요.
+
 v2.15.3 이전 항목은 이 파일에만 한국어로 보존되어 있습니다.
 
 ## v2.28.1 - 잠금 해제 시 파일 확장자 유지 (Unlock keeps your file extension) - 2026-07-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to Markleaf are documented in this file. This English edition is the source for GitHub release notes; the Korean edition is kept at [CHANGELOG.ko.md](CHANGELOG.ko.md).
 
+> 💬 **Questions or feedback?** Start a thread in [GitHub Discussions](https://github.com/jeiel85/markleaf-android/discussions). Bug reports still belong in [Issues](https://github.com/jeiel85/markleaf-android/issues).
+
 ## v2.28.1 - Unlock keeps your file extension - 2026-07-22
 
 A small bug-fix release. No feature, permission, or storage-format changes.


### PR DESCRIPTION
## What

Add a short preamble banner to **both** `CHANGELOG.md` and `CHANGELOG.ko.md` pointing readers to **GitHub Discussions** for questions/feedback and to **Issues** for bug reports.

## Why

The Korean changelog was requested to carry the Discussions guidance. Since `CHANGELOG.md` (English) is the canonical source and `CHANGELOG.ko.md` is its translation, the banner is added to both to keep them in sync.

## Placement & safety

The banner sits in the file preamble, **above the first `## vX.Y.Z` heading**, so it is outside every version section:

- Release-note `awk` extraction (`.github/workflows/android-build.yml`) keys on version headings — verified the v2.28.0 title/notes extract unchanged, banner excluded.
- `scripts/verify-release-notes.ps1` compares only `## vX.Y.Z` sections — passes (112 sections in sync, 6 fastlane locales OK).

Docs-only change; no version strings or app code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)