### PR TITLE
fix(sync): an indented --- no longer closes the frontmatter block

### DIFF
--- a/app/src/main/java/com/markleaf/notes/data/sync/SyncFrontmatter.kt
+++ b/app/src/main/java/com/markleaf/notes/data/sync/SyncFrontmatter.kt
@@ -146,7 +146,14 @@ object SyncFrontmatter {
                 blockClosed = false
             )
         }
-        val closeOffset = lines.subList(1, lines.size).indexOfFirst { it.trim() == DELIMITER }
+        // `trimEnd`, not `trim`: trailing tolerance is wanted — an editor that
+        // leaves `--- ` should still close the block — but leading tolerance is
+        // not. A top-level delimiter belongs at column 0, so an indented `---`
+        // is by definition inside something else, and the one place it turns up
+        // is a `|` or `>` block scalar. Accepting it ended the frontmatter early:
+        // every entry after it was pasted into the note body along with a stray
+        // `---`, and the next mirror write persisted that arrangement (#234).
+        val closeOffset = lines.subList(1, lines.size).indexOfFirst { it.trimEnd() == DELIMITER }
         if (closeOffset < 0) {
             return Parsed(
                 null, null, null, null, null, text, emptyList(),

--- a/app/src/test/java/com/markleaf/notes/data/sync/SyncFrontmatterTest.kt
+++ b/app/src/test/java/com/markleaf/notes/data/sync/SyncFrontmatterTest.kt
@@ -452,4 +452,51 @@ class SyncFrontmatterTest {
             first.unknownEntries
         )
     }
+
+    @Test
+    fun decode_doesNotCloseOnAnIndentedRuleInsideABlockScalar() {
+        // #234: the closing delimiter was located with `trim()`, so a `---`
+        // indented inside a `|` block scalar ended the frontmatter. `tags` never
+        // reached the frontmatter at all — it was pasted into the body along
+        // with a stray `---`, and the next mirror write persisted that.
+        val raw = """
+            ---
+            description: |
+              ---
+              a rule inside the block scalar
+            tags:
+              - reading
+            ---
+
+            # Reading log
+        """.trimIndent()
+
+        val parsed = SyncFrontmatter.decode(raw)
+
+        assertTrue("the block is read as frontmatter", parsed.hasFrontmatter)
+        assertTrue("and it is closed", parsed.blockClosed)
+        assertEquals("nothing spills into the body", "# Reading log", parsed.body)
+        assertEquals(
+            listOf(
+                "description: |\n  ---\n  a rule inside the block scalar",
+                "tags:\n  - reading"
+            ),
+            parsed.unknownEntries
+        )
+    }
+
+    @Test
+    fun decode_stillClosesOnADelimiterWithTrailingWhitespace() {
+        // The tolerance the old `trim()` existed for: an editor that leaves
+        // `--- ` must still close the block. `trimEnd()` keeps exactly that,
+        // and nothing more.
+        val raw = "---\nmarkleaf_id: abc-123-def\n--- \n\n# Body"
+
+        val parsed = SyncFrontmatter.decode(raw)
+
+        assertTrue("a trailing space still closes the block", parsed.blockClosed)
+        assertTrue(parsed.hasFrontmatter)
+        assertEquals("abc-123-def", parsed.markleafId)
+        assertEquals("# Body", parsed.body)
+    }
 }


### PR DESCRIPTION
Fixes #234.

## Problem

`decode` located the closing delimiter with `it.trim() == DELIMITER`, so **any** line trimming to `---` ended the frontmatter — including one indented inside a `|` or `>` block scalar.

```markdown
---
description: |
  ---
  a rule inside the block scalar
tags:
  - reading
---

# Reading log
```

| | before | after |
|---|---|---|
| frontmatter entries | `["description: \|"]` | `["description: \|\n  ---\n  a rule inside the block scalar", "tags:\n  - reading"]` |
| note body | `"  a rule inside the block scalar\ntags:\n  - reading\n---\n\n# Reading log"` | `"# Reading log"` |

`tags` never reached the frontmatter at all, and a stray `---` plus the scalar's contents were pasted into the note text. The next mirror write persisted that arrangement and the pass after re-parsed the mangled result, so it compounded on every save.

## Fix

`it.trimEnd() == DELIMITER`, one line.

`trimEnd` keeps the tolerance the `trim` existed for — an editor leaving `--- ` still closes the block — and drops the leading tolerance, which was never wanted: a top-level delimiter belongs at column 0, so an indented one is by definition inside something else.

The **opening** delimiter check is deliberately left as `trim()`. Narrowing it too would change how existing files parse for a case this issue does not cover, and that risk does not belong in a fix release.

## Verification

- **Mutation-checked.** Reverting to `trim()` fails `decode_doesNotCloseOnAnIndentedRuleInsideABlockScalar` while the trailing-space test keeps passing — exactly the split the fix intends. Without this, a test that passes both before and after proves nothing.
- 449 unit tests across 55 suites, 0 failures.
- `lintRelease` clean.

Two tests added: the reproduction above, and `--- ` (trailing space) still closing the block so the retained tolerance is pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)