### PR TITLE
ci: drop R8 mapping from the Release and cap artifact retention

### DIFF
--- a/.agent/decisions.md
+++ b/.agent/decisions.md
@@ -7,6 +7,42 @@
 
 ## Confirmed Decisions
 
+### D064 - The R8 Mapping Is Not A GitHub Release Asset Either
+
+The GitHub Release carries exactly one asset, the signed APK. The R8 mapping is
+still built, verified, and kept — as a 30-day workflow artifact — but it is no
+longer attached to the Release. This narrows the asset list D062 defined.
+
+Why:
+- Nobody was taking it. The mapping is ~41 MB on every tag and the download
+  count is 0 — checked on both v2.29.0 and v2.28.1, whose APKs pulled 6 and 43
+  downloads over the same window. It is the AAB problem from D062 in a second
+  form: a large file nobody installs, sitting next to a 2.7 MB APK that is the
+  only thing a Releases visitor actually wants.
+- Permanent copies already exist, which is what made the AAB omission safe and
+  makes this one safe too. `:app:exportReleaseToBuildDrive` writes the mapping
+  to `D:\Build` next to the AAB, and GitLab publishes it to the Generic Package
+  Registry (D057).
+- Play Console holds its own deobfuscation copy for anything installed from
+  Play, so the GitHub asset only ever mattered for sideloaded crash reports —
+  and those are handled from `D:\Build` by the same maintainer who has the file.
+
+Decision:
+- `gh release create` attaches `markleaf-vX.Y.Z.apk` only.
+- Retention is set per artifact and reflects how long each one can still be
+  useful: `markleaf-r8-mapping` 7 days (regenerated on every PR and push, no
+  post-hoc value), `markleaf-release-aab` 14 days (dead once uploaded to Play),
+  `markleaf-release-mapping` 30 days (the only GitHub-side copy of a released
+  version's mapping).
+- CI verification is unchanged. The release job still fails if the APK, AAB, or
+  mapping is missing from the build outputs — `Verify R8 mapping exists` kept
+  the check when the release-asset copy step was removed.
+- `D:\Build` is now the primary permanent copy, not a redundant one. GitLab is
+  a real mirror but not a guaranteed one: its CI minutes have run out mid-month
+  before (v2.28.0/v2.28.1 shipped without GitLab Releases) and `SKIP_GITLAB_CI`
+  can disable it outright. If the local export is ever dropped, this entry has
+  to be revisited before it is.
+
 ### D063 - Passcode Backoff Uses Wall-Clock And Does Not Resist Clock Tampering
 
 `PasscodeBackoff`'s retry deadline is an absolute `System.currentTimeMillis`
@@ -41,6 +77,9 @@ Decision:
   per-note encryption lands and makes the passcode the actual boundary.
 
 ### D062 - The AAB Is Not A GitHub Release Asset
+
+> Narrowed by D064: the Release now carries one asset, not two — the mapping was
+> dropped from the list as well. Everything below about the AAB still holds.
 
 The GitHub Release carries exactly two assets — the signed APK and the R8
 mapping. The signed AAB is built and verified in the same tag job, but it is

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -102,6 +102,9 @@ jobs:
           name: markleaf-r8-mapping
           path: app/build/outputs/mapping/release/mapping.txt
           if-no-files-found: error
+          # PR·push 검증마다 새로 생기는 사본이라 사후 추적 가치가 없다.
+          # 릴리스 시점 mapping 은 release job 이 따로 보관한다.
+          retention-days: 7
 
       - name: Upload debug APK artifact
         uses: actions/upload-artifact@v7
@@ -269,13 +272,12 @@ jobs:
           test -s "$AAB"
           ls -lh "$AAB"
 
-      - name: Prepare R8 mapping for release asset
+      - name: Verify R8 mapping exists
         run: |
           MAPPING="app/build/outputs/mapping/release/mapping.txt"
           test -f "$MAPPING"
           test -s "$MAPPING"
-          cp "$MAPPING" "markleaf-${GITHUB_REF_NAME}.mapping.txt"
-          ls -lh "markleaf-${GITHUB_REF_NAME}.mapping.txt"
+          ls -lh "$MAPPING"
 
       - name: Upload Play Console AAB artifact
         uses: actions/upload-artifact@v7
@@ -283,6 +285,9 @@ jobs:
           name: markleaf-release-aab
           path: app/build/outputs/bundle/release/app-release.aab
           if-no-files-found: error
+          # Play Console 업로드용 산출물이라 업로드가 끝나면 쓸모가 없다.
+          # 릴리스 에셋으로는 배포하지 않으므로 14일이면 충분하다.
+          retention-days: 14
 
       - name: Upload R8 mapping artifact (release job)
         uses: actions/upload-artifact@v7
@@ -290,6 +295,10 @@ jobs:
           name: markleaf-release-mapping
           path: app/build/outputs/mapping/release/mapping.txt
           if-no-files-found: error
+          # 릴리스 에셋에서 뺀 뒤로는 GitHub 쪽 유일한 사본이다(영구 사본은
+          # D:\Build 와 GitLab 패키지 레지스트리, D064). 크래시 역난독화
+          # 요청이 뒤늦게 들어올 여유를 두어 30일로 잡는다.
+          retention-days: 30
 
       - name: Prepare release notes
         run: |
@@ -320,7 +329,6 @@ jobs:
         run: |
           gh release create "$GITHUB_REF_NAME" \
             "markleaf-${GITHUB_REF_NAME}.apk" \
-            "markleaf-${GITHUB_REF_NAME}.mapping.txt" \
             --repo "$GITHUB_REPOSITORY" \
             --title "$(cat release-title.txt)" \
             --notes-file release-notes.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,9 +146,10 @@ GitLab CI용 산출물은 `-Pmarkleaf.releaseExportDir=<dir>`와 함께
 3. **F-Droid — 태그 푸시로 자동 배포.** versionCode/versionName bump + `CHANGELOG.md`(영어,
    릴리즈 노트 원본) + `CHANGELOG.ko.md`(한국어판) + fastlane changelog 작성 후 main에
    푸시하고 `vX.Y.Z` 태그를 GitLab 먼저, GitHub 다음으로 푸시한다. 같은 태그가 양쪽에서
-   독립적으로 서명 빌드를 돌리지만 **릴리스에 붙는 자산은 다르다** — GitHub Release는 APK와
-   R8 mapping 두 개만, GitLab Release는 Generic Package Registry를 통해 AAB까지 포함한다
-   (AAB를 GitHub에 올리지 않는 이유는 D062). GitHub 태그는 F-Droid 자동 픽업도 발동하므로
+   독립적으로 서명 빌드를 돌리지만 **릴리스에 붙는 자산은 다르다** — GitHub Release는 APK
+   하나만, GitLab Release는 Generic Package Registry를 통해 AAB와 mapping까지 포함한다
+   (AAB를 GitHub에 올리지 않는 이유는 D062, mapping을 빼고 30일 아티팩트로만 두는 이유는
+   D064). GitHub 태그는 F-Droid 자동 픽업도 발동하므로
    별도 F-Droid 제출 단계는 없다.
    릴리스 커밋은 `git add -A`로 만들지 않는다 — 변경 파일을 명시적으로 stage하거나 커밋 전
    working tree가 릴리스 대상만 담고 있는지 확인한다(무관한 작업이 태그에 섞여 나가는 것을

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -78,9 +78,12 @@ crash reports:
 app/build/outputs/mapping/release/mapping.txt
 ```
 
-Keep the mapping that corresponds to each released APK. GitHub Actions and
-GitLab CI attach a versioned mapping file to every tag release so historical
-versions can still be deobfuscated.
+Keep the mapping that corresponds to each released APK. The permanent copies
+live in `D:\Build` through the local `exportReleaseToBuildDrive` hand-off and
+in the GitLab package registry. GitHub keeps it only as the 30-day
+`markleaf-release-mapping` workflow artifact — it is no longer attached to the
+GitHub Release, so pull it from one of the permanent copies when an older
+version needs deobfuscating.
 
 If R8 strips something at runtime (NoClassDefFoundError, missing reflection
 target, lost Compose Composer slot), the fix is to add a precise `-keep`
@@ -289,17 +292,18 @@ tag pipelines can read the signing variables. Never expose these variables to
 branch or merge-request jobs.
 
 On tag pushes matching `v*`, GitHub Actions runs tests, builds the signed
-release APK and AAB, and creates a GitHub Release with **two** assets attached:
+release APK and AAB, and creates a GitHub Release with **one** asset attached:
 
 - `markleaf-vX.Y.Z.apk` — signed, R8-shrunk APK for sideload installs and the Releases mirror
-- `markleaf-vX.Y.Z.mapping.txt` — R8 mapping for deobfuscating crash stack traces
 
-The signed AAB is built and verified in the same job but is **not** attached to
-the GitHub Release. It is uploaded as the `markleaf-release-aab` workflow
-artifact, and it reaches Play Console through the local
-`exportReleaseToBuildDrive` hand-off (see [Release Artifact Export](../AGENTS.md#release-artifact-export))
-rather than from GitHub. GitLab publishes the AAB to its package registry as
-well, so a permanent download link for it exists there — see
+The signed AAB and the R8 mapping are built and verified in the same job but are
+**not** attached to the GitHub Release. Both are uploaded as workflow artifacts
+instead — `markleaf-release-aab` (14-day retention) and
+`markleaf-release-mapping` (30-day retention) — and both reach their permanent
+home through the local `exportReleaseToBuildDrive` hand-off
+(see [Release Artifact Export](../AGENTS.md#release-artifact-export)) rather
+than from GitHub. GitLab publishes both to its package registry as well, so
+permanent download links exist there — see
 [GitLab Release Assets](#gitlab-release-assets).
 
 The release job fails before publishing if the keystore secret is missing, if


### PR DESCRIPTION
## What

- `gh release create` attaches the signed APK only — the R8 mapping is no longer a Release asset.
- Artifact retention is now set per artifact instead of defaulting to 90 days.
- `docs/RELEASE.md`, `AGENTS.md`, and `.agent/decisions.md` (new **D064**) are updated to match.

| Artifact | Retention | Rationale |
|---|---:|---|
| `markleaf-r8-mapping` | 7d | regenerated on every PR and push, no post-hoc value |
| `markleaf-release-aab` | 14d | dead once uploaded to Play Console |
| `markleaf-release-mapping` | 30d | the only GitHub-side copy of a released version's mapping |
| `markleaf-debug-apk` | 7d | unchanged, set in #243 |

Roborazzi goldens, diff images, and the lint report keep the 90-day default.

## Why drop the mapping asset

It was ~41 MB on every tag with a **download count of 0** — verified on both v2.29.0 and v2.28.1, whose APKs pulled 6 and 43 downloads over the same window. That is the AAB problem from D062 in a second form: a large file nobody installs, sitting next to a 2.7 MB APK that is the only thing a Releases visitor wants.

Permanent copies are unaffected:
- `:app:exportReleaseToBuildDrive` writes the mapping to `D:\Build` next to the AAB
- GitLab publishes it to the Generic Package Registry (D057)
- Play Console holds its own deobfuscation copy for Play installs

## Verification

- Workflow YAML parses; the seven upload steps carry exactly the retention values in the table above.
- **No dangling reference**: the release-asset copy (`cp` to `markleaf-vX.Y.Z.mapping.txt`) was removed, so a check confirmed no `run` line in the release job still references that filename — `gh release create` cannot fail on a missing file.
- **Hard gate preserved**: the copy step became `Verify R8 mapping exists`, keeping `test -f` / `test -s`, so the release job still fails if the mapping is missing from the build outputs.

## Note

D064 records that `D:\Build` is now the *primary* permanent copy rather than a redundant one. GitLab is a real mirror but not a guaranteed one — its CI minutes have run out mid-month before (v2.28.0/v2.28.1 shipped without GitLab Releases) and `SKIP_GITLAB_CI` can disable it outright. If the local export is ever dropped, D064 has to be revisited first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)