### PR TITLE
fix(sync): keep multi-line frontmatter from other tools instead of erasing it

### DIFF
--- a/app/src/main/java/com/markleaf/notes/data/sync/NoteFolderMirror.kt
+++ b/app/src/main/java/com/markleaf/notes/data/sync/NoteFolderMirror.kt
@@ -93,7 +93,7 @@ object NoteFolderMirror {
         val wrote = runCatching {
             context.contentResolver.openOutputStream(target.uri, "wt")?.use { stream ->
                 BufferedWriter(OutputStreamWriter(stream, Charsets.UTF_8)).use { writer ->
-                    writer.write(SyncFrontmatter.encode(note, match?.extraKeys.orEmpty()))
+                    writer.write(SyncFrontmatter.encode(note, match?.extraEntries.orEmpty()))
                 }
             } ?: return@runCatching false
             true
@@ -149,7 +149,7 @@ object NoteFolderMirror {
 
     /**
      * Rewrite [file] in place with [note]'s frontmatter (incl. `markleaf_id`)
-     * prepended, preserving any [extraKeys] the file already carried. Used when
+     * prepended, preserving any [extraEntries] the file already carried. Used when
      * importing a file that had no `markleaf_id` so the next reconcile can match
      * it by id rather than re-creating a duplicate note (#140). Best-effort —
      * returns false on any IO failure without throwing, so a write-back hiccup
@@ -159,13 +159,13 @@ object NoteFolderMirror {
         context: Context,
         file: DocumentFile,
         note: Note,
-        extraKeys: Map<String, String>
+        extraEntries: List<String>
     ): Boolean {
         if (!file.canWrite()) return false
         return runCatching {
             context.contentResolver.openOutputStream(file.uri, "wt")?.use { stream ->
                 BufferedWriter(OutputStreamWriter(stream, Charsets.UTF_8)).use { writer ->
-                    writer.write(SyncFrontmatter.encode(note, extraKeys))
+                    writer.write(SyncFrontmatter.encode(note, extraEntries))
                 }
             } ?: return@runCatching false
             true
@@ -345,7 +345,7 @@ object NoteFolderMirror {
                         // frontmatter keys are preserved. Best-effort: a failed
                         // write just defers de-duplication to a later sync.
                         if (parsed.markleafId == null) {
-                            stampFrontmatter(context, file, newNote, parsed.unknownKeys)
+                            stampFrontmatter(context, file, newNote, parsed.unknownEntries)
                         }
                     }
                     Reconcile.Conflict -> {
@@ -500,7 +500,7 @@ object NoteFolderMirror {
         mirrorFiles.firstOrNull { peekFrontmatter(context, it)?.markleafId == noteId }
 
     /** A note's mirror file together with the frontmatter keys it already carries. */
-    private class MirrorMatch(val file: DocumentFile, val extraKeys: Map<String, String>)
+    private class MirrorMatch(val file: DocumentFile, val extraEntries: List<String>)
 
     /**
      * The file [note] should be written to. The canonical link is the
@@ -532,19 +532,19 @@ object NoteFolderMirror {
         var unclaimed: MirrorMatch? = null
         for (file in mirrorFiles) {
             val head = peekFrontmatter(context, file) ?: continue
-            if (head.markleafId == note.id) return MirrorMatch(file, head.extraKeys)
+            if (head.markleafId == note.id) return MirrorMatch(file, head.extraEntries)
             if (head.markleafId == null &&
                 unclaimed == null &&
                 MirrorFileNames.isPlainNameFor(file.name.orEmpty(), base)
             ) {
-                unclaimed = MirrorMatch(file, head.extraKeys)
+                unclaimed = MirrorMatch(file, head.extraEntries)
             }
         }
         return unclaimed
     }
 
     /** What a file's head says about which note owns it. */
-    private class HeadInfo(val markleafId: String?, val extraKeys: Map<String, String>)
+    private class HeadInfo(val markleafId: String?, val extraEntries: List<String>)
 
     /** Whether a head read has seen enough to answer that question. */
     internal enum class HeadScan {
@@ -628,7 +628,7 @@ object NoteFolderMirror {
                         limit = limit
                     )
                     when (verdict) {
-                        HeadScan.Done -> return@use HeadInfo(parsed.markleafId, parsed.unknownKeys)
+                        HeadScan.Done -> return@use HeadInfo(parsed.markleafId, parsed.unknownEntries)
                         HeadScan.Undetermined -> return@use null
                         HeadScan.NeedMore -> {
                             limit = (limit * 4).coerceAtMost(FRONTMATTER_MAX_BYTES)

--- a/app/src/main/java/com/markleaf/notes/data/sync/SyncFrontmatter.kt
+++ b/app/src/main/java/com/markleaf/notes/data/sync/SyncFrontmatter.kt
@@ -19,9 +19,16 @@ import java.time.format.DateTimeFormatter
  * # Body...
  * ```
  *
- * We don't ship a YAML parser — everything is `key: value` line-by-line.
- * Unrecognized keys are preserved opaquely so external tools can add their
- * own without us stomping on them on round-trip.
+ * We don't ship a YAML parser. Our own five keys are read as `key: value` on a
+ * single line, which is all we ever write. Everything else is treated as opaque
+ * text: an entry is a top-level line plus every continuation line under it, and
+ * it is carried back out byte-for-byte so external tools can keep their own
+ * frontmatter through a Markleaf round-trip.
+ *
+ * That opacity is the point. Reading unknown entries as `key: value` used to
+ * drop every continuation line, so the block sequence Obsidian writes tags in
+ * by default came back as a bare `tags:` with the items gone, and a nested map
+ * was flattened into bogus top-level keys (#226).
  */
 object SyncFrontmatter {
     private const val DELIMITER = "---"
@@ -37,7 +44,7 @@ object SyncFrontmatter {
      */
     private val BOM: String = Char(0xFEFF).toString()
 
-    /** Keys we own and emit explicitly — never echoed back from [Parsed.unknownKeys]. */
+    /** Keys we own and emit explicitly — never echoed back from [Parsed.unknownEntries]. */
     private val RESERVED_KEYS = setOf(
         "markleaf_id", "created_at", "updated_at", "pinned", "archived"
     )
@@ -51,7 +58,13 @@ object SyncFrontmatter {
         val pinned: Boolean?,
         val archived: Boolean?,
         val body: String,
-        val unknownKeys: Map<String, String>,
+        /**
+         * Frontmatter entries we don't model, each holding its top-level line and
+         * any continuation lines below it, exactly as they were read. Multi-line
+         * entries keep their newlines, so a block sequence or a nested map is one
+         * element here rather than several lossy ones (#226).
+         */
+        val unknownEntries: List<String>,
         /**
          * True only when a complete `---` … `---` block was found *and* its
          * contents read as metadata. False for a file with no block, for one
@@ -83,13 +96,16 @@ object SyncFrontmatter {
         fileContents.removePrefix(BOM).lineSequence().firstOrNull()?.trim() == DELIMITER
 
     /**
-     * @param extraKeys frontmatter keys written by other tools (Obsidian
-     *   aliases, tags, custom colors, …) that we don't model. Pass
-     *   [Parsed.unknownKeys] here when re-stamping a file we imported so a
-     *   round-trip through Markleaf doesn't strip them. Reserved keys are
-     *   ignored — we always emit our own canonical versions.
+     * @param extraEntries frontmatter entries written by other tools (Obsidian
+     *   aliases, tags, cssclasses, comments, …) that we don't model, each as the
+     *   verbatim text of one top-level entry. Pass [Parsed.unknownEntries] here
+     *   when re-stamping a file we imported so a round-trip through Markleaf
+     *   doesn't strip or reshape them. Entries are written out unchanged —
+     *   indentation, quoting and blank lines included — because we cannot know
+     *   what the owning tool needs. Reserved keys are ignored; we always emit
+     *   our own canonical versions.
      */
-    fun encode(note: Note, extraKeys: Map<String, String> = emptyMap()): String {
+    fun encode(note: Note, extraEntries: List<String> = emptyList()): String {
         val sb = StringBuilder()
         sb.append(DELIMITER).append('\n')
         sb.append("markleaf_id: ").append(note.id).append('\n')
@@ -97,9 +113,12 @@ object SyncFrontmatter {
         sb.append("updated_at: ").append(isoFormatter.format(note.updatedAt)).append('\n')
         sb.append("pinned: ").append(note.pinned).append('\n')
         sb.append("archived: ").append(note.archived).append('\n')
-        extraKeys.forEach { (key, value) ->
-            if (key !in RESERVED_KEYS) {
-                sb.append(key).append(": ").append(value).append('\n')
+        extraEntries.forEach { entry ->
+            val key = topLevelKeyOf(entry.lineSequence().firstOrNull().orEmpty())
+            // A null key is a comment or a line we can't read as `key: value`;
+            // we keep those too rather than deciding they don't matter.
+            if (key == null || key !in RESERVED_KEYS) {
+                sb.append(entry).append('\n')
             }
         }
         sb.append(DELIMITER).append('\n')
@@ -122,7 +141,7 @@ object SyncFrontmatter {
                 pinned = null,
                 archived = null,
                 body = text,
-                unknownKeys = emptyMap(),
+                unknownEntries = emptyList(),
                 hasFrontmatter = false,
                 blockClosed = false
             )
@@ -130,7 +149,7 @@ object SyncFrontmatter {
         val closeOffset = lines.subList(1, lines.size).indexOfFirst { it.trim() == DELIMITER }
         if (closeOffset < 0) {
             return Parsed(
-                null, null, null, null, null, text, emptyMap(),
+                null, null, null, null, null, text, emptyList(),
                 hasFrontmatter = false, blockClosed = false
             )
         }
@@ -141,7 +160,7 @@ object SyncFrontmatter {
         // swallowed as unparseable frontmatter and dropped on import (#222).
         if (!looksLikeMetadata(frontmatterLines)) {
             return Parsed(
-                null, null, null, null, null, text, emptyMap(),
+                null, null, null, null, null, text, emptyList(),
                 hasFrontmatter = false, blockClosed = true
             )
         }
@@ -156,27 +175,69 @@ object SyncFrontmatter {
         var updatedAt: Instant? = null
         var pinned: Boolean? = null
         var archived: Boolean? = null
-        val unknownKeys = mutableMapOf<String, String>()
+        val unknownEntries = mutableListOf<String>()
 
-        frontmatterLines.forEach { line ->
-            val colon = line.indexOf(':')
-            if (colon <= 0) return@forEach
-            val key = line.substring(0, colon).trim()
-            val value = line.substring(colon + 1).trim().trim('"').trim('\'')
+        groupEntries(frontmatterLines).forEach { entry ->
+            val key = topLevelKeyOf(entry.first())
+            if (key == null || key !in RESERVED_KEYS) {
+                unknownEntries += entry.joinToString("\n")
+                return@forEach
+            }
+            // Our own keys are single-line by construction, so the value comes
+            // from the opening line; nothing else can be hiding under them.
+            val value = valueOf(entry.first())
             when (key) {
                 "markleaf_id" -> markleafId = value.takeIf { it.isNotEmpty() }
                 "created_at" -> createdAt = parseInstantOrNull(value)
                 "updated_at" -> updatedAt = parseInstantOrNull(value)
                 "pinned" -> pinned = value.equals("true", ignoreCase = true)
                 "archived" -> archived = value.equals("true", ignoreCase = true)
-                else -> unknownKeys[key] = value
             }
         }
 
         return Parsed(
-            markleafId, createdAt, updatedAt, pinned, archived, body, unknownKeys,
+            markleafId, createdAt, updatedAt, pinned, archived, body, unknownEntries,
             hasFrontmatter = true, blockClosed = true
         )
+    }
+
+    /**
+     * Splits frontmatter into top-level entries. A line starting at column 0
+     * that isn't a sequence item opens a new entry; indented lines, `-` items
+     * and blank lines belong to the entry above them. Zero-indent sequences
+     * (`tags:` followed by unindented `- reading`) are legal YAML and common in
+     * the wild, which is why a leading `-` counts as a continuation rather than
+     * a new entry — the closing `---` never reaches here, it is stripped as the
+     * delimiter before this runs.
+     *
+     * This is not YAML parsing. It is only enough structure to know where one
+     * entry ends and the next begins, so we can hand the whole thing back.
+     */
+    private fun groupEntries(lines: List<String>): List<List<String>> {
+        val entries = mutableListOf<MutableList<String>>()
+        lines.forEach { line ->
+            if (entries.isEmpty() || !isContinuation(line)) {
+                entries += mutableListOf(line)
+            } else {
+                entries.last() += line
+            }
+        }
+        return entries
+    }
+
+    private fun isContinuation(line: String): Boolean =
+        line.isBlank() || line[0] == ' ' || line[0] == '\t' || line[0] == '-'
+
+    /** The key of a top-level entry, or null if the line isn't `key: …`. */
+    private fun topLevelKeyOf(line: String): String? {
+        val colon = line.indexOf(':')
+        return if (colon > 0) line.substring(0, colon).trim() else null
+    }
+
+    private fun valueOf(line: String): String {
+        val colon = line.indexOf(':')
+        if (colon < 0) return ""
+        return line.substring(colon + 1).trim().trim('"').trim('\'')
     }
 
     /**

--- a/app/src/test/java/com/markleaf/notes/data/sync/SyncFrontmatterTest.kt
+++ b/app/src/test/java/com/markleaf/notes/data/sync/SyncFrontmatterTest.kt
@@ -41,13 +41,12 @@ class SyncFrontmatterTest {
         // keys the file already carried — e.g. an Obsidian tag — must survive
         // the round-trip rather than being silently dropped.
         val note = sampleNote()
-        val extras = mapOf("obsidian_tag" to "review", "custom_color" to "blue")
+        val extras = listOf("obsidian_tag: review", "custom_color: blue")
 
         val parsed = SyncFrontmatter.decode(SyncFrontmatter.encode(note, extras))
 
         assertEquals(note.id, parsed.markleafId)
-        assertEquals("review", parsed.unknownKeys["obsidian_tag"])
-        assertEquals("blue", parsed.unknownKeys["custom_color"])
+        assertEquals(extras, parsed.unknownEntries)
         assertEquals(note.contentMarkdown, parsed.body)
     }
 
@@ -57,7 +56,7 @@ class SyncFrontmatterTest {
         // must emit our canonical markleaf_id once and never echo the stray one.
         val note = sampleNote()
 
-        val encoded = SyncFrontmatter.encode(note, mapOf("markleaf_id" to "STRAY"))
+        val encoded = SyncFrontmatter.encode(note, listOf("markleaf_id: STRAY"))
 
         assertEquals(1, encoded.split("markleaf_id:").size - 1)
         assertTrue(encoded.contains("markleaf_id: ${note.id}"))
@@ -117,8 +116,7 @@ class SyncFrontmatterTest {
         val parsed = SyncFrontmatter.decode(raw)
 
         assertEquals("x", parsed.markleafId)
-        assertEquals("review", parsed.unknownKeys["obsidian_tag"])
-        assertEquals("blue", parsed.unknownKeys["custom_color"])
+        assertEquals(listOf("obsidian_tag: review", "custom_color: blue"), parsed.unknownEntries)
     }
 
     @Test
@@ -301,5 +299,157 @@ class SyncFrontmatterTest {
 
         assertEquals(false, parsed.pinned)
         assertFalse(parsed.pinned ?: true)
+    }
+
+    // --- #226: entries we don't model are opaque, not `key: value` ------------
+    //
+    // Reading them line by line dropped every continuation line, so the block
+    // sequence Obsidian writes tags in by default came back as a bare `tags:`
+    // with the items gone. These pin the forms that used to be destroyed.
+
+    @Test
+    fun decode_keepsIndentedBlockSequenceWholeAndInOrder() {
+        val raw = """
+            ---
+            markleaf_id: x
+            tags:
+              - reading
+              - notes
+            ---
+            body
+        """.trimIndent()
+
+        val parsed = SyncFrontmatter.decode(raw)
+
+        assertEquals("x", parsed.markleafId)
+        assertEquals(listOf("tags:\n  - reading\n  - notes"), parsed.unknownEntries)
+    }
+
+    @Test
+    fun decode_keepsZeroIndentBlockSequenceWhole() {
+        // `tags:` followed by unindented `- reading` is legal YAML and common in
+        // the wild, so a leading `-` has to read as a continuation line.
+        val raw = """
+            ---
+            markleaf_id: x
+            tags:
+            - reading
+            - notes
+            ---
+            body
+        """.trimIndent()
+
+        val parsed = SyncFrontmatter.decode(raw)
+
+        assertEquals(listOf("tags:\n- reading\n- notes"), parsed.unknownEntries)
+    }
+
+    @Test
+    fun decode_keepsNestedMapWithoutInventingTopLevelKeys() {
+        // The indented child used to be captured as its own top-level key, so a
+        // round-trip both emptied the parent and grew a key nobody wrote.
+        val raw = """
+            ---
+            markleaf_id: x
+            cssclasses:
+              wide: true
+              theme: dark
+            ---
+            body
+        """.trimIndent()
+
+        val parsed = SyncFrontmatter.decode(raw)
+
+        assertEquals(1, parsed.unknownEntries.size)
+        assertEquals("cssclasses:\n  wide: true\n  theme: dark", parsed.unknownEntries.single())
+    }
+
+    @Test
+    fun decode_doesNotReadOurOwnKeysOutOfSomebodyElsesNesting() {
+        // `pinned` indented under another key belongs to that key, not to us.
+        val raw = """
+            ---
+            markleaf_id: x
+            obsidian_ui:
+              pinned: true
+            ---
+            body
+        """.trimIndent()
+
+        val parsed = SyncFrontmatter.decode(raw)
+
+        assertNull("nested pinned must not reach our field", parsed.pinned)
+        assertEquals(listOf("obsidian_ui:\n  pinned: true"), parsed.unknownEntries)
+    }
+
+    @Test
+    fun decode_keepsCommentsAndQuotingInForeignEntries() {
+        val raw = """
+            ---
+            markleaf_id: x
+            # personal notes
+            title: "Meeting: Q3"
+            ---
+            body
+        """.trimIndent()
+
+        val parsed = SyncFrontmatter.decode(raw)
+
+        // The comment used to be dropped and the quotes stripped, which left
+        // `title: Meeting: Q3` — no longer valid YAML.
+        assertEquals(listOf("# personal notes", "title: \"Meeting: Q3\""), parsed.unknownEntries)
+    }
+
+    @Test
+    fun encode_writesForeignEntriesBackByteForByte() {
+        val note = sampleNote()
+        val entries = listOf(
+            "tags:\n  - reading\n  - notes",
+            "aliases:\n  - log",
+            "# hand-written note"
+        )
+
+        val encoded = SyncFrontmatter.encode(note, entries)
+
+        assertTrue("block sequence verbatim", encoded.contains("tags:\n  - reading\n  - notes\n"))
+        assertTrue("second block verbatim", encoded.contains("aliases:\n  - log\n"))
+        assertTrue("comment kept", encoded.contains("# hand-written note\n"))
+    }
+
+    @Test
+    fun decode_encode_decode_isStableForARealisticObsidianFile() {
+        val original = """
+            ---
+            tags:
+              - reading
+              - notes
+            aliases:
+              - log
+            cssclasses:
+              wide: true
+            # written by hand
+            title: "Meeting: Q3"
+            ---
+
+            # Reading log
+        """.trimIndent()
+
+        val first = SyncFrontmatter.decode(original)
+        val note = sampleNote().copy(contentMarkdown = first.body)
+        val second = SyncFrontmatter.decode(SyncFrontmatter.encode(note, first.unknownEntries))
+
+        assertEquals("entries survive a full round-trip", first.unknownEntries, second.unknownEntries)
+        assertEquals("body survives", first.body, second.body)
+        assertEquals(note.id, second.markleafId)
+        assertEquals(
+            listOf(
+                "tags:\n  - reading\n  - notes",
+                "aliases:\n  - log",
+                "cssclasses:\n  wide: true",
+                "# written by hand",
+                "title: \"Meeting: Q3\""
+            ),
+            first.unknownEntries
+        )
     }
 }


### PR DESCRIPTION
Fixes #226.

## The bug

`decode` read frontmatter one line at a time and skipped any line whose first colon wasn't past position 0 — which is **every `  - item` continuation line**. So an Obsidian file written the way Obsidian writes it by default came back out of the next Markleaf save with its tags gone.

| Input | Before | After |
|---|---|---|
| `tags:`<br>`  - reading`<br>`  - notes` | `tags: ` — items **erased** | unchanged |
| `tags:`<br>`- reading` (zero-indent, legal YAML) | `tags: ` — items **erased** | unchanged |
| `cssclasses:`<br>`  wide: true` | `cssclasses: ` **+ bogus top-level** `wide: true` | unchanged |
| `# personal notes` | dropped | kept |
| `title: "Meeting: Q3"` | `title: Meeting: Q3` — invalid YAML | unchanged |
| `tags: [reading]` | fine | fine |

No error, no undo, on the first sync after pointing Markleaf at a vault.

## The fix

Do what `unknownKeys` was already trying to be — **opaque**. Unknown frontmatter is grouped into top-level entries, each carrying its own continuation lines, and written back byte-for-byte. Our own five keys are still parsed as single-line `key: value`, because that is all we ever write.

```kotlin
Parsed.unknownKeys: Map<String, String>   →   Parsed.unknownEntries: List<String>
encode(note, extraKeys: Map<…>)           →   encode(note, extraEntries: List<String>)
```

Neither was ever read *by key* in production code — both were passed straight through `MirrorMatch` / `HeadInfo` / `stampFrontmatter` — so for every caller this is a shape change, not a behaviour change.

Two things fall out of it: a leading `-` counts as a continuation so zero-indent sequences survive, and duplicate foreign keys are no longer silently deduplicated by the map.

## Deliberately not a YAML parser

`groupEntries` only decides where one entry ends and the next begins. It does not interpret anything, which is the point — we cannot know what the owning tool needs, so we hand it back untouched. This sits next to the `looksLikeMetadata` heuristic from #222, which already reasoned about the same continuation lines for a different question.

## Tests

Seven new cases pin the forms that used to be destroyed: indented and zero-indent block sequences, a nested map, a nested `pinned:` that must **not** reach our own field, comments and quoted scalars, verbatim write-back, and a full `decode → encode → decode` round-trip of a realistic Obsidian file.

These are new coverage rather than adjusted assertions — the old API returned a `Map`, so none of them could have compiled against it. `SyncFrontmatterTest` had only single-line unknown keys (`obsidian_tag: review`) before.

## Verification

- `:app:testDebugUnitTest` — **433 tests, 0 failures, 0 skipped**
- `:app:testReleaseUnitTest` — **369 tests, 0 failures, 0 skipped**
- `SyncFrontmatterTest` 27/27, alongside the #222 metadata-detection cases it now shares the file with
- `:app:lintRelease` — clean

## Docs stay narrow for now

The README and landing copy still say multi-line properties are not preserved. That is true of every **released** build, so widening it belongs to the release that ships this — noted on #226.

## Noticed while auditing, not touched

`decode` finds the closing delimiter with `it.trim() == DELIMITER`, so an indented `---` inside a YAML block scalar reads as the end of the frontmatter and truncates it. That predates this change and is unaffected by it; the `trim()` is also what lets a trailing-space `--- ` close a block. Happy to file it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)