### PR TITLE
feat(preview): make the checkbox in reading view tappable

### DIFF
--- a/app/src/main/java/com/markleaf/notes/core/markdown/CommonMarkPreviewAdapter.kt
+++ b/app/src/main/java/com/markleaf/notes/core/markdown/CommonMarkPreviewAdapter.kt
@@ -36,6 +36,7 @@ import org.commonmark.node.SoftLineBreak
 import org.commonmark.node.StrongEmphasis
 import org.commonmark.node.Text
 import org.commonmark.node.ThematicBreak
+import org.commonmark.parser.IncludeSourceSpans
 import org.commonmark.parser.Parser
 import com.markleaf.notes.util.WikilinkExtractor
 
@@ -57,6 +58,11 @@ import com.markleaf.notes.util.WikilinkExtractor
 internal object CommonMarkPreviewAdapter {
 
     private val parser: Parser = Parser.builder()
+        // Block spans give each ListItem the line it started on, which is what
+        // lets a preview checkbox tap flip the right `[ ]` in the source (#219).
+        // Block-level is enough — we never need to locate an inline node — and
+        // it keeps the extra bookkeeping off every piece of text.
+        .includeSourceSpans(IncludeSourceSpans.BLOCKS)
         .extensions(
             listOf(
                 YamlFrontMatterExtension.create(),
@@ -172,7 +178,13 @@ internal object CommonMarkPreviewAdapter {
                     TaskState.TODO -> PreviewLineType.CHECKBOX_TODO
                     TaskState.NONE -> PreviewLineType.BULLET
                 }
-                out += PreviewLine(text = text, type = type, segments = segments)
+                out += PreviewLine(
+                    text = text,
+                    type = type,
+                    segments = segments,
+                    // Only task items need it, and only they can be tapped.
+                    sourceLine = if (marker == TaskState.NONE) null else sourceLineOf(item)
+                )
             }
             item = item.next
         }
@@ -345,6 +357,14 @@ internal object CommonMarkPreviewAdapter {
         val segments = collectInlineSegments(node)
         return text to segments
     }
+
+    /**
+     * The 0-based source line a block started on, or null when spans are absent
+     * (a hand-built node in a test, say). Never guessed — a wrong line here
+     * would toggle somebody else's checkbox.
+     */
+    private fun sourceLineOf(node: Node): Int? =
+        node.sourceSpans.firstOrNull()?.lineIndex
 
     private fun detectTaskMarker(item: ListItem): TaskState {
         // commonmark-ext-task-list-items inserts a TaskListItemMarker as the

--- a/app/src/main/java/com/markleaf/notes/core/markdown/MarkdownEditActions.kt
+++ b/app/src/main/java/com/markleaf/notes/core/markdown/MarkdownEditActions.kt
@@ -36,6 +36,32 @@ object MarkdownEditActions {
         return value.copy(text = updated, selection = value.selection)
     }
 
+    /**
+     * Flip the task marker on [lineIndex] (0-based) of [markdown] and return the
+     * new text, or null when that line is not a checklist item (#219).
+     *
+     * Used by the preview, where the tap carries a line number rather than a
+     * caret. Returning null instead of guessing matters: a preview built from
+     * slightly older text could point at a line that has since become something
+     * else, and silently rewriting it would corrupt the note. Exactly one
+     * character changes, so line endings, indentation and everything else in the
+     * document are left byte-for-byte alone.
+     */
+    fun toggleTaskAtLine(markdown: String, lineIndex: Int): String? {
+        if (lineIndex < 0) return null
+        var start = 0
+        repeat(lineIndex) {
+            val newline = markdown.indexOf('\n', start)
+            if (newline < 0) return null
+            start = newline + 1
+        }
+        val end = markdown.indexOf('\n', start).takeIf { it >= 0 } ?: markdown.length
+        val match = checkboxPattern.find(markdown.substring(start, end)) ?: return null
+        val box = start + match.value.indexOf('[') + 1
+        val flipped = if (markdown[box] == ' ') 'x' else ' '
+        return markdown.substring(0, box) + flipped + markdown.substring(box + 1)
+    }
+
     fun markdownLink(value: TextFieldValue): TextFieldValue {
         val selected = selectedText(value)
         return if (selected.isBlank()) {

--- a/app/src/main/java/com/markleaf/notes/core/markdown/SimpleMarkdownPreview.kt
+++ b/app/src/main/java/com/markleaf/notes/core/markdown/SimpleMarkdownPreview.kt
@@ -82,7 +82,15 @@ data class PreviewLine(
     val extra: String? = null,
     val segments: List<PreviewInlineSegment> = emptyList(),
     /** Only set when [type] is [PreviewLineType.TABLE]. */
-    val tableData: TableData? = null
+    val tableData: TableData? = null,
+    /**
+     * 0-based index of the source line this row came from, when we can say for
+     * certain. Only the checklist rows set it today: tapping a checkbox in the
+     * preview has to flip the `[ ]` on exactly one line of the note, and
+     * counting checkboxes would drift the moment a `- [ ]` appeared inside a
+     * fenced code block (#219). Null means "don't offer to edit this row".
+     */
+    val sourceLine: Int? = null
 )
 
 object SimpleMarkdownPreview {

--- a/app/src/main/java/com/markleaf/notes/core/markdown/preview/MarkdownPreviewList.kt
+++ b/app/src/main/java/com/markleaf/notes/core/markdown/preview/MarkdownPreviewList.kt
@@ -76,7 +76,8 @@ fun MarkdownPreviewList(
     contentPadding: PaddingValues = PaddingValues(horizontal = 16.dp, vertical = 12.dp),
     listState: LazyListState = rememberLazyListState(),
     onWikilinkClick: (String) -> Unit = {},
-    onImageLongPress: (path: String, currentAlt: String) -> Unit = { _, _ -> }
+    onImageLongPress: (path: String, currentAlt: String) -> Unit = { _, _ -> },
+    onToggleTask: ((sourceLine: Int) -> Unit)? = null
 ) {
     val scope = rememberCoroutineScope()
     // Footnote ref → def: clicking a superscript `[^N]` scrolls the matching
@@ -100,7 +101,8 @@ fun MarkdownPreviewList(
                 line = line,
                 onWikilinkClick = onWikilinkClick,
                 onImageLongPress = onImageLongPress,
-                onFootnoteRefClick = onFootnoteRefClick
+                onFootnoteRefClick = onFootnoteRefClick,
+                onToggleTask = onToggleTask
             )
         }
     }
@@ -111,8 +113,14 @@ fun PreviewLineRenderer(
     line: PreviewLine,
     onWikilinkClick: (String) -> Unit = {},
     onImageLongPress: (path: String, currentAlt: String) -> Unit = { _, _ -> },
-    onFootnoteRefClick: (String) -> Unit = {}
+    onFootnoteRefClick: (String) -> Unit = {},
+    onToggleTask: ((sourceLine: Int) -> Unit)? = null
 ) {
+    // Only a row that knows its own source line can be toggled; see
+    // PreviewLine.sourceLine for why we refuse to guess (#219).
+    val toggle: (() -> Unit)? = line.sourceLine?.let { source ->
+        onToggleTask?.let { handler -> { handler(source) } }
+    }
     when (line.type) {
         PreviewLineType.H1 -> Text(
             text = line.text,
@@ -143,13 +151,15 @@ fun PreviewLineRenderer(
             leadingMarker = "☑ ",
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             onWikilinkClick = onWikilinkClick,
-            onFootnoteRefClick = onFootnoteRefClick
+            onFootnoteRefClick = onFootnoteRefClick,
+            onMarkerClick = toggle
         )
         PreviewLineType.CHECKBOX_TODO -> InlineMarkdownText(
             line = line,
             leadingMarker = "☐ ",
             onWikilinkClick = onWikilinkClick,
-            onFootnoteRefClick = onFootnoteRefClick
+            onFootnoteRefClick = onFootnoteRefClick,
+            onMarkerClick = toggle
         )
         PreviewLineType.CODE_BLOCK -> MarkdownCodeBlock(line.text, line.extra)
         PreviewLineType.BODY -> InlineMarkdownText(
@@ -212,7 +222,14 @@ internal fun InlineMarkdownText(
      * separate Text) so wrapping and click offsets stay aligned.
      */
     leadingMarker: String = "",
-    color: Color = MaterialTheme.colorScheme.onBackground
+    color: Color = MaterialTheme.colorScheme.onBackground,
+    /**
+     * When set, [leadingMarker] becomes a clickable region. Carried inside the
+     * same AnnotatedString as the text rather than split into its own composable
+     * so the row lays out exactly as before — the checklist goldens must not
+     * move for a change that only adds an interaction (#219).
+     */
+    onMarkerClick: (() -> Unit)? = null
 ) {
     // Some line types (and the legacy hand-rolled parser) can leave segments
     // empty even when text is present — fall back to the raw text so we never
@@ -224,7 +241,8 @@ internal fun InlineMarkdownText(
         segments = segments,
         leadingMarker = leadingMarker,
         onWikilinkClick = onWikilinkClick,
-        onFootnoteRefClick = onFootnoteRefClick
+        onFootnoteRefClick = onFootnoteRefClick,
+        onMarkerClick = onMarkerClick
     )
     // Links are now embedded as LinkAnnotations in `annotated`, so a plain Text
     // handles styling, clicks, and accessibility — no offset-mapped onClick.
@@ -246,13 +264,30 @@ private fun inlineAnnotatedString(
     segments: List<PreviewInlineSegment>,
     leadingMarker: String = "",
     onWikilinkClick: (String) -> Unit = {},
-    onFootnoteRefClick: (String) -> Unit = {}
+    onFootnoteRefClick: (String) -> Unit = {},
+    onMarkerClick: (() -> Unit)? = null
 ): AnnotatedString {
     // Captured by the LinkAnnotation click listeners built below, so it must be
     // resolved before buildAnnotatedString rather than at the Text call site.
     val context = LocalContext.current
     return buildAnnotatedString {
-        if (leadingMarker.isNotEmpty()) append(leadingMarker)
+        if (leadingMarker.isNotEmpty()) {
+            if (onMarkerClick == null) {
+                append(leadingMarker)
+            } else {
+                // No styles: the checkbox already looks like a control, and
+                // link colouring here would read as a hyperlink and change
+                // every checklist golden.
+                withLink(
+                    LinkAnnotation.Clickable(
+                        tag = TASK_MARKER_TAG,
+                        linkInteractionListener = { onMarkerClick() }
+                    )
+                ) {
+                    append(leadingMarker)
+                }
+            }
+        }
         segments.forEach { segment ->
             when (segment.type) {
                 PreviewInlineType.TEXT -> append(segment.text)
@@ -340,6 +375,7 @@ private fun inlineAnnotatedString(
 private const val WIKILINK_TAG = "wikilink"
 private const val LINK_TAG = "link"
 private const val FOOTNOTE_REF_TAG = "footnote_ref"
+private const val TASK_MARKER_TAG = "task_marker"
 
 /**
  * Returns the index of the first `FOOTNOTE_DEF` line whose label matches [label],

--- a/app/src/main/java/com/markleaf/notes/feature/editor/EditorScreen.kt
+++ b/app/src/main/java/com/markleaf/notes/feature/editor/EditorScreen.kt
@@ -552,6 +552,18 @@ fun EditorScreen(
                         modifier = Modifier.weight(1f, fill = false),
                         contentPadding = PaddingValues(horizontal = 20.dp, vertical = 12.dp),
                         listState = previewListState,
+                        // Tapping a checkbox in the preview flips it in the
+                        // source (#219). The preview is rebuilt from the text,
+                        // so the row redraws on its own; a null result means the
+                        // line stopped being a task item since this preview was
+                        // built, and the tap is dropped rather than guessed at.
+                        onToggleTask = { sourceLine ->
+                            MarkdownEditActions.toggleTaskAtLine(editorState.text, sourceLine)
+                                ?.let { updated ->
+                                    editorState = editorState.copy(text = updated)
+                                    if (isLoaded) saveTrigger++
+                                }
+                        },
                         onWikilinkClick = { title ->
                             coroutineScope.launch {
                                 val existing = db.noteDao().getNoteByTitle(title)

--- a/app/src/test/java/com/markleaf/notes/core/markdown/MarkdownEditActionsTest.kt
+++ b/app/src/test/java/com/markleaf/notes/core/markdown/MarkdownEditActionsTest.kt
@@ -3,6 +3,8 @@ package com.markleaf.notes.core.markdown
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class MarkdownEditActionsTest {
@@ -450,5 +452,87 @@ class MarkdownEditActionsTest {
         )
         assertEquals("hello **bold**", result.text)
         assertEquals(TextRange(8), result.selection)
+    }
+
+    // --- #219: toggling a task from the preview, by line number ------------
+
+    @Test
+    fun toggleTaskAtLine_flipsTodoToDone() {
+        val markdown = """
+            # Plan
+
+            - [ ] Tag the release
+            - [ ] Write store note
+        """.trimIndent()
+
+        val result = MarkdownEditActions.toggleTaskAtLine(markdown, 2)
+
+        assertEquals(
+            """
+                # Plan
+
+                - [x] Tag the release
+                - [ ] Write store note
+            """.trimIndent(),
+            result
+        )
+    }
+
+    @Test
+    fun toggleTaskAtLine_flipsDoneBackToTodo() {
+        assertEquals("- [ ] done", MarkdownEditActions.toggleTaskAtLine("- [x] done", 0))
+    }
+
+    @Test
+    fun toggleTaskAtLine_treatsUppercaseXAsDone() {
+        assertEquals("- [ ] done", MarkdownEditActions.toggleTaskAtLine("- [X] done", 0))
+    }
+
+    @Test
+    fun toggleTaskAtLine_handlesIndentedItems() {
+        val markdown = """
+            - outer
+              - [ ] nested
+        """.trimIndent()
+
+        assertEquals(
+            """
+                - outer
+                  - [x] nested
+            """.trimIndent(),
+            MarkdownEditActions.toggleTaskAtLine(markdown, 1)
+        )
+    }
+
+    @Test
+    fun toggleTaskAtLine_returnsNullWhenTheLineIsNotATask() {
+        // A preview built from slightly older text can point at a line that has
+        // since become prose; rewriting it anyway would corrupt the note.
+        val markdown = """
+            just text
+            - [ ] task
+        """.trimIndent()
+
+        assertNull(MarkdownEditActions.toggleTaskAtLine(markdown, 0))
+    }
+
+    @Test
+    fun toggleTaskAtLine_returnsNullWhenTheLineDoesNotExist() {
+        assertNull(MarkdownEditActions.toggleTaskAtLine("- [ ] task", 5))
+        assertNull(MarkdownEditActions.toggleTaskAtLine("- [ ] task", -1))
+    }
+
+    @Test
+    fun toggleTaskAtLine_changesExactlyOneCharacter() {
+        // Windows line endings and trailing spaces have to survive: the note is
+        // mirrored to a file, and reflowing it would surface as a whole-file
+        // diff in whatever syncs that folder.
+        val markdown = "- [ ] a\r\n- [ ] b  \r\n"
+
+        val result = MarkdownEditActions.toggleTaskAtLine(markdown, 1)!!
+
+        assertEquals(markdown.length, result.length)
+        assertEquals(1, markdown.indices.count { markdown[it] != result[it] })
+        assertTrue(result.contains("- [x] b  \r\n"))
     }
 }

--- a/app/src/test/java/com/markleaf/notes/core/markdown/SimpleMarkdownPreviewTest.kt
+++ b/app/src/test/java/com/markleaf/notes/core/markdown/SimpleMarkdownPreviewTest.kt
@@ -370,4 +370,53 @@ class SimpleMarkdownPreviewTest {
         val wikilink = row?.get(1)?.firstOrNull { it.type == PreviewInlineType.WIKILINK }
         assertEquals("Another Note", wikilink?.text)
     }
+
+    // --- #219: checklist rows carry the source line they came from ---------
+
+    @Test
+    fun parse_tagsChecklistRowsWithTheirSourceLine() {
+        val markdown = """
+            # Plan
+
+            - [ ] first
+            - [x] second
+        """.trimIndent()
+
+        val lines = SimpleMarkdownPreview.parse(markdown)
+        val checks = lines.filter {
+            it.type == PreviewLineType.CHECKBOX_TODO || it.type == PreviewLineType.CHECKBOX_DONE
+        }
+
+        assertEquals(listOf(2, 3), checks.map { it.sourceLine })
+    }
+
+    @Test
+    fun parse_leavesPlainBulletsWithoutASourceLine() {
+        // Only rows we offer to edit carry one, so a tap can never land on a
+        // bullet that has no `[ ]` to flip.
+        val lines = SimpleMarkdownPreview.parse("- plain bullet")
+
+        assertEquals(PreviewLineType.BULLET, lines.first().type)
+        assertEquals(null, lines.first().sourceLine)
+    }
+
+    @Test
+    fun parse_sourceLineSurvivesACheckboxInsideAFencedCodeBlock() {
+        // The reason we ask the parser instead of counting checkboxes: a
+        // `- [ ]` in a code block is not a task, so an index-based mapping
+        // would slide by one from here on.
+        val markdown = """
+            ```
+            - [ ] not a task
+            ```
+
+            - [ ] real task
+        """.trimIndent()
+
+        val lines = SimpleMarkdownPreview.parse(markdown)
+        val check = lines.single { it.type == PreviewLineType.CHECKBOX_TODO }
+
+        assertEquals("real task", check.text)
+        assertEquals(4, check.sourceLine)
+    }
 }

--- a/app/src/testDebug/java/com/markleaf/notes/core/markdown/preview/MarkdownTaskToggleClickTest.kt
+++ b/app/src/testDebug/java/com/markleaf/notes/core/markdown/preview/MarkdownTaskToggleClickTest.kt
@@ -1,0 +1,99 @@
+package com.markleaf.notes.core.markdown.preview
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.click
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performTouchInput
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.markleaf.notes.core.markdown.SimpleMarkdownPreview
+import com.markleaf.notes.ui.theme.MarkleafTheme
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * Regression net for #219: the checkbox drawn in Preview must be tappable, and
+ * the tap has to name the right source line. Before the fix the glyph was a
+ * plain text prefix with nothing behind it, so a tap did nothing at all.
+ *
+ * Only the marker is clickable, not the whole row — long-pressing the item text
+ * to select it has to keep working.
+ */
+@RunWith(AndroidJUnit4::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(sdk = [33], qualifiers = "w360dp-h640dp-mdpi")
+class MarkdownTaskToggleClickTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    private fun preview(markdown: String, onToggle: (Int) -> Unit) {
+        composeRule.setContent {
+            MarkleafTheme(darkTheme = false, dynamicColor = false) {
+                MarkdownPreviewList(
+                    lines = SimpleMarkdownPreview.parse(markdown),
+                    onToggleTask = onToggle
+                )
+            }
+        }
+    }
+
+    @Test
+    fun tappingTheCheckbox_reportsThatRowsSourceLine() {
+        var toggled: Int? = null
+        preview("# Plan\n\n- [ ] first\n- [ ] second") { toggled = it }
+
+        composeRule.onNodeWithText("☐ second").performTouchInput {
+            click(centerLeft.copy(x = 4f))
+        }
+
+        assertEquals(3, toggled)
+    }
+
+    @Test
+    fun tappingACompletedCheckbox_reportsItsSourceLineToo() {
+        var toggled: Int? = null
+        preview("- [x] done") { toggled = it }
+
+        composeRule.onNodeWithText("☑ done").performTouchInput {
+            click(centerLeft.copy(x = 4f))
+        }
+
+        assertEquals(0, toggled)
+    }
+
+    @Test
+    fun tappingTheItemText_doesNotToggle() {
+        // The marker is the control; the text stays selectable.
+        var toggled: Int? = null
+        preview("- [ ] a much longer task label") { toggled = it }
+
+        composeRule.onNodeWithText("☐ a much longer task label").performTouchInput {
+            click(centerRight.copy(x = width - 4f))
+        }
+
+        assertNull(toggled)
+    }
+
+    @Test
+    fun withoutAHandler_theCheckboxIsInert() {
+        // Snapshot tests and any other caller that passes no handler must not
+        // gain a clickable region — that is what keeps the goldens honest.
+        composeRule.setContent {
+            MarkleafTheme(darkTheme = false, dynamicColor = false) {
+                MarkdownPreviewList(lines = SimpleMarkdownPreview.parse("- [ ] task"))
+            }
+        }
+
+        composeRule.onNodeWithText("☐ task").performTouchInput {
+            click(centerLeft.copy(x = 4f))
+        }
+        // Nothing to assert beyond "this did not crash and nothing was called";
+        // the handler is absent, so a click must simply be ignored.
+        composeRule.onNodeWithText("☐ task").assertExists()
+    }
+}


### PR DESCRIPTION
Fixes #219.

## Why

A checklist rendered in Preview drew a checkbox that did nothing. Ticking an item meant switching back to the editor and editing the `[ ]` by hand — that reads as a broken control, not a missing feature, since Obsidian, GitHub and Joplin all toggle from the reading view.

v2.28.0's **open notes in preview** (#200) sharpened it: users who now stay in preview had a read-only checklist, which is the one thing a checklist is for.

## Always on, no setting

Recent releases (#188, #191, #192, #200) each added an opt-in switch defaulting to the old behaviour. That pattern is for *new behaviour*. This completes an interaction the UI already depicts, and a switch nobody turns on would leave the checkbox looking broken for everyone who never finds it. Flagged as a decision on the issue; going with always-on deliberately.

## How it knows which line to flip

| | |
|---|---|
| **Parser** | now runs with `IncludeSourceSpans.BLOCKS`, so every `ListItem` carries the line it started on |
| **Model** | checklist rows carry it as `PreviewLine.sourceLine`; plain bullets get `null`, so only rows we can edit are offered |
| **Toggle** | `MarkdownEditActions.toggleTaskAtLine` flips the marker and returns `null` when the line is no longer a task item |

Counting checkboxes would have been simpler and wrong: a `- [ ]` inside a fenced code block is not a task, so an index-based mapping slides by one from there on. There is a test for exactly that case.

Returning `null` matters too — a preview built from slightly older text can point at a line that has since become prose, and rewriting it anyway would corrupt the note. Exactly one character changes, so CRLF endings and trailing whitespace survive; the note is mirrored to a file, and reflowing it would surface as a whole-file diff in whatever syncs that folder.

## Marker only, and the goldens do not move

Only the marker is clickable, not the row, so long-pressing item text to select it still works.

It is a `LinkAnnotation` inside the existing `AnnotatedString` — the mechanism this file already uses for links, wikilinks and footnotes — rather than a separate composable. That keeps the row laying out exactly as before, which matters because `verifyRoborazziDebug` is a hard gate and `lists_light` / `list_inline_formatting_light` both render checkboxes.

**Verified rather than assumed:** the set of Roborazzi failures on this machine is byte-identical with and without the change — 20 pre-existing local diffs both ways, and neither list contains either checklist golden.

## Verification

- `:app:testDebugUnitTest` — **447 tests, 0 failures, 0 skipped** (14 new)
- `:app:testReleaseUnitTest` — **379 tests, 0 failures, 0 skipped**
- `:app:lintRelease` — clean
- Roborazzi failure-set diff before/after — **empty in both directions**
- **On `markleaf-phone-api36`:** tapping `☐ alpha` turned it to `☑`, `☐ beta` stayed put, and the note list showed the saved source as `- [x] alpha` / `- [ ] beta`

## New tests

`toggleTaskAtLine` — todo↔done, uppercase `X`, indented items, non-task line returns null, out-of-range returns null, single-character change with CRLF preserved.
`sourceLine` — tagged on checklist rows, absent on plain bullets, correct past a fenced code block containing `- [ ]`.
`MarkdownTaskToggleClickTest` — tapping the marker reports the right source line, tapping the item text does not toggle, and a preview built without a handler stays inert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)