### PR TITLE
test(sync): cover the mirror's real folder IO with an instrumented test (#222)

### DIFF
--- a/app/src/androidTest/java/com/markleaf/notes/data/sync/NoteFolderMirrorFolderTest.kt
+++ b/app/src/androidTest/java/com/markleaf/notes/data/sync/NoteFolderMirrorFolderTest.kt
@@ -1,0 +1,229 @@
+package com.markleaf.notes.data.sync
+
+import android.content.Context
+import androidx.documentfile.provider.DocumentFile
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.markleaf.notes.data.settings.SyncFileExtension
+import com.markleaf.notes.domain.model.Note
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+import java.time.Instant
+
+/**
+ * Exercises the mirror's real IO path — `listFiles`, the frontmatter head read,
+ * adoption, in-place rename, `ContentResolver` writes — over a live
+ * [DocumentFile] tree. Everything else about the mirror is pure logic covered by
+ * JVM tests; this covers the part that was only ever checked by hand (#222).
+ *
+ * The tree is [DocumentFile.fromFile] over a temp directory rather than a
+ * user-granted SAF folder, because a grant needs a person to tap it. That is
+ * faithful for reads, writes, listing and rename — all measured — with **one**
+ * divergence: `RawDocumentFile.createFile` appends an extension derived from the
+ * MIME type unconditionally (`Note.md` becomes `Note.md.md`), where a real
+ * provider strips a matching one first. So nothing here asserts on a name that
+ * `createFile` produced; the cases that would are written as "the file we must
+ * not touch is untouched", which is the property that actually matters. Name
+ * generation itself is covered by `MirrorFileNamesTest`.
+ */
+@RunWith(AndroidJUnit4::class)
+class NoteFolderMirrorFolderTest {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private lateinit var dir: File
+    private lateinit var folder: DocumentFile
+
+    @Before
+    fun setUp() {
+        dir = File(context.cacheDir, "mirror-folder-test").apply {
+            deleteRecursively()
+            mkdirs()
+        }
+        folder = DocumentFile.fromFile(dir)
+    }
+
+    @After
+    fun tearDown() {
+        dir.deleteRecursively()
+    }
+
+    // --- helpers ------------------------------------------------------------
+
+    private fun note(
+        id: String = "note-1",
+        title: String = "My Note",
+        body: String = "# My Note\n\nlocal body",
+        updatedAtMs: Long = 2_000,
+        lastImportMs: Long? = 2_000,
+        remoteSeenMs: Long? = null
+    ) = Note(
+        id = id,
+        title = title,
+        contentMarkdown = body,
+        excerpt = body.take(40),
+        createdAt = Instant.ofEpochMilli(1_000),
+        updatedAt = Instant.ofEpochMilli(updatedAtMs),
+        lastImportedAt = lastImportMs?.let { Instant.ofEpochMilli(it) },
+        remoteSeenAt = remoteSeenMs?.let { Instant.ofEpochMilli(it) }
+    )
+
+    private fun seed(name: String, contents: String): File =
+        File(dir, name).apply { writeText(contents) }
+
+    private fun write(note: Note, extension: SyncFileExtension = SyncFileExtension.MD) =
+        NoteFolderMirror.writeNoteInto(context, folder, note, extension)
+
+    private fun files() = dir.listFiles()?.map { it.name }?.sorted().orEmpty()
+
+    // --- the note's own file is rewritten, never duplicated ------------------
+
+    @Test
+    fun writesIntoTheFileCarryingTheNotesId() {
+        seed("My Note.md", "---\nmarkleaf_id: note-1\nupdated_at: 1970-01-01T00:00:01Z\n---\n\nstale")
+
+        assertTrue(write(note()))
+
+        assertEquals(listOf("My Note.md"), files())
+        val text = File(dir, "My Note.md").readText()
+        assertTrue("body was rewritten: $text", text.contains("local body"))
+        assertFalse("stale body is gone: $text", text.contains("stale"))
+    }
+
+    @Test
+    fun renamesInPlaceWhenTheTitleChanges() {
+        seed("Old Title.md", "---\nmarkleaf_id: note-1\n---\n\nold")
+
+        assertTrue(write(note(title = "New Title", body = "# New Title\n\nfresh")))
+
+        // Renamed, not deleted-and-recreated: a mid-flight sync client must
+        // never see the note vanish and reappear.
+        assertEquals(listOf("New Title.md"), files())
+        assertTrue(File(dir, "New Title.md").readText().contains("fresh"))
+    }
+
+    // --- #213: a lost id must not fork a new file every save ----------------
+
+    @Test
+    fun adoptsAnUnclaimedFileThatAlreadyCarriesTheNotesName() {
+        // What another app leaves behind when it rewrites a file without
+        // keeping our block. Before the fix this forked "My Note (2).md", then
+        // "(3)", on every auto-save.
+        seed("My Note.md", "# My Note\n\nwritten by another app")
+
+        assertTrue(write(note()))
+
+        assertEquals(listOf("My Note.md"), files())
+        val text = File(dir, "My Note.md").readText()
+        assertTrue("id was stamped back in: $text", text.contains("markleaf_id: note-1"))
+    }
+
+    @Test
+    fun neverTakesAFileClaimedByAnotherNote() {
+        val other = "---\nmarkleaf_id: someone-else\n---\n\ntheir body"
+        seed("My Note.md", other)
+
+        assertTrue(write(note()))
+
+        // The safety property is that the other note's file is untouched — not
+        // what the new file ends up called (see the class comment).
+        assertEquals(other, File(dir, "My Note.md").readText())
+        assertEquals(2, files().size)
+    }
+
+    @Test
+    fun preservesFrontmatterKeysWrittenByOtherTools() {
+        seed(
+            "My Note.md",
+            "---\nmarkleaf_id: note-1\nobsidian_tag: review\ncustom_color: blue\n---\n\nold"
+        )
+
+        assertTrue(write(note()))
+
+        val text = File(dir, "My Note.md").readText()
+        assertTrue("obsidian_tag survived: $text", text.contains("obsidian_tag: review"))
+        assertTrue("custom_color survived: $text", text.contains("custom_color: blue"))
+    }
+
+    // --- #222: a header we cannot read to the end is left alone -------------
+
+    @Test
+    fun leavesAFileAloneWhenItsHeaderRunsPastTheReadCap() {
+        // An open block bigger than the cap reads as "we cannot say who owns
+        // this". Claiming it would rewrite metadata never read; a duplicate file
+        // is the safe answer.
+        val huge = buildString {
+            append("---\n")
+            while (length < NoteFolderMirror.FRONTMATTER_MAX_BYTES + 4096) {
+                append("padding_key: padding value that goes on and on\n")
+            }
+        }
+        seed("My Note.md", huge)
+
+        assertTrue(write(note()))
+
+        assertEquals(huge, File(dir, "My Note.md").readText())
+        assertEquals(2, files().size)
+    }
+
+    // --- import ------------------------------------------------------------
+
+    @Test
+    fun importStampsOurIdIntoAFileThatHadNone() = runBlocking {
+        seed("Dropped In.md", "# Dropped In\n\nhand-dropped")
+        val created = mutableListOf<Note>()
+
+        val result = NoteFolderMirror.importChangesFrom(
+            context, folder, existing = emptyList(),
+            applyUpdate = { }, applyCreate = { created += it }
+        )
+
+        assertEquals(1, result.created)
+        assertEquals(1, created.size)
+        // Without the write-back the next pass would import it again as another
+        // new note — the #140 "same note appears 4-5 times" duplication.
+        val text = File(dir, "Dropped In.md").readText()
+        assertTrue("id stamped back: $text", text.contains("markleaf_id: ${created[0].id}"))
+    }
+
+    @Test
+    fun conflictKeepsTheLocalNoteAndSettlesOnTheNextPass() = runBlocking {
+        // Remote moved to 9s; local was edited at 5s after a 2s import.
+        seed(
+            "My Note.md",
+            "---\nmarkleaf_id: note-1\nupdated_at: 1970-01-01T00:00:09Z\n---\n\nremote body"
+        )
+        var local = note(updatedAtMs = 5_000, lastImportMs = 2_000)
+        val created = mutableListOf<Note>()
+
+        val first = NoteFolderMirror.importChangesFrom(
+            context, folder, existing = listOf(local),
+            applyUpdate = { local = it }, applyCreate = { created += it }
+        )
+
+        assertEquals(1, first.conflicts)
+        assertEquals(1, created.size)
+        assertTrue("copy is flagged", created[0].isConflictCopy)
+        assertEquals("remote body", created[0].contentMarkdown)
+        // The user's own note keeps its content and its edit time (#222).
+        assertEquals("# My Note\n\nlocal body", local.contentMarkdown)
+        assertEquals(Instant.ofEpochMilli(5_000), local.updatedAt)
+        assertNotNull("the resolved remote version is recorded", local.remoteSeenAt)
+
+        // #217: the same pass used to fire again every minute, without end.
+        val second = NoteFolderMirror.importChangesFrom(
+            context, folder, existing = listOf(local),
+            applyUpdate = { local = it }, applyCreate = { created += it }
+        )
+
+        assertEquals(0, second.conflicts)
+        assertEquals(1, created.size)
+    }
+}

--- a/app/src/main/java/com/markleaf/notes/data/sync/NoteFolderMirror.kt
+++ b/app/src/main/java/com/markleaf/notes/data/sync/NoteFolderMirror.kt
@@ -76,6 +76,24 @@ object NoteFolderMirror {
         extension: SyncFileExtension = SyncFileExtension.MD
     ): Boolean {
         val folder = DocumentFile.fromTreeUri(context, folderUri) ?: return false
+        return writeNoteInto(context, folder, note, extension)
+    }
+
+    /**
+     * [writeNote] once the folder has been resolved.
+     *
+     * Split out because resolving a user-granted tree Uri and operating on a
+     * folder are separate concerns — and because the second one is where all the
+     * behaviour lives. A test can hand this a [DocumentFile] over a temp
+     * directory and exercise the real matching, adoption and rename paths
+     * instead of leaving them to manual device smoke (#222).
+     */
+    internal fun writeNoteInto(
+        context: Context,
+        folder: DocumentFile,
+        note: Note,
+        extension: SyncFileExtension
+    ): Boolean {
         if (!folder.canWrite()) return false
 
         val mirrorFiles = folder.listFiles().filter { it.isFile && isMirrorFile(it.name) }
@@ -283,6 +301,20 @@ object NoteFolderMirror {
     ): ImportResult {
         val folder = DocumentFile.fromTreeUri(context, folderUri)
             ?: return ImportResult(0, 0, 0, 1)
+        return importChangesFrom(context, folder, existing, applyUpdate, applyCreate)
+    }
+
+    /**
+     * [importChanges] once the folder has been resolved — see [writeNoteInto]
+     * for why the resolution is a separate step.
+     */
+    internal suspend fun importChangesFrom(
+        context: Context,
+        folder: DocumentFile,
+        existing: List<Note>,
+        applyUpdate: suspend (Note) -> Unit,
+        applyCreate: suspend (Note) -> Unit
+    ): ImportResult {
         if (!folder.canRead()) return ImportResult(0, 0, 0, 1)
 
         var updated = 0


### PR DESCRIPTION
Item 5 of #222.

`writeNote` and `importChanges` were covered only by pure-logic JVM tests plus manual device smoke. The adoption fallback and the extra-keys preservation added in #220 are both IO-shaped — exactly the kind that regresses without anything going red.

## The seam

Root resolution is split from folder operation: `writeNoteInto` / `importChangesFrom` take a `DocumentFile`, and the public entry points resolve the tree Uri and delegate. That boundary earns its place independently — resolving a user-granted tree Uri is a different concern from operating on the folder it names — and it lets a test drive the real `listFiles`, head read, adoption, in-place rename and `ContentResolver` writes.

## Eight cases

| | |
|---|---|
| rewrite in place by id | no duplicate appears |
| rename on title change | renamed, not deleted-and-recreated |
| **adopt an unclaimed same-named file** | the #213 core |
| never take a file another note claims | the other file is byte-identical after |
| preserve another tool's frontmatter keys | `obsidian_tag`, `custom_color` survive |
| **leave a file alone when its header runs past the read cap** | the #222 fix |
| stamp our id into a hand-dropped file | the #140 duplication guard |
| **take a conflict copy exactly once** | the #217 fix, at the IO level |

## Why `DocumentFile.fromFile` and not a granted SAF folder

A grant needs a person to tap it, so the alternative was writing a test `DocumentsProvider` (~200 lines). I measured `RawDocumentFile` on-device first rather than assuming:

```
md.name=Note.md.md | txt.name=Plain.txt.txt
roundTrip=hello | renameTo=true | afterRename=Renamed.md
canWrite=true | isDirectory=true
```

Faithful for reads, writes, listing and rename. **One divergence**: `createFile` appends a MIME-derived extension unconditionally, where a real provider strips a matching one first.

So no assertion here reads a name `createFile` produced. Those two cases assert *"the file we must not touch is untouched"* instead — which is the property that actually matters, and is not weakened by the quirk. Name generation stays covered by `MirrorFileNamesTest`.

## Do the tests have teeth?

Eight passing on the first run is not evidence on its own, so I mutated the production code — made `findMirrorFile` skip the adoption fallback — and re-ran:

```
adoptsAnUnclaimedFileThatAlreadyCarriesTheNotesName FAILED
  expected:<[My Note.md]> but was:<[My Note (2).md.md, My Note.md]>
```

Exactly the #213 symptom. Reverted, all eight green again.

## Verification

| Check | Result |
|---|---|
| `NoteFolderMirrorFolderTest` on `markleaf-tablet-api36` | 8 passed |
| `gradlew test` (debug + release) | 420 passed |
| `gradlew lintRelease` | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)