### PR TITLE
fix(sync): stop reading a horizontal rule as frontmatter (#222)

### DIFF
--- a/app/src/main/java/com/markleaf/notes/data/sync/NoteFolderMirror.kt
+++ b/app/src/main/java/com/markleaf/notes/data/sync/NoteFolderMirror.kt
@@ -568,16 +568,19 @@ object NoteFolderMirror {
     internal fun headScanVerdict(
         hasFrontmatter: Boolean,
         opensFrontmatter: Boolean,
+        blockClosed: Boolean,
         atEof: Boolean,
         limit: Int
     ): HeadScan = when {
-        // The block closed — everything we need is in hand.
+        // Metadata parsed — everything we need is in hand.
         hasFrontmatter -> HeadScan.Done
         // No opening delimiter: this file has no block, and never will.
         !opensFrontmatter -> HeadScan.Done
-        // Whole file read and the block still hasn't closed, so it is not
-        // frontmatter at all — a `---` rule at the top of the body. decode()
-        // already treats it that way.
+        // The block opened and closed but held body text, not metadata — a pair
+        // of horizontal rules. Reading further cannot change that verdict.
+        blockClosed -> HeadScan.Done
+        // Whole file read and the block never closed, so the opening `---` was
+        // a rule too. decode() already treats it as body.
         atEof -> HeadScan.Done
         limit >= FRONTMATTER_MAX_BYTES -> HeadScan.Undetermined
         else -> HeadScan.NeedMore
@@ -618,6 +621,7 @@ object NoteFolderMirror {
                     val verdict = headScanVerdict(
                         hasFrontmatter = parsed.hasFrontmatter,
                         opensFrontmatter = SyncFrontmatter.opensFrontmatter(text),
+                        blockClosed = parsed.blockClosed,
                         atEof = eof,
                         limit = limit
                     )

--- a/app/src/main/java/com/markleaf/notes/data/sync/SyncFrontmatter.kt
+++ b/app/src/main/java/com/markleaf/notes/data/sync/SyncFrontmatter.kt
@@ -53,14 +53,21 @@ object SyncFrontmatter {
         val body: String,
         val unknownKeys: Map<String, String>,
         /**
-         * True only when a complete `---` … `---` block was found. False both
-         * for a file with no block at all *and* for one whose block never
-         * closes — including the case where the caller simply hasn't read far
-         * enough yet. Pair it with [opensFrontmatter] to tell those apart: a
-         * reader that only peeked at the head must not mistake "not read far
-         * enough" for "this file has no metadata" (#222).
+         * True only when a complete `---` … `---` block was found *and* its
+         * contents read as metadata. False for a file with no block, for one
+         * whose block never closes — including when the caller simply hasn't
+         * read far enough yet — and for a pair of horizontal rules with body
+         * text between them. Pair it with [opensFrontmatter] and [blockClosed]
+         * to tell those apart: a reader that only peeked at the head must not
+         * mistake "not read far enough" for "no metadata here" (#222).
          */
-        val hasFrontmatter: Boolean
+        val hasFrontmatter: Boolean,
+        /**
+         * True when an opening delimiter was followed by a closing one, whether
+         * or not what sat between them was metadata. Lets a reader stop: once
+         * the block has closed, reading further cannot change the verdict.
+         */
+        val blockClosed: Boolean
     )
 
     /**
@@ -116,14 +123,28 @@ object SyncFrontmatter {
                 archived = null,
                 body = text,
                 unknownKeys = emptyMap(),
-                hasFrontmatter = false
+                hasFrontmatter = false,
+                blockClosed = false
             )
         }
         val closeOffset = lines.subList(1, lines.size).indexOfFirst { it.trim() == DELIMITER }
         if (closeOffset < 0) {
-            return Parsed(null, null, null, null, null, text, emptyMap(), hasFrontmatter = false)
+            return Parsed(
+                null, null, null, null, null, text, emptyMap(),
+                hasFrontmatter = false, blockClosed = false
+            )
         }
         val frontmatterLines = lines.subList(1, 1 + closeOffset)
+        // `---` is also a Markdown horizontal rule, so an opening delimiter on
+        // its own proves nothing. A note whose body starts with a rule and
+        // carries another one later used to have everything between them
+        // swallowed as unparseable frontmatter and dropped on import (#222).
+        if (!looksLikeMetadata(frontmatterLines)) {
+            return Parsed(
+                null, null, null, null, null, text, emptyMap(),
+                hasFrontmatter = false, blockClosed = true
+            )
+        }
         var bodyStart = 1 + closeOffset + 1
         // Skip a single leading blank line after the closing delimiter for cleanliness.
         if (bodyStart < lines.size && lines[bodyStart].isEmpty()) bodyStart++
@@ -154,8 +175,32 @@ object SyncFrontmatter {
 
         return Parsed(
             markleafId, createdAt, updatedAt, pinned, archived, body, unknownKeys,
-            hasFrontmatter = true
+            hasFrontmatter = true, blockClosed = true
         )
+    }
+
+    /**
+     * Whether the lines inside a closed `---` … `---` block are metadata rather
+     * than body text that happens to sit between two horizontal rules.
+     *
+     * The test is the **first non-blank line**: real frontmatter opens with a
+     * key. Later lines are deliberately not checked, because a YAML value
+     * legitimately continues across lines — `tags:` followed by `  - a` is an
+     * ordinary Obsidian block, and demanding that every line look like a key
+     * would throw those away, trading one silent loss for a worse one.
+     *
+     * Requiring the key to carry no whitespace also pins it to column 0, which
+     * is where a top-level YAML key belongs, and narrows the ambiguity to prose
+     * whose first line is a single word followed by a colon. That case is still
+     * read as frontmatter; going further needs a real YAML parser. When in
+     * doubt this errs toward *not* frontmatter, because the cost of being wrong
+     * that way is a duplicate file, while the other way is deleted text.
+     */
+    private fun looksLikeMetadata(blockLines: List<String>): Boolean {
+        val first = blockLines.firstOrNull { it.isNotBlank() } ?: return false
+        val colon = first.indexOf(':')
+        if (colon <= 0) return false
+        return first.substring(0, colon).none { it.isWhitespace() }
     }
 
     private fun parseInstantOrNull(value: String): Instant? = runCatching {

--- a/app/src/test/java/com/markleaf/notes/data/sync/NoteFolderMirrorConflictLogicTest.kt
+++ b/app/src/test/java/com/markleaf/notes/data/sync/NoteFolderMirrorConflictLogicTest.kt
@@ -125,8 +125,27 @@ class NoteFolderMirrorConflictLogicTest {
         hasFrontmatter: Boolean,
         opensFrontmatter: Boolean,
         atEof: Boolean,
-        limit: Int = 4096
-    ) = NoteFolderMirror.headScanVerdict(hasFrontmatter, opensFrontmatter, atEof, limit)
+        limit: Int = 4096,
+        blockClosed: Boolean = hasFrontmatter
+    ) = NoteFolderMirror.headScanVerdict(
+        hasFrontmatter, opensFrontmatter, blockClosed, atEof, limit
+    )
+
+    @Test
+    fun closedBlockThatIsNotMetadata_stopsTheRead() {
+        // Two horizontal rules with body text between them. The block has
+        // closed, so reading further cannot turn it into metadata — chasing it
+        // to the 256 KB cap would be wasted IO on every save (#222).
+        assertEquals(
+            NoteFolderMirror.HeadScan.Done,
+            scan(
+                hasFrontmatter = false,
+                opensFrontmatter = true,
+                blockClosed = true,
+                atEof = false
+            )
+        )
+    }
 
     @Test
     fun closedBlock_needsNoFurtherReading() {

--- a/app/src/test/java/com/markleaf/notes/data/sync/SyncFrontmatterTest.kt
+++ b/app/src/test/java/com/markleaf/notes/data/sync/SyncFrontmatterTest.kt
@@ -172,6 +172,76 @@ class SyncFrontmatterTest {
         assertEquals("# Just a body", parsed.body)
     }
 
+    // --- #222: a horizontal rule is not frontmatter -------------------------
+
+    @Test
+    fun decode_keepsBodyTextBetweenTwoHorizontalRules() {
+        // The reported loss: `---` opens a Markdown rule as readily as it opens
+        // frontmatter. Everything between the two rules used to be swallowed as
+        // "frontmatter we could not parse" and dropped on import.
+        val raw = "---\nSome text\n---\nMore body"
+
+        val parsed = SyncFrontmatter.decode(raw)
+
+        assertNull(parsed.markleafId)
+        assertFalse(parsed.hasFrontmatter)
+        assertEquals(raw, parsed.body)
+    }
+
+    @Test
+    fun decode_keepsAnEmptyRulePair() {
+        val raw = "---\n---\nBody"
+
+        val parsed = SyncFrontmatter.decode(raw)
+
+        assertFalse(parsed.hasFrontmatter)
+        assertEquals(raw, parsed.body)
+    }
+
+    @Test
+    fun decode_stillAcceptsYamlWhoseValueSpansLines() {
+        // The guard must not be stricter than YAML. An Obsidian block with a
+        // list value has lines that look nothing like `key: value`; rejecting it
+        // would trade one silent loss for a worse one.
+        val raw = """
+            ---
+            tags:
+              - review
+              - draft
+            markleaf_id: x
+            ---
+            body
+        """.trimIndent()
+
+        val parsed = SyncFrontmatter.decode(raw)
+
+        assertTrue(parsed.hasFrontmatter)
+        assertEquals("x", parsed.markleafId)
+        assertEquals("body", parsed.body)
+    }
+
+    @Test
+    fun decode_blockClosedIsTrueEvenWhenTheBlockIsNotMetadata() {
+        // Lets the mirror's head reader stop instead of chasing a closed rule
+        // pair to its read cap on every save.
+        val rules = SyncFrontmatter.decode("---\nSome text\n---\nMore")
+        assertTrue(rules.blockClosed)
+        assertFalse(rules.hasFrontmatter)
+
+        val unterminated = SyncFrontmatter.decode("---\nmarkleaf_id: x\nstill open")
+        assertFalse(unterminated.blockClosed)
+    }
+
+    @Test
+    fun decode_ourOwnOutputIsAlwaysRecognised() {
+        // encode() always emits markleaf_id first, so the guard can never reject
+        // a file Markleaf itself wrote.
+        val parsed = SyncFrontmatter.decode(SyncFrontmatter.encode(sampleNote()))
+
+        assertTrue(parsed.hasFrontmatter)
+        assertEquals(sampleNote().id, parsed.markleafId)
+    }
+
     // --- #222: telling "no metadata" from "not read far enough" -------------
 
     @Test


### PR DESCRIPTION
Item 6 of #222. Pre-existing — not introduced by the v2.28.2/v2.28.3 work — but in the same parser and the same blast radius, and it deletes text.

## The loss

`---` opens a Markdown **horizontal rule** as readily as it opens a frontmatter block. `decode()` treated any file starting with `---` and containing a later `---` as frontmatter:

```markdown
---
Some text
---
More body
```

`Some text` parses as no key at all, so it was dropped, and both rules with it. The note imported as just `More body`. No error, no warning.

## The guard

A closed block now has to *look like* metadata: its first non-blank line must parse as `key: value` with a whitespace-free key.

**Only the first line, deliberately.** A YAML value legitimately continues across lines —

```yaml
tags:
  - review
  - draft
```

— and `  - review` looks nothing like a key. Demanding that every line qualify would throw away ordinary Obsidian blocks: one silent loss traded for a worse one. There's a test pinning that case.

Prose whose first line reads `Word: …` stays ambiguous and is still treated as frontmatter. Narrowing further needs a real YAML parser, which this project does not ship. Where the heuristic is unsure it errs toward *not* frontmatter, because being wrong that way costs a duplicate file while the other way costs deleted text.

`encode()` always emits `markleaf_id` first, so a file Markleaf wrote can never be rejected — also pinned by a test.

## `blockClosed`

`Parsed` gains `blockClosed` alongside `hasFrontmatter`. The mirror's head reader needs three states, not two:

| | `hasFrontmatter` | `blockClosed` | Reader |
|---|---|---|---|
| metadata | true | true | done |
| rules with text between | false | true | **done** — reading on can't change it |
| block not closed yet | false | false | read more |

Without the middle row, a note that merely opens with a rule would be chased to the 256 KB cap on every auto-save.

## Verification

| Check | Result |
|---|---|
| `gradlew test` (debug + release) | 423 passed, 0 failed — 6 new |

🤖 Generated with [Claude Code](https://claude.com/claude-code)