### PR TITLE
refactor(sync): settle conflicts with remoteSeenAt instead of moving updatedAt (#222)

### DIFF
--- a/app/schemas/com.markleaf.notes.data.local.AppDatabase/17.json
+++ b/app/schemas/com.markleaf.notes.data.local.AppDatabase/17.json
@@ -1,0 +1,443 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 17,
+    "identityHash": "d9b54172baf18cbec67d49e3c32138d1",
+    "entities": [
+      {
+        "tableName": "notes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT NOT NULL, `contentMarkdown` TEXT NOT NULL, `excerpt` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `pinned` INTEGER NOT NULL, `archived` INTEGER NOT NULL, `trashed` INTEGER NOT NULL, `deletedAt` INTEGER, `sortOrder` INTEGER NOT NULL, `lastImportedAt` INTEGER, `remoteSeenAt` INTEGER, `locked` INTEGER NOT NULL, `isConflictCopy` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contentMarkdown",
+            "columnName": "contentMarkdown",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "excerpt",
+            "columnName": "excerpt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pinned",
+            "columnName": "pinned",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "archived",
+            "columnName": "archived",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trashed",
+            "columnName": "trashed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sortOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastImportedAt",
+            "columnName": "lastImportedAt",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "remoteSeenAt",
+            "columnName": "remoteSeenAt",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "locked",
+            "columnName": "locked",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isConflictCopy",
+            "columnName": "isConflictCopy",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_notes_trashed_pinned_sortOrder",
+            "unique": false,
+            "columnNames": [
+              "trashed",
+              "pinned",
+              "sortOrder"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_notes_trashed_pinned_sortOrder` ON `${TABLE_NAME}` (`trashed`, `pinned`, `sortOrder`)"
+          },
+          {
+            "name": "index_notes_trashed_deletedAt",
+            "unique": false,
+            "columnNames": [
+              "trashed",
+              "deletedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_notes_trashed_deletedAt` ON `${TABLE_NAME}` (`trashed`, `deletedAt`)"
+          },
+          {
+            "name": "index_notes_title_trashed",
+            "unique": false,
+            "columnNames": [
+              "title",
+              "trashed"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_notes_title_trashed` ON `${TABLE_NAME}` (`title`, `trashed`)"
+          },
+          {
+            "name": "index_notes_sortOrder",
+            "unique": false,
+            "columnNames": [
+              "sortOrder"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_notes_sortOrder` ON `${TABLE_NAME}` (`sortOrder`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "tags",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `createdAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "note_tag_cross_ref",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`noteId` TEXT NOT NULL, `tagId` INTEGER NOT NULL, PRIMARY KEY(`noteId`, `tagId`), FOREIGN KEY(`noteId`) REFERENCES `notes`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`tagId`) REFERENCES `tags`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "noteId",
+            "columnName": "noteId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tagId",
+            "columnName": "tagId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "noteId",
+            "tagId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_note_tag_cross_ref_noteId",
+            "unique": false,
+            "columnNames": [
+              "noteId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_note_tag_cross_ref_noteId` ON `${TABLE_NAME}` (`noteId`)"
+          },
+          {
+            "name": "index_note_tag_cross_ref_tagId",
+            "unique": false,
+            "columnNames": [
+              "tagId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_note_tag_cross_ref_tagId` ON `${TABLE_NAME}` (`tagId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "notes",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "noteId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "tags",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "tagId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "ftsVersion": "FTS4",
+        "ftsOptions": {
+          "tokenizer": "simple",
+          "tokenizerArgs": [],
+          "contentTable": "notes",
+          "languageIdColumnName": "",
+          "matchInfo": "FTS4",
+          "notIndexedColumns": [],
+          "prefixSizes": [],
+          "preferredOrder": "ASC"
+        },
+        "contentSyncTriggers": [
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_notes_fts_BEFORE_UPDATE BEFORE UPDATE ON `notes` BEGIN DELETE FROM `notes_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_notes_fts_BEFORE_DELETE BEFORE DELETE ON `notes` BEGIN DELETE FROM `notes_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_notes_fts_AFTER_UPDATE AFTER UPDATE ON `notes` BEGIN INSERT INTO `notes_fts`(`docid`, `title`, `contentMarkdown`, `excerpt`) VALUES (NEW.`rowid`, NEW.`title`, NEW.`contentMarkdown`, NEW.`excerpt`); END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_notes_fts_AFTER_INSERT AFTER INSERT ON `notes` BEGIN INSERT INTO `notes_fts`(`docid`, `title`, `contentMarkdown`, `excerpt`) VALUES (NEW.`rowid`, NEW.`title`, NEW.`contentMarkdown`, NEW.`excerpt`); END"
+        ],
+        "tableName": "notes_fts",
+        "createSql": "CREATE VIRTUAL TABLE IF NOT EXISTS `${TABLE_NAME}` USING FTS4(`title` TEXT NOT NULL, `contentMarkdown` TEXT NOT NULL, `excerpt` TEXT NOT NULL, content=`notes`)",
+        "fields": [
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contentMarkdown",
+            "columnName": "contentMarkdown",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "excerpt",
+            "columnName": "excerpt",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": []
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "note_links",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceNoteId` TEXT NOT NULL, `targetTitle` TEXT NOT NULL, `normalizedTitle` TEXT NOT NULL, `position` INTEGER NOT NULL, PRIMARY KEY(`sourceNoteId`, `position`), FOREIGN KEY(`sourceNoteId`) REFERENCES `notes`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceNoteId",
+            "columnName": "sourceNoteId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetTitle",
+            "columnName": "targetTitle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "normalizedTitle",
+            "columnName": "normalizedTitle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceNoteId",
+            "position"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_note_links_sourceNoteId",
+            "unique": false,
+            "columnNames": [
+              "sourceNoteId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_note_links_sourceNoteId` ON `${TABLE_NAME}` (`sourceNoteId`)"
+          },
+          {
+            "name": "index_note_links_normalizedTitle",
+            "unique": false,
+            "columnNames": [
+              "normalizedTitle"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_note_links_normalizedTitle` ON `${TABLE_NAME}` (`normalizedTitle`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "notes",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceNoteId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "attachments",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `noteId` TEXT NOT NULL, `fileName` TEXT NOT NULL, `mimeType` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`noteId`) REFERENCES `notes`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "noteId",
+            "columnName": "noteId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileName",
+            "columnName": "fileName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mimeType",
+            "columnName": "mimeType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_attachments_noteId",
+            "unique": false,
+            "columnNames": [
+              "noteId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_attachments_noteId` ON `${TABLE_NAME}` (`noteId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "notes",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "noteId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'd9b54172baf18cbec67d49e3c32138d1')"
+    ]
+  }
+}

--- a/app/src/androidTest/java/com/markleaf/notes/data/local/AppDatabaseMigrationTest.kt
+++ b/app/src/androidTest/java/com/markleaf/notes/data/local/AppDatabaseMigrationTest.kt
@@ -33,7 +33,7 @@ class AppDatabaseMigrationTest {
             .build()
 
         db.openHelper.writableDatabase.query(
-            "SELECT id, title, sortOrder, lastImportedAt, locked, isConflictCopy FROM notes WHERE id = '42'"
+            "SELECT id, title, sortOrder, lastImportedAt, locked, isConflictCopy, remoteSeenAt FROM notes WHERE id = '42'"
         ).use { cursor ->
             assertTrue(cursor.moveToFirst())
             assertEquals("42", cursor.getString(0))
@@ -46,6 +46,11 @@ class AppDatabaseMigrationTest {
             // #217: v15→v16 adds `isConflictCopy`, defaulting to 0 — an ordinary
             // note must not be swept into the Sync Center's conflict list.
             assertEquals(0, cursor.getInt(5))
+            // #222: v16→v17 adds `remoteSeenAt`, deliberately NOT backfilled.
+            // Null reads as "no remote version resolved yet", which keeps the
+            // whole reconcile matrix answering exactly as it did before the
+            // column existed.
+            assertTrue(cursor.isNull(6))
         }
 
         // #217: conflict copies created under the old scheme were recognised

--- a/app/src/main/java/com/markleaf/notes/data/local/AppDatabase.kt
+++ b/app/src/main/java/com/markleaf/notes/data/local/AppDatabase.kt
@@ -26,7 +26,7 @@ import com.markleaf.notes.data.local.entity.TagEntity
         NoteLinkEntity::class,
         AttachmentEntity::class
     ],
-    version = 16,
+    version = 17,
     exportSchema = true
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -280,6 +280,19 @@ abstract class AppDatabase : RoomDatabase() {
             }
         }
 
+        // v16 → v17 (#222): track how far the folder reconcile has read a note's
+        // mirror file, separately from `updatedAt`. Settling a sync conflict
+        // used to work by pushing `updatedAt` past the file's timestamp — the
+        // only field the decision looked at — which reordered a note in the
+        // "recently updated" list that the user had not touched. Nullable with
+        // no backfill: a null reads as "no remote version resolved yet", which
+        // is exactly right for every note that predates this column.
+        private val MIGRATION_16_17 = object : Migration(16, 17) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE `notes` ADD COLUMN `remoteSeenAt` INTEGER")
+            }
+        }
+
         internal val ALL_MIGRATIONS = arrayOf(
             MIGRATION_4_5,
             MIGRATION_5_6,
@@ -293,7 +306,8 @@ abstract class AppDatabase : RoomDatabase() {
             MIGRATION_12_14,
             MIGRATION_13_14,
             MIGRATION_14_15,
-            MIGRATION_15_16
+            MIGRATION_15_16,
+            MIGRATION_16_17
         )
     }
 }

--- a/app/src/main/java/com/markleaf/notes/data/local/entity/NoteEntity.kt
+++ b/app/src/main/java/com/markleaf/notes/data/local/entity/NoteEntity.kt
@@ -29,6 +29,10 @@ data class NoteEntity(
     val deletedAt: Long? = null,
     val sortOrder: Int = 0,
     val lastImportedAt: Long? = null,
+    /** Newest mirror-file timestamp the reconcile has resolved for this note.
+     *  Keeps conflict-settling bookkeeping out of `updatedAt`, which is the
+     *  user's own edit time and orders the notes list. */
+    val remoteSeenAt: Long? = null,
     /** When true the note lives in the passcode-gated "Locked notes" space and is
      *  hidden from every normal list, search, tag and export path. This is a
      *  UI-visibility gate — the body still sits in the same Room DB in plain
@@ -55,6 +59,7 @@ fun NoteEntity.toDomain(): Note {
         tags = emptyList(),
         sortOrder = sortOrder,
         lastImportedAt = lastImportedAt?.let { Instant.ofEpochMilli(it) },
+        remoteSeenAt = remoteSeenAt?.let { Instant.ofEpochMilli(it) },
         locked = locked,
         isConflictCopy = isConflictCopy
     )
@@ -74,6 +79,7 @@ fun Note.toEntity(): NoteEntity {
         deletedAt = deletedAt?.toEpochMilli(),
         sortOrder = sortOrder,
         lastImportedAt = lastImportedAt?.toEpochMilli(),
+        remoteSeenAt = remoteSeenAt?.toEpochMilli(),
         locked = locked,
         isConflictCopy = isConflictCopy
     )

--- a/app/src/main/java/com/markleaf/notes/data/sync/NoteFolderMirror.kt
+++ b/app/src/main/java/com/markleaf/notes/data/sync/NoteFolderMirror.kt
@@ -331,7 +331,8 @@ object NoteFolderMirror {
                             updatedAt = parsed.updatedAt ?: now,
                             pinned = parsed.pinned ?: false,
                             archived = parsed.archived ?: false,
-                            lastImportedAt = parsed.updatedAt ?: now
+                            lastImportedAt = parsed.updatedAt ?: now,
+                            remoteSeenAt = parsed.updatedAt ?: now
                         )
                         applyCreate(newNote)
                         created++
@@ -363,24 +364,17 @@ object NoteFolderMirror {
                             pinned = false,
                             archived = false,
                             lastImportedAt = fileTs,
+                            remoteSeenAt = fileTs,
                             isConflictCopy = true
                         )
                         applyCreate(duplicate)
-                        // Advance the local note past the file we just copied.
-                        // [reconcileAction] reads nothing but (updatedAt,
-                        // lastImportedAt, fileTs); taking the copy changed none
-                        // of them, so the next pass reached the same verdict and
-                        // made another copy — once a minute, without end (#217).
-                        // The body is untouched, so the local edit survives; the
-                        // bump only records "this file has been dealt with", and
-                        // leaves the pair resolving to Skip until one side moves
-                        // again.
-                        applyUpdate(
-                            existingNote!!.copy(
-                                updatedAt = fileTs.plusMillis(1),
-                                lastImportedAt = fileTs
-                            )
-                        )
+                        // Record that this remote version has been dealt with,
+                        // so the next pass resolves to Skip instead of taking
+                        // the copy again — once a minute, without end (#217).
+                        // Nothing the *user* owns is touched: `updatedAt` stays
+                        // put, so a note they never edited keeps its place in
+                        // the list (#222). Only `remoteSeenAt` moves.
+                        applyUpdate(existingNote!!.copy(remoteSeenAt = fileTs))
                         conflicts++
                     }
                     Reconcile.Overwrite -> {
@@ -392,7 +386,8 @@ object NoteFolderMirror {
                             updatedAt = fileTs,
                             pinned = parsed.pinned ?: note.pinned,
                             archived = parsed.archived ?: note.archived,
-                            lastImportedAt = fileTs
+                            lastImportedAt = fileTs,
+                            remoteSeenAt = fileTs
                         )
                         applyUpdate(merged)
                         updated++
@@ -433,6 +428,13 @@ object NoteFolderMirror {
         // user deleted (#148). Archived notes are *not* skipped: they stay hidden
         // but still take edits from the folder.
         if (existingNote.trashed) return Reconcile.SkipTrashed
+        // A remote version we have already resolved is not news, whatever it
+        // looks like next to `updatedAt`. This is what lets a conflict settle:
+        // the copy is taken once, and this pair goes quiet until one side
+        // actually moves again. Before it, the only lever was pushing
+        // `updatedAt` past the file — reordering a note nobody had edited (#222).
+        val remoteSeen = existingNote.remoteSeenAt?.toEpochMilli()
+        if (remoteSeen != null && fileTs.toEpochMilli() <= remoteSeen) return Reconcile.Skip
         val fileNewer =
             fileTs.toEpochMilli() > existingNote.updatedAt.toEpochMilli() + SLACK_MILLIS
         if (!fileNewer) return Reconcile.Skip

--- a/app/src/main/java/com/markleaf/notes/domain/model/Note.kt
+++ b/app/src/main/java/com/markleaf/notes/domain/model/Note.kt
@@ -21,6 +21,13 @@ data class Note(
      *  edited since the last sync and an incoming newer file is treated as a
      *  conflict (kept as a duplicate) rather than silently overwriting. */
     val lastImportedAt: Instant? = null,
+    /** The newest mirror-file timestamp the reconcile has already dealt with for
+     *  this note. Purely reconcile bookkeeping — it exists so settling a sync
+     *  conflict does not have to move [updatedAt], which is the user's "when did
+     *  I last change this" and drives the notes list order. Before it, the only
+     *  way to stop a conflict repeating every pass was to push [updatedAt] past
+     *  the file, which quietly reordered a note nobody had edited. */
+    val remoteSeenAt: Instant? = null,
     /** When true the note is in the passcode-gated "Locked notes" space: hidden
      *  from every normal list, search, tag view and sync/export path until the
      *  user unlocks that space. UI-visibility gate only — not encryption. */

--- a/app/src/test/java/com/markleaf/notes/data/sync/NoteFolderMirrorConflictLogicTest.kt
+++ b/app/src/test/java/com/markleaf/notes/data/sync/NoteFolderMirrorConflictLogicTest.kt
@@ -19,7 +19,8 @@ class NoteFolderMirrorConflictLogicTest {
         updatedAtMs: Long,
         lastImportMs: Long? = null,
         trashed: Boolean = false,
-        archived: Boolean = false
+        archived: Boolean = false,
+        remoteSeenMs: Long? = null
     ) = Note(
         id = "n1",
         title = "T",
@@ -29,7 +30,8 @@ class NoteFolderMirrorConflictLogicTest {
         updatedAt = Instant.ofEpochMilli(updatedAtMs),
         trashed = trashed,
         archived = archived,
-        lastImportedAt = lastImportMs?.let { Instant.ofEpochMilli(it) }
+        lastImportedAt = lastImportMs?.let { Instant.ofEpochMilli(it) },
+        remoteSeenAt = remoteSeenMs?.let { Instant.ofEpochMilli(it) }
     )
 
     private fun action(existing: Note?, fileTsMs: Long) =
@@ -188,23 +190,63 @@ class NoteFolderMirrorConflictLogicTest {
     fun absorbedConflict_isSkippedOnTheNextPass() {
         // The Conflict branch used to leave the local note and the file both
         // untouched, so this same call returned Conflict again on the next
-        // reconcile — once a minute, without end. importChanges now advances the
-        // local note past the file it copied; that state must resolve to Skip.
+        // reconcile — once a minute, without end. importChanges now records the
+        // remote version it copied; that state must resolve to Skip.
         val fileTsMs = 100_000L
-        val absorbed = note(updatedAtMs = fileTsMs + 1, lastImportMs = fileTsMs)
+        val absorbed = note(updatedAtMs = 20_000, lastImportMs = 10_000, remoteSeenMs = fileTsMs)
 
         assertEquals(Reconcile.Skip, action(absorbed, fileTsMs))
     }
 
     @Test
-    fun absorbedConflict_stillSeesTheNextRemoteEdit() {
-        // Settling must not deafen the note to genuine later changes. Nothing
-        // was edited locally after the copy was taken, so the next newer file is
-        // a clean overwrite rather than another conflict.
+    fun absorbedConflict_leavesTheUsersEditTimeAlone() {
+        // Settling used to work by pushing `updatedAt` past the file, which
+        // reordered a note in the list that the user had not touched (#222).
+        // The local edit time must be exactly what it was, and the pair must
+        // still be quiet.
         val fileTsMs = 100_000L
-        val absorbed = note(updatedAtMs = fileTsMs + 1, lastImportMs = fileTsMs)
+        val absorbed = note(updatedAtMs = 20_000, lastImportMs = 10_000, remoteSeenMs = fileTsMs)
 
-        assertEquals(Reconcile.Overwrite, action(absorbed, fileTsMs = 200_000))
+        assertEquals(Instant.ofEpochMilli(20_000), absorbed.updatedAt)
+        assertEquals(Reconcile.Skip, action(absorbed, fileTsMs))
+    }
+
+    @Test
+    fun absorbedConflict_stillSeesTheNextRemoteEdit() {
+        // Settling must not deafen the note to genuine later changes. The local
+        // side is still ahead of its last import, so a newer file is another
+        // conflict rather than a silent overwrite of the user's edit.
+        val absorbed = note(updatedAtMs = 20_000, lastImportMs = 10_000, remoteSeenMs = 100_000)
+
+        assertEquals(Reconcile.Conflict, action(absorbed, fileTsMs = 200_000))
+    }
+
+    @Test
+    fun remoteSeenAt_doesNotSuppressAnUnresolvedNewerFile() {
+        // The guard only silences versions already dealt with. A file newer than
+        // the one we resolved must still come through.
+        val note = note(updatedAtMs = 10_000, lastImportMs = 10_000, remoteSeenMs = 50_000)
+
+        assertEquals(Reconcile.Overwrite, action(note, fileTsMs = 100_000))
+    }
+
+    @Test
+    fun noRemoteSeenAt_behavesExactlyAsBefore() {
+        // Every note predating the column has a null here, and the migration
+        // deliberately does not backfill — so the whole existing matrix has to
+        // keep its answers.
+        assertEquals(
+            Reconcile.Overwrite,
+            action(note(updatedAtMs = 10_000, lastImportMs = 10_000), fileTsMs = 100_000)
+        )
+        assertEquals(
+            Reconcile.Conflict,
+            action(note(updatedAtMs = 20_000, lastImportMs = 10_000), fileTsMs = 100_000)
+        )
+        assertEquals(
+            Reconcile.Skip,
+            action(note(updatedAtMs = 5_000, lastImportMs = 0), fileTsMs = 1_000)
+        )
     }
 
     // --- #217: which timestamp represents the file --------------------------


### PR DESCRIPTION
Item 4 of #222.

## Why the old fix had to overload `updatedAt`

`reconcileAction` decided from `(updatedAt, lastImportedAt, fileTs)` and nothing else. Settling a conflict means making that function stop returning `Conflict` for the same file — so the only lever available was `updatedAt`, and #217 pushed it past the file's timestamp.

It works, and it costs: a note the user never edited jumps in the "recently updated" list, and a field that means *"when I last changed this"* is quietly carrying reconcile bookkeeping.

## `remoteSeenAt`

The newest mirror-file timestamp the reconcile has already resolved for a note.

```kotlin
val remoteSeen = existingNote.remoteSeenAt?.toEpochMilli()
if (remoteSeen != null && fileTs.toEpochMilli() <= remoteSeen) return Reconcile.Skip
```

A conflict copy is taken exactly once, and `updatedAt` is left alone.

| | Before | After |
|---|---|---|
| Conflict settles | `updatedAt = fileTs + 1ms` | `remoteSeenAt = fileTs` |
| Note's place in the list | moves | **unchanged** |
| Next reconcile | Skip | Skip |
| A genuinely newer file later | seen | seen |

`Create` and `Overwrite` record it too, so the field means what its name says rather than being set only on the conflict path.

## Migration safety

**DB v16 → v17**, nullable, **deliberately not backfilled**. Null reads as "no remote version resolved yet", so every note predating the column gets exactly the answers the matrix gave before. There is a test that walks the whole existing matrix with `remoteSeenAt == null` and asserts the old verdicts, and the migration test asserts the column comes through null on a legacy row.

## Verification

| Check | Result |
|---|---|
| `gradlew test` (debug + release) | 420 passed, 0 failed — 3 new |
| `gradlew lintRelease` | clean |
| `AppDatabaseMigrationTest` on `markleaf-tablet-api36` | pass — v4 → v17 |

The migration ran on a real Android runtime, since a schema change is the one thing JVM tests cannot cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)