### PR TITLE
release: make the local export a required, verified pre-tag step

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,7 +96,7 @@ Android 프로젝트가 아직 초기화되지 않았다면 먼저 표준 Kotlin
 이 task는 `bundleRelease`에 의존하므로 **서명 AAB**도 함께 빌드된다(서명: repo 루트 `release-signing.properties` + `.secrets/markleaf-release.p12` 키스토어; cert는 Play 업로드 키와 동일). 산출물은 모두 `D:\Build\` 평면 배치, 공통 stem `markleaf-v<semver>-vc<versionCode>`:
 
 - `markleaf-v<semver>-vc<versionCode>.aab` — `app/build/outputs/bundle/release/app-release.aab`(서명) 복사본
-- `markleaf-v<semver>-vc<versionCode>.mapping.txt` — R8 mapping(Play 크래시 deobfuscation; 있으면 복사)
+- `markleaf-v<semver>-vc<versionCode>.mapping.txt` — R8 mapping(Play 크래시 deobfuscation; 있으면 복사). AAB가 없으면 task가 예외를 던지지만 mapping은 warn만 남기고 넘어가므로, AAB가 나왔다고 mapping도 나왔다고 볼 수 없다 — `scripts/verify-release-export.ps1`이 이것까지 확인한다
 - `markleaf-v<semver>-vc<versionCode>-release-notes.txt` — **모든 스토어 로케일**(ko-KR / en-US / ja-JP / de-DE / fr-FR / es-ES)의 `fastlane/metadata/android/<locale>/changelogs/<versionCode>.txt`를 읽어 하나의 파일에 로케일 태그 블록을 연달아 묶음
 
 TXT 파일은 바로 복사/붙여넣기 가능해야 하며, 각 로케일 릴리즈 노트만 아래 태그로 감싼다. 태그 밖에는 어떤 설명이나 문구도 넣지 않는다 (Gradle task가 이 형식을 보장한다).
@@ -145,7 +145,11 @@ GitLab CI용 산출물은 `-Pmarkleaf.releaseExportDir=<dir>`와 함께
    workflow_dispatch — 로컬 재기록은 폰트 힌팅 차이로 CI verify와 어긋난다).
 3. **F-Droid — 태그 푸시로 자동 배포.** versionCode/versionName bump + `CHANGELOG.md`(영어,
    릴리즈 노트 원본) + `CHANGELOG.ko.md`(한국어판) + fastlane changelog 작성 후 main에
-   푸시하고 `vX.Y.Z` 태그를 GitLab 먼저, GitHub 다음으로 푸시한다. 같은 태그가 양쪽에서
+   푸시한다. **태그를 밀기 전에** `:app:exportReleaseToBuildDrive`로 `D:\Build` 산출물을
+   남기고 `pwsh scripts/verify-release-export.ps1`로 확인한다 — `D:\Build`는 CI가 볼 수 없는
+   로컬 경로라 이 단계가 빠져도 아무것도 실패하지 않으며, 실제로 v2.27.2부터 v2.29.0까지
+   여섯 릴리스가 AAB·mapping 없이 지나갔다(#247). 그다음 `vX.Y.Z` 태그를 GitLab 먼저,
+   GitHub 다음으로 푸시한다. 같은 태그가 양쪽에서
    독립적으로 서명 빌드를 돌리지만 **릴리스에 붙는 자산은 다르다** — GitHub Release는 APK
    하나만, GitLab Release는 Generic Package Registry를 통해 AAB와 mapping까지 포함한다
    (AAB를 GitHub에 올리지 않는 이유는 D062, mapping을 빼고 30일 아티팩트로만 두는 이유는

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -230,6 +230,38 @@ emulator -avd markleaf-tablet-api36 -no-boot-anim -no-snapshot-load
 
 A failure that survives a cold boot is real. One that does not is the emulator.
 
+## Release Export — Local Gate, Not CI
+
+**CI cannot check this.** `D:\Build` is a local path on the maintainer's
+machine, so no pipeline can confirm the export ran. Run it, then verify it,
+before pushing a tag:
+
+```powershell
+.\gradlew.bat :app:exportReleaseToBuildDrive
+pwsh scripts/verify-release-export.ps1
+```
+
+The check asserts that three files exist and are non-empty for the current
+`versionName`/`versionCode`, under the `markleaf-v<semver>-vc<code>` stem —
+`.aab`, `.mapping.txt`, and `-release-notes.txt` — and that the notes file
+carries a block for all six store locales. `D:\Build` is shared with other
+projects, so only files matching that stem are considered.
+
+This gate exists because the export is a manual step that silently went missing
+for six consecutive releases. v2.27.2, v2.28.0, v2.28.1, v2.28.2, v2.28.3, and
+v2.29.0 have no AAB and no mapping in `D:\Build`; the gap only surfaced while
+removing the mapping from the GitHub Release assets (#244), and the mappings had
+to be recovered from those assets before they were deleted.
+
+It also checks the mapping specifically, which the export itself does not
+guarantee: `writeReleaseArtifacts` throws when the AAB is missing but only logs
+a warning and continues when the mapping is absent. A successful export is not
+evidence that a mapping was written.
+
+Since D064 the mapping is no longer a GitHub Release asset — it survives on
+GitHub only as a 30-day workflow artifact. A release that skips this export and
+is noticed more than 30 days later cannot be deobfuscated at all.
+
 ## Release Version and Notes Checks
 
 Two PowerShell checks guard the parts of a release that are maintained by hand.
@@ -376,13 +408,18 @@ The local Play Console hand-off remains separate:
 ```
 
 It writes only the signed AAB, mapping, and six-locale notes to `D:\Build`.
-The GitLab APK does not change that local directory contract.
+The GitLab APK does not change that local directory contract. This step is
+mandatory before a tag, and verified — see
+[Release Export](#release-export--local-gate-not-ci).
 
-Before tagging, run the one gate CI does not cover — see
-[Instrumented Tests](#instrumented-tests--local-gate-not-ci):
+Before tagging, run the two gates CI does not cover — see
+[Instrumented Tests](#instrumented-tests--local-gate-not-ci) and
+[Release Export](#release-export--local-gate-not-ci):
 
 ```powershell
 pwsh scripts/run-instrumented-tests.ps1
+.\gradlew.bat :app:exportReleaseToBuildDrive
+pwsh scripts/verify-release-export.ps1
 ```
 
 Push the release tag to GitLab first, then GitHub (unless `SKIP_GITLAB_CI` is

--- a/scripts/verify-release-export.ps1
+++ b/scripts/verify-release-export.ps1
@@ -1,0 +1,142 @@
+<#
+.SYNOPSIS
+  `:app:exportReleaseToBuildDrive` 가 이번 버전 산출물을 실제로 남겼는지 검증한다.
+.DESCRIPTION
+  기대 버전은 `app/build.gradle.kts` 의 versionName / versionCode 다. 태그를 밀기 전에
+  `D:\Build` 에 이번 버전의 세 파일이 있는지 확인한다.
+
+  이 검사가 필요한 이유는 두 가지다.
+
+  1. export 는 사람이 손으로 돌리는 단계라 통째로 빠질 수 있다. v2.27.2 부터
+     v2.29.0 까지 여섯 릴리스가 AAB 도 mapping 도 없이 지나갔고, 그 사실은
+     GitHub 릴리스 자산을 정리하다가(#244) 뒤늦게 드러났다.
+  2. mapping 은 없어도 export 가 성공한다 — `writeReleaseArtifacts` 는 AAB 가 없으면
+     예외를 던지지만 mapping 은 `logger.warn` 만 남기고 건너뛴다(minify 가 꺼져 있으면
+     조용히 그렇게 된다). AAB 가 있다고 mapping 도 있다고 볼 수 없다.
+
+  mapping 은 D064 이후 GitHub Release 에 붙지 않고 30일 아티팩트로만 남으므로,
+  여기서 놓치면 그 버전은 영구히 역난독화할 수 없게 된다.
+
+  `D:\Build` 는 여러 프로젝트가 함께 쓰는 디렉터리다. `markleaf-v<semver>-vc<code>`
+  stem 에 해당하는 파일만 본다.
+.EXAMPLE
+  pwsh scripts/verify-release-export.ps1
+.EXAMPLE
+  pwsh scripts/verify-release-export.ps1 -ExportDir E:\Build -ExpectedVersion 2.29.0 -ExpectedVersionCode 118
+#>
+[CmdletBinding()]
+param(
+    [string]$RepoRoot = (Split-Path -Parent $PSScriptRoot),
+    [string]$ExportDir = "D:\Build",
+    [string]$ExpectedVersion = "",
+    [int]$ExpectedVersionCode = 0
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+# app/build.gradle.kts 의 noteLocales 와 같은 목록이어야 한다. 릴리스 노트 TXT 는
+# 로케일마다 <tag> ... </tag> 블록을 연달아 담는다(writeReleaseArtifacts).
+$StoreLocales = @("ko-KR", "en-US", "ja-JP", "de-DE", "fr-FR", "es-ES")
+
+function Resolve-UnderRoot([string]$Path) {
+    if ([System.IO.Path]::IsPathRooted($Path)) { return $Path }
+    return (Join-Path $RepoRoot $Path)
+}
+
+$fail = 0
+function Add-Failure([string]$Message) {
+    Write-Host $Message -ForegroundColor Red
+    $script:fail++
+}
+
+# ---- 기대 버전: app/build.gradle.kts ----
+if (-not $ExpectedVersion -or $ExpectedVersionCode -le 0) {
+    $gradlePath = Resolve-UnderRoot "app/build.gradle.kts"
+    if (-not (Test-Path -LiteralPath $gradlePath)) {
+        Write-Error "기대 버전을 읽을 app/build.gradle.kts 를 찾지 못했습니다: $gradlePath"
+        exit 1
+    }
+    $gradleText = Get-Content -Raw -Encoding utf8 -LiteralPath $gradlePath
+
+    if (-not $ExpectedVersion) {
+        $nameMatch = [regex]::Match($gradleText, 'versionName\s*=\s*"([0-9]+\.[0-9]+\.[0-9]+)"')
+        if (-not $nameMatch.Success) {
+            Write-Error "app/build.gradle.kts 에서 versionName 을 찾지 못했습니다."
+            exit 1
+        }
+        $ExpectedVersion = $nameMatch.Groups[1].Value
+    }
+    if ($ExpectedVersionCode -le 0) {
+        $codeMatch = [regex]::Match($gradleText, 'versionCode\s*=\s*([0-9]+)')
+        if (-not $codeMatch.Success) {
+            Write-Error "app/build.gradle.kts 에서 versionCode 를 찾지 못했습니다."
+            exit 1
+        }
+        $ExpectedVersionCode = [int]$codeMatch.Groups[1].Value
+    }
+}
+
+$stem = "markleaf-v$ExpectedVersion-vc$ExpectedVersionCode"
+Write-Host "기대 버전: v$ExpectedVersion (versionCode $ExpectedVersionCode)"
+Write-Host "내보내기 위치: $ExportDir"
+Write-Host "파일 stem: $stem"
+
+if (-not (Test-Path -LiteralPath $ExportDir)) {
+    Write-Host "`n  FAIL  내보내기 디렉터리가 없습니다: $ExportDir" -ForegroundColor Red
+    Write-Host "`n실패 1건. .\gradlew.bat :app:exportReleaseToBuildDrive 를 먼저 실행하세요 — 검사를 고치지 마세요." -ForegroundColor Red
+    exit 2
+}
+
+# ---- 1. 세 산출물 존재 + 비어 있지 않음 ----
+Write-Host "`n릴리스 산출물"
+$expected = [ordered]@{
+    'AAB'      = "$stem.aab"
+    'mapping'  = "$stem.mapping.txt"
+    '릴리스 노트' = "$stem-release-notes.txt"
+}
+
+$notesPath = $null
+foreach ($label in $expected.Keys) {
+    $name = $expected[$label]
+    $path = Join-Path $ExportDir $name
+    if (-not (Test-Path -LiteralPath $path)) {
+        Add-Failure ("  FAIL  {0,-12} {1} 이(가) 없습니다." -f $label, $name)
+        continue
+    }
+    $size = (Get-Item -LiteralPath $path).Length
+    if ($size -le 0) {
+        Add-Failure ("  FAIL  {0,-12} {1} 이(가) 비어 있습니다." -f $label, $name)
+        continue
+    }
+    if ($label -eq '릴리스 노트') { $notesPath = $path }
+    # 노트 TXT 는 수 KB라 MB 로 찍으면 0.0 으로 보여 비어 있는 것처럼 읽힌다.
+    $human = if ($size -ge 1MB) { "{0:N1} MB" -f ($size / 1MB) } else { "{0:N0} KB" -f ($size / 1KB) }
+    Write-Host ("  OK    {0,-12} {1} ({2})" -f $label, $name, $human) -ForegroundColor Green
+}
+
+# ---- 2. 릴리스 노트 TXT 가 여섯 로케일 블록을 모두 담고 있는지 ----
+# 노트 파일은 있는데 로케일이 빠진 채 만들어지는 경우는 Gradle task 가 막지만,
+# 손으로 편집하거나 오래된 버전의 파일이 남아 있는 경우까지 막지는 못한다.
+if ($notesPath) {
+    Write-Host "`n릴리스 노트 로케일 ($($StoreLocales.Count)개)"
+    $notesText = Get-Content -Raw -Encoding utf8 -LiteralPath $notesPath
+    $missingLocales = @()
+    foreach ($locale in $StoreLocales) {
+        if ($notesText -notmatch [regex]::Escape("<$locale>") -or $notesText -notmatch [regex]::Escape("</$locale>")) {
+            $missingLocales += $locale
+        }
+    }
+    if ($missingLocales.Count -gt 0) {
+        Add-Failure ("  FAIL  블록이 없는 로케일: {0}" -f ($missingLocales -join ', '))
+    } else {
+        Write-Host ("  OK    여섯 로케일 블록이 모두 있습니다.") -ForegroundColor Green
+    }
+}
+
+if ($fail -ne 0) {
+    Write-Host "`n실패 $fail 건. .\gradlew.bat :app:exportReleaseToBuildDrive 를 실행해 산출물을 남기세요 — 검사를 고치지 마세요." -ForegroundColor Red
+    Write-Host "mapping 이 빠졌다면 minify 가 켜진 상태로 bundleRelease 가 돌았는지 확인하세요." -ForegroundColor Red
+    exit 2
+}
+Write-Host "`n모든 내보내기 검사를 통과했습니다 (v$ExpectedVersion / vc$ExpectedVersionCode)." -ForegroundColor Green


### PR DESCRIPTION
Addresses the manual-export item in #247.

## Problem

`:app:exportReleaseToBuildDrive` is run by hand and **nothing fails when it is skipped** — `D:\Build` is a local path no pipeline can see. It went missing for six consecutive releases:

| Version | AAB in `D:\Build` | mapping in `D:\Build` |
|---|---|---|
| v2.27.2, v2.28.0, v2.28.1, v2.28.2, v2.28.3, v2.29.0 | ❌ | ❌ |

The newest markleaf artifact there is `markleaf-v2.27.1-vc112`, while the current version is vc118. The gap only surfaced while removing mappings from the GitHub Release assets (#244) — those six mappings had to be recovered from the assets before they were deleted.

This matters more since D064: the mapping is no longer a Release asset and survives on GitHub only as a 30-day workflow artifact. A skipped export noticed a month later is unrecoverable.

## Change

New `scripts/verify-release-export.ps1`, following the existing `verify-*.ps1` conventions (expected version read from `app/build.gradle.kts`, `Add-Failure` counter, exit 2 on failure). It asserts:

- `<stem>.aab`, `<stem>.mapping.txt`, `<stem>-release-notes.txt` exist and are non-empty, where stem is `markleaf-v<semver>-vc<code>`
- the notes file carries a block for all six store locales

**The mapping check is the point.** `writeReleaseArtifacts` throws when the AAB is missing but only logs a warning and continues when the mapping is absent, so a successful export is not evidence a mapping was written.

`D:\Build` is shared with other projects (ClearPDFLocal, DaddyCarBook, …), so only files matching the markleaf stem are read.

Docs updated: a new `Release Export — Local Gate, Not CI` section in `docs/RELEASE.md` mirroring the existing instrumented-tests local-gate section, the pre-tag command list now covers both gates, and the `AGENTS.md` release procedure makes the export a required step before pushing a tag.

## Verification

Run against the real `D:\Build`:

| Case | Result |
|---|---|
| v2.27.1 / vc112 (present) | all three OK, six locales OK — **exit 0** |
| v2.29.0 / vc118 (current, missing) | three FAILs — **exit 2** |
| nonexistent export directory | clean single FAIL — **exit 2** |

## Note

This gate is local-only by necessity — CI cannot verify a path on the maintainer's machine. It converts a silent omission into a loud one at the moment it matters (before the tag), but it still depends on someone running it. Making the artifacts land somewhere CI can see would be a larger change and is not attempted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)