### PR TITLE
docs: make the instrumented tests a written local gate, not a hope (#235)

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -114,6 +114,76 @@ mapping and six-locale notes, and verifies the APK certificate before
 publishing. GitHub remains the canonical Roborazzi and emulator-smoke runner;
 GitLab is an independent build and binary-distribution path.
 
+## Instrumented Tests — Local Gate, Not CI
+
+**CI does not run `connectedDebugAndroidTest`.** Nothing in
+`app/src/androidTest/` is executed by any pipeline. Run it by hand before
+cutting a release:
+
+```powershell
+pwsh scripts/run-instrumented-tests.ps1
+```
+
+The script picks the first connected device, checks it reports an API level,
+and runs the suite with `com.markleaf.notes.ui` excluded. Add `-Serial` when
+more than one device is attached.
+
+### What it covers
+
+The two places where a mistake costs a user their notes, and which no unit test
+can reach:
+
+- **Room migrations** — `AppDatabaseMigrationTest` walks v4 → current on a real
+  Android runtime. A JVM test cannot; SQLite behaviour and Room's schema
+  validation are the point.
+- **The folder mirror's SAF IO** — `NoteFolderMirrorFolderTest`, twelve cases
+  over a live `DocumentFile` tree: rewrite-in-place by id, rename on title
+  change, adoption of an unclaimed file, never touching a file another note
+  claims, preserving another tool's frontmatter, and the read-cap guard.
+- **Navigation after a suspend point** — `NavigateAfterSuspendTest`, the #235
+  regression.
+
+`com.markleaf.notes.ui` is excluded because those classes drifted against the
+UI they assert on while a crash made the suite unrunnable; 24 of them fail
+(#239). The exclusion is by package, not an allow-list, so a test added
+anywhere else runs by default rather than being silently skipped.
+
+### Why it is not in CI
+
+It was tried, four times, in #238. The configuration works — the job builds,
+filters, and reaches `connectedDebugAndroidTest`. The GitHub-hosted emulator
+does not:
+
+```text
+[EmulatorConsole]: Failed to start Emulator console for 5554
+[PropertyFetcher]: ShellCommandUnresponsiveException
+Skipping device 'emulator-5554': Unknown API Level
+Found 1 connected device(s), 0 of which were compatible.
+```
+
+Raw `adb` answers on that same device — a wait loop added before Gradle
+reported `device settled at API 30` and ddmlib still timed out seconds later.
+That is why `launch-smoke` passes while this fails: `launch-smoke` only uses
+raw adb. It also means no adb-based waiting can fix it; the timeout is inside
+ddmlib. Tracked in #235, where Gradle Managed Devices is the next thing to try.
+
+The honest trade: this is a **manual** gate, so it is only as reliable as the
+person cutting the release. That is worse than automation and better than the
+previous state, where these tests were run when someone happened to remember.
+
+### If a test fails, re-run on a fresh emulator before believing it
+
+The UI-driving tests are sensitive to emulator health. On an emulator that has
+been up for hours through repeated install cycles, they intermittently fail
+with `No compose hierarchies found in the app` or a lone assertion failure that
+does not reproduce. Cold-boot and re-run before investigating:
+
+```powershell
+emulator -avd markleaf-tablet-api36 -no-boot-anim -no-snapshot-load
+```
+
+A failure that survives a cold boot is real. One that does not is the emulator.
+
 ## Release Version and Notes Checks
 
 Two PowerShell checks guard the parts of a release that are maintained by hand.
@@ -260,6 +330,13 @@ The local Play Console hand-off remains separate:
 
 It writes only the signed AAB, mapping, and six-locale notes to `D:\Build`.
 The GitLab APK does not change that local directory contract.
+
+Before tagging, run the one gate CI does not cover — see
+[Instrumented Tests](#instrumented-tests--local-gate-not-ci):
+
+```powershell
+pwsh scripts/run-instrumented-tests.ps1
+```
 
 Push the release tag to GitLab first, then GitHub (unless `SKIP_GITLAB_CI` is
 on, the GitLab tag push runs the GitLab pipeline and the GitHub tag push runs

--- a/scripts/run-instrumented-tests.ps1
+++ b/scripts/run-instrumented-tests.ps1
@@ -1,0 +1,87 @@
+<#
+.SYNOPSIS
+  연결된 기기/에뮬레이터에서 계측 테스트를 실행한다.
+.DESCRIPTION
+  CI 는 계측 테스트를 돌리지 않는다(#235). GitHub 호스티드 러너의 에뮬레이터가
+  ddmlib 의 property fetch 에 응답하지 못해 네 번 연속 실패했고, 그 타임아웃은
+  adb 쪽에서 기다려서 해결되는 종류가 아니다. 그래서 이 검증은 **로컬 수동 게이트**로
+  옮겼다. 릴리스 전에 반드시 한 번 돌린다 — docs/RELEASE.md 의 "Instrumented tests"
+  절을 볼 것.
+
+  `com.markleaf.notes.ui` 는 제외한다. 그 클래스들은 크래시(#235)로 오래 실행되지
+  못하는 동안 검증 대상 UI 가 바뀌어 24 건이 실패한다(#239). 허용 목록이 아니라
+  제외로 거는 이유는, 다른 패키지에 테스트를 추가했을 때 필터를 넓혀줄 때까지
+  조용히 건너뛰지 않게 하기 위해서다.
+
+  gradlew.bat 을 쓴다. POSIX `gradlew` 는 인자를 하나로 합쳐버린다(#241).
+.EXAMPLE
+  pwsh scripts/run-instrumented-tests.ps1
+.EXAMPLE
+  pwsh scripts/run-instrumented-tests.ps1 -Serial emulator-5554
+#>
+[CmdletBinding()]
+param(
+    [string]$RepoRoot = (Split-Path -Parent $PSScriptRoot),
+    [string]$Serial = "",
+    [string]$ExcludePackage = "com.markleaf.notes.ui"
+)
+
+$ErrorActionPreference = "Stop"
+
+$adb = Join-Path $env:LOCALAPPDATA "Android\Sdk\platform-tools\adb.exe"
+if (-not (Test-Path $adb)) {
+    $adb = (Get-Command adb -ErrorAction SilentlyContinue)?.Source
+}
+if (-not $adb) {
+    Write-Error "adb 를 찾을 수 없습니다. Android SDK platform-tools 를 설치하거나 PATH 에 추가하세요."
+}
+
+# 기기 선택 — 명시된 시리얼이 없으면 'device' 상태인 첫 항목.
+if (-not $Serial) {
+    $Serial = (& $adb devices |
+        Select-String -Pattern '^(\S+)\s+device$' |
+        ForEach-Object { $_.Matches[0].Groups[1].Value } |
+        Select-Object -First 1)
+}
+if (-not $Serial) {
+    Write-Host ""
+    Write-Host "연결된 기기가 없습니다." -ForegroundColor Red
+    Write-Host "  실기기: USB 연결 후 `adb devices` 로 'device' 상태 확인"
+    Write-Host "  에뮬레이터: emulator -list-avds 로 AVD 확인 후 emulator -avd <name>"
+    exit 1
+}
+
+# boot_completed 만으로는 부족한 경우가 있어 API 레벨까지 확인한다. Gradle 이
+# 기기를 고를 때 실제로 묻는 값이고, 여기서 비어 있으면 아래 실행은
+# "0 of which were compatible" 로 끝난다.
+$sdk = (& $adb -s $Serial shell getprop ro.build.version.sdk 2>$null) -replace '\s',''
+if (-not $sdk) {
+    Write-Host "기기 $Serial 가 API 레벨을 보고하지 않습니다 (부팅 중이거나 응답 불가)." -ForegroundColor Red
+    exit 1
+}
+
+Write-Host ""
+Write-Host "기기: $Serial (API $sdk)" -ForegroundColor Cyan
+Write-Host "제외: $ExcludePackage  (#239)" -ForegroundColor DarkGray
+Write-Host ""
+
+Push-Location $RepoRoot
+try {
+    $env:ANDROID_SERIAL = $Serial
+    & (Join-Path $RepoRoot "gradlew.bat") `
+        ":app:connectedDebugAndroidTest" `
+        "-Pandroid.testInstrumentationRunnerArguments.notPackage=$ExcludePackage" `
+        "--console=plain"
+    $code = $LASTEXITCODE
+}
+finally {
+    Pop-Location
+}
+
+Write-Host ""
+if ($code -eq 0) {
+    Write-Host "계측 테스트 통과." -ForegroundColor Green
+} else {
+    Write-Host "계측 테스트 실패. 리포트: app/build/reports/androidTests/connected/debug/index.html" -ForegroundColor Red
+}
+exit $code


### PR DESCRIPTION
Resolves the CI half of #235 — by deciding not to automate it, and writing down what replaces it.

## Why stop trying

Four runs in #238. The job's configuration works: it builds, filters, and reaches `connectedDebugAndroidTest`. The GitHub-hosted emulator does not:

```text
[EmulatorConsole]: Failed to start Emulator console for 5554
[PropertyFetcher]: ShellCommandUnresponsiveException
Skipping device 'emulator-5554': Unknown API Level
Found 1 connected device(s), 0 of which were compatible.
```

Run 4 settled it. A wait loop added before Gradle reported `device settled at API 30 (attempt 2)` — **raw adb answered fine** — and ddmlib timed out on the same device seconds later. That is why `launch-smoke` passes while this fails: it only ever uses raw adb. And it means no amount of adb-based waiting helps, because the timeout is inside ddmlib.

Continuing to guess at this costs ~15 minutes a run and was not converging.

## What replaces it

```powershell
pwsh scripts/run-instrumented-tests.ps1
```

Picks the first connected device, checks it reports an API level — the exact question that failed in CI, so a bad emulator fails immediately with a clear message instead of `0 of which were compatible` — and runs the suite with `com.markleaf.notes.ui` excluded (#239).

`docs/RELEASE.md` gains a section covering what the suite protects, why it is not automated (with the CI log), and it is referenced from the tag step so it is read at the moment it matters.

## What it protects

The two places where a mistake costs a user their notes and no unit test can reach:

| | |
|---|---|
| `AppDatabaseMigrationTest` | v4 → current on a real Android runtime |
| `NoteFolderMirrorFolderTest` | twelve cases over a live `DocumentFile` tree |
| `NavigateAfterSuspendTest` | the #235 regression (lands with #238) |

## Stated plainly in the doc

- **This is a manual gate, so it is only as reliable as the person cutting the release.** Worse than automation; better than the previous state, where these ran when someone remembered.
- **A lone failure on a long-running emulator should be re-checked on a cold boot before it is believed.** Seen twice today — `No compose hierarchies found in the app`, and a single unreproducible assertion — neither survived a cold boot.

#235 stays open for the automation, with Gradle Managed Devices as the next thing to try.

Stacks conceptually on #238 (which adds `NavigateAfterSuspendTest`); no file overlap, so merge order does not matter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)