### PR TITLE
fix(sync): stop adopting a file whose frontmatter runs past the read cap (#222)

### DIFF
--- a/app/src/main/java/com/markleaf/notes/data/sync/NoteFolderMirror.kt
+++ b/app/src/main/java/com/markleaf/notes/data/sync/NoteFolderMirror.kt
@@ -513,6 +513,10 @@ object NoteFolderMirror {
      * rewrites the file without preserving our block. Adoption is safe because
      * a file carrying *someone else's* id is never taken — only unclaimed ones,
      * and only under the undisambiguated name (`Notes.md`, never `Notes (2).md`).
+     * "Unclaimed" means [peekFrontmatter] read the file's whole block and found
+     * no id; a file it could not read to the end of is skipped rather than
+     * adopted, so a header longer than the read cap is never overwritten
+     * unseen (#222).
      *
      * The file's own unknown frontmatter keys come back alongside it so the
      * write can put them back rather than dropping tags another tool wrote.
@@ -525,36 +529,109 @@ object NoteFolderMirror {
         val base = MirrorFileNames.sanitizeBase(note.title)
         var unclaimed: MirrorMatch? = null
         for (file in mirrorFiles) {
-            val parsed = peekFrontmatter(context, file) ?: continue
-            if (parsed.markleafId == note.id) return MirrorMatch(file, parsed.unknownKeys)
-            if (parsed.markleafId == null &&
+            val head = peekFrontmatter(context, file) ?: continue
+            if (head.markleafId == note.id) return MirrorMatch(file, head.extraKeys)
+            if (head.markleafId == null &&
                 unclaimed == null &&
                 MirrorFileNames.isPlainNameFor(file.name.orEmpty(), base)
             ) {
-                unclaimed = MirrorMatch(file, parsed.unknownKeys)
+                unclaimed = MirrorMatch(file, head.extraKeys)
             }
         }
         return unclaimed
     }
 
+    /** What a file's head says about which note owns it. */
+    private class HeadInfo(val markleafId: String?, val extraKeys: Map<String, String>)
+
+    /** Whether a head read has seen enough to answer that question. */
+    internal enum class HeadScan {
+        /** The block was read in full, or the file provably has none. */
+        Done,
+
+        /** A block is open and its end lies past what has been read. */
+        NeedMore,
+
+        /** The block never closed within the read cap — we cannot say. */
+        Undetermined
+    }
+
     /**
-     * Parse the frontmatter at the head of [file]. Only the leading bytes are
-     * read — the block always sits at the very top — so this stays cheap even
-     * when it runs over every file in the folder. Returns null on any read
-     * failure, which the callers treat as "this file tells us nothing".
+     * Whether a head read of [limit] bytes settled the question.
+     *
+     * Pulled out of the IO loop because the dangerous case is the quiet one:
+     * a truncated read of a file whose frontmatter runs long looks exactly like
+     * a file with no frontmatter at all. Treating the two alike let
+     * [findMirrorFile] class such a file as *unclaimed*, adopt it, and rewrite
+     * it — dropping metadata the file really had (#222).
      */
-    private fun peekFrontmatter(context: Context, file: DocumentFile): SyncFrontmatter.Parsed? =
+    internal fun headScanVerdict(
+        hasFrontmatter: Boolean,
+        opensFrontmatter: Boolean,
+        atEof: Boolean,
+        limit: Int
+    ): HeadScan = when {
+        // The block closed — everything we need is in hand.
+        hasFrontmatter -> HeadScan.Done
+        // No opening delimiter: this file has no block, and never will.
+        !opensFrontmatter -> HeadScan.Done
+        // Whole file read and the block still hasn't closed, so it is not
+        // frontmatter at all — a `---` rule at the top of the body. decode()
+        // already treats it that way.
+        atEof -> HeadScan.Done
+        limit >= FRONTMATTER_MAX_BYTES -> HeadScan.Undetermined
+        else -> HeadScan.NeedMore
+    }
+
+    /**
+     * Read [file]'s head far enough to learn which note owns it.
+     *
+     * Starts at [FRONTMATTER_PEEK_BYTES] — enough for any block we write, and
+     * cheap enough to run over every file in the folder on each save — and only
+     * reads further when the file opens a block that hasn't closed yet, up to
+     * [FRONTMATTER_MAX_BYTES].
+     *
+     * Returns null when the file can't be read, and when a block is still open
+     * at the cap. Both mean "this file tells us nothing", which the callers
+     * treat as *skip*: better to leave an unreadable file alone — and write a
+     * duplicate — than to adopt it and overwrite metadata we never saw.
+     *
+     * Deliberately does not return the parsed body: at these read sizes the
+     * body is usually truncated, and the type shouldn't offer it.
+     */
+    private fun peekFrontmatter(context: Context, file: DocumentFile): HeadInfo? =
         runCatching {
             context.contentResolver.openInputStream(file.uri)?.use { stream ->
-                val buf = ByteArray(FRONTMATTER_PEEK_BYTES)
+                var limit = FRONTMATTER_PEEK_BYTES
+                var buf = ByteArray(limit)
                 var read = 0
-                while (read < buf.size) {
-                    val n = stream.read(buf, read, buf.size - read)
-                    if (n < 0) break
-                    read += n
+                while (true) {
+                    var eof = false
+                    while (read < limit) {
+                        val n = stream.read(buf, read, limit - read)
+                        if (n < 0) { eof = true; break }
+                        read += n
+                    }
+                    if (read <= 0) return@use null
+                    val text = String(buf, 0, read, Charsets.UTF_8)
+                    val parsed = SyncFrontmatter.decode(text)
+                    val verdict = headScanVerdict(
+                        hasFrontmatter = parsed.hasFrontmatter,
+                        opensFrontmatter = SyncFrontmatter.opensFrontmatter(text),
+                        atEof = eof,
+                        limit = limit
+                    )
+                    when (verdict) {
+                        HeadScan.Done -> return@use HeadInfo(parsed.markleafId, parsed.unknownKeys)
+                        HeadScan.Undetermined -> return@use null
+                        HeadScan.NeedMore -> {
+                            limit = (limit * 4).coerceAtMost(FRONTMATTER_MAX_BYTES)
+                            buf = buf.copyOf(limit)
+                        }
+                    }
                 }
-                if (read <= 0) null
-                else SyncFrontmatter.decode(String(buf, 0, read, Charsets.UTF_8))
+                // Unreachable: every branch above returns.
+                @Suppress("UNREACHABLE_CODE") null
             }
         }.getOrNull()
 
@@ -590,6 +667,15 @@ object NoteFolderMirror {
     private const val SLACK_MILLIS = 2_000L
     private const val ATTACHMENTS_DIR = "attachments"
     private const val FRONTMATTER_PEEK_BYTES = 4096
+
+    /**
+     * Ceiling on how far [peekFrontmatter] will chase an unclosed frontmatter
+     * block. A block we write is a few hundred bytes; one that has not ended
+     * after 256 KB is not a header we should be reasoning about, and reading
+     * further would put an unbounded cost on a path that runs over every file
+     * in the folder each time a note is saved.
+     */
+    internal const val FRONTMATTER_MAX_BYTES = 256 * 1024
 }
 
 /**

--- a/app/src/main/java/com/markleaf/notes/data/sync/SyncFrontmatter.kt
+++ b/app/src/main/java/com/markleaf/notes/data/sync/SyncFrontmatter.kt
@@ -51,8 +51,29 @@ object SyncFrontmatter {
         val pinned: Boolean?,
         val archived: Boolean?,
         val body: String,
-        val unknownKeys: Map<String, String>
+        val unknownKeys: Map<String, String>,
+        /**
+         * True only when a complete `---` … `---` block was found. False both
+         * for a file with no block at all *and* for one whose block never
+         * closes — including the case where the caller simply hasn't read far
+         * enough yet. Pair it with [opensFrontmatter] to tell those apart: a
+         * reader that only peeked at the head must not mistake "not read far
+         * enough" for "this file has no metadata" (#222).
+         */
+        val hasFrontmatter: Boolean
     )
+
+    /**
+     * True when [fileContents] *opens* a frontmatter block — the first line is
+     * the delimiter — whether or not the block is closed within this string.
+     *
+     * The distinction matters to anyone parsing a truncated prefix of a file:
+     * `hasFrontmatter == false` alone cannot tell "no metadata here" from "the
+     * block runs past what I read", and treating the second as the first
+     * discards metadata the file really has.
+     */
+    fun opensFrontmatter(fileContents: String): Boolean =
+        fileContents.removePrefix(BOM).lineSequence().firstOrNull()?.trim() == DELIMITER
 
     /**
      * @param extraKeys frontmatter keys written by other tools (Obsidian
@@ -94,12 +115,13 @@ object SyncFrontmatter {
                 pinned = null,
                 archived = null,
                 body = text,
-                unknownKeys = emptyMap()
+                unknownKeys = emptyMap(),
+                hasFrontmatter = false
             )
         }
         val closeOffset = lines.subList(1, lines.size).indexOfFirst { it.trim() == DELIMITER }
         if (closeOffset < 0) {
-            return Parsed(null, null, null, null, null, text, emptyMap())
+            return Parsed(null, null, null, null, null, text, emptyMap(), hasFrontmatter = false)
         }
         val frontmatterLines = lines.subList(1, 1 + closeOffset)
         var bodyStart = 1 + closeOffset + 1
@@ -130,7 +152,10 @@ object SyncFrontmatter {
             }
         }
 
-        return Parsed(markleafId, createdAt, updatedAt, pinned, archived, body, unknownKeys)
+        return Parsed(
+            markleafId, createdAt, updatedAt, pinned, archived, body, unknownKeys,
+            hasFrontmatter = true
+        )
     }
 
     private fun parseInstantOrNull(value: String): Instant? = runCatching {

--- a/app/src/test/java/com/markleaf/notes/data/sync/NoteFolderMirrorConflictLogicTest.kt
+++ b/app/src/test/java/com/markleaf/notes/data/sync/NoteFolderMirrorConflictLogicTest.kt
@@ -119,6 +119,69 @@ class NoteFolderMirrorConflictLogicTest {
         )
     }
 
+    // --- #222: how far to read a file's head --------------------------------
+
+    private fun scan(
+        hasFrontmatter: Boolean,
+        opensFrontmatter: Boolean,
+        atEof: Boolean,
+        limit: Int = 4096
+    ) = NoteFolderMirror.headScanVerdict(hasFrontmatter, opensFrontmatter, atEof, limit)
+
+    @Test
+    fun closedBlock_needsNoFurtherReading() {
+        assertEquals(
+            NoteFolderMirror.HeadScan.Done,
+            scan(hasFrontmatter = true, opensFrontmatter = true, atEof = false)
+        )
+    }
+
+    @Test
+    fun fileWithNoOpeningDelimiter_isSettledImmediately() {
+        // Plain Markdown. It has no block and never will, so it is genuinely
+        // unclaimed and safe to adopt.
+        assertEquals(
+            NoteFolderMirror.HeadScan.Done,
+            scan(hasFrontmatter = false, opensFrontmatter = false, atEof = false)
+        )
+    }
+
+    @Test
+    fun openBlockNotYetClosed_asksForMore() {
+        // The dangerous case before #222: this looked identical to "no
+        // frontmatter", so the file was treated as unclaimed and overwritten.
+        assertEquals(
+            NoteFolderMirror.HeadScan.NeedMore,
+            scan(hasFrontmatter = false, opensFrontmatter = true, atEof = false)
+        )
+    }
+
+    @Test
+    fun openBlockAtEndOfFile_isSettled() {
+        // The whole file has been read and the block never closed, so it isn't
+        // frontmatter at all — a `---` rule at the top of the body.
+        assertEquals(
+            NoteFolderMirror.HeadScan.Done,
+            scan(hasFrontmatter = false, opensFrontmatter = true, atEof = true)
+        )
+    }
+
+    @Test
+    fun openBlockAtTheReadCap_isUndetermined() {
+        // Stop chasing, and report that we cannot say. The caller skips the
+        // file rather than adopting it — a duplicate file beats overwriting
+        // metadata we never read.
+        assertEquals(
+            NoteFolderMirror.HeadScan.Undetermined,
+            scan(
+                hasFrontmatter = false,
+                opensFrontmatter = true,
+                atEof = false,
+                limit = NoteFolderMirror.FRONTMATTER_MAX_BYTES
+            )
+        )
+    }
+
     // --- #217: a conflict must settle instead of repeating ------------------
 
     @Test

--- a/app/src/test/java/com/markleaf/notes/data/sync/SyncFrontmatterTest.kt
+++ b/app/src/test/java/com/markleaf/notes/data/sync/SyncFrontmatterTest.kt
@@ -172,6 +172,35 @@ class SyncFrontmatterTest {
         assertEquals("# Just a body", parsed.body)
     }
 
+    // --- #222: telling "no metadata" from "not read far enough" -------------
+
+    @Test
+    fun hasFrontmatter_trueOnlyForAClosedBlock() {
+        assertTrue(SyncFrontmatter.decode(SyncFrontmatter.encode(sampleNote())).hasFrontmatter)
+        assertFalse(SyncFrontmatter.decode("# Plain body").hasFrontmatter)
+        assertFalse(SyncFrontmatter.decode("---\nmarkleaf_id: x\nstill open").hasFrontmatter)
+    }
+
+    @Test
+    fun opensFrontmatter_separatesAnOpenBlockFromNoBlock() {
+        // A truncated read of a file whose block runs long yields
+        // hasFrontmatter == false, exactly like a file with no block. Only
+        // opensFrontmatter tells the two apart — and mistaking the first for
+        // the second is what let the mirror overwrite metadata it never read.
+        val truncated = "---\nmarkleaf_id: x\nalias: something-very-"
+
+        assertFalse(SyncFrontmatter.decode(truncated).hasFrontmatter)
+        assertTrue(SyncFrontmatter.opensFrontmatter(truncated))
+        assertFalse(SyncFrontmatter.opensFrontmatter("# Plain body"))
+    }
+
+    @Test
+    fun opensFrontmatter_looksPastAByteOrderMark() {
+        val bom = Char(0xFEFF).toString()
+
+        assertTrue(SyncFrontmatter.opensFrontmatter(bom + "---\nmarkleaf_id: x\n"))
+    }
+
     @Test
     fun decode_pinnedFalseWhenAbsent() {
         val raw = """


### PR DESCRIPTION
First item of #222 — the one the v2.28.2 fixes made *worse*, so it is worth taking on its own rather than waiting for the rest of the list.

## The problem

`peekFrontmatter` read a fixed 4096-byte head. A file whose frontmatter block does not close within that prefix decoded as *"no id, no keys"* — the exact same result as a file with no frontmatter at all. The type had no way to say "I did not read far enough."

| | Before #220 | After #220 |
|---|---|---|
| Such a file is… | not matched → a duplicate file is written | read as **unclaimed** → **adopted and rewritten** |
| Cost | annoying | **metadata destroyed unseen** |

The filename fallback shipped in #220 is what changed the consequence. Rare — it needs a frontmatter block over 4 KB — but the failure is silent and unrecoverable, which is the wrong pair of properties.

## Changes

- **`SyncFrontmatter.Parsed.hasFrontmatter`** — a complete `---` … `---` block was found.
- **`SyncFrontmatter.opensFrontmatter()`** — the text *starts* a block, closed or not.

  Neither alone is enough. `hasFrontmatter == false` covers both "no metadata" and "block runs past my read"; only the pair separates them.

- **`peekFrontmatter` grows its read** — 4 KB, then ×4 per round, but only while a block is open, up to a **256 KB** cap. At the cap it returns null. Callers already treat null as *skip*, so the outcome for an unreadable header is a duplicate file, not an overwrite. Back to annoying.
- **`headScanVerdict()` is pure**, so the four cases (closed / no block / EOF with block still open / cap reached) are tested directly instead of through SAF IO.
- **`peekFrontmatter` returns `HeadInfo`** (id + extra keys) rather than `Parsed` — at these read sizes the body is truncated, and the type should not hand callers something they must not use.

Normal files close their block within a few hundred bytes, so the growth path never runs in practice and the per-save cost over the folder is unchanged.

## Verification

| Check | Result |
|---|---|
| `gradlew test` (debug + release) | 417 passed, 0 failed — 8 new |
| `gradlew lintRelease` | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)