### PR TITLE
ci: cap debug APK artifact retention at 7 days

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -109,6 +109,9 @@ jobs:
           name: markleaf-debug-apk
           path: app/build/outputs/apk/debug/app-debug.apk
           if-no-files-found: error
+          # 검증용 임시 산출물이라 기본 90일까지 둘 이유가 없다. 릴리스 산출물
+          # (aab / mapping) 과 달리 사후 추적에도 쓰이지 않으므로 7일로 줄인다.
+          retention-days: 7
 
   launch-smoke:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

Add `retention-days: 7` to the `markleaf-debug-apk` upload step in `android-build.yml`.

## Why

The debug APK is a throwaway verification output, but it inherited the default 90-day retention. Current accumulation in this repository:

| Artifact | Count | Size |
|---|---:|---:|
| **markleaf-debug-apk** | **438** | **7,416 MB** |
| markleaf-r8-mapping | 221 | 655 MB |
| markleaf-release-aab | 71 | 537 MB |
| others | 91 | 129 MB |
| **total** | **821** | **~8.7 GB** |

This repository is public, so the storage is free and there is no billing impact — this is housekeeping, not a cost fix.

## Scope

Only the debug APK step changes. Release outputs (`markleaf-release-aab`, `markleaf-release-mapping`, `markleaf-r8-mapping`) and the Roborazzi goldens keep the default retention, since those are genuinely useful for post-release tracing and snapshot recovery.

## Verification

- Workflow YAML parses; `markleaf-debug-apk` is the only step with a non-default retention.
- No consumer exists: the repository contains no `download-artifact` step anywhere, and the `launch-smoke` job builds its own debug APK via `assembleDebug`. Shortening retention cannot break any job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)