### PR TITLE
feat(editor): let notes open at the bottom or where you left off (#214)

### DIFF
--- a/app/schemas/com.markleaf.notes.data.local.AppDatabase/18.json
+++ b/app/schemas/com.markleaf.notes.data.local.AppDatabase/18.json
@@ -1,0 +1,487 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 18,
+    "identityHash": "c4c1488eacf6d29c0dd875541cb72547",
+    "entities": [
+      {
+        "tableName": "notes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT NOT NULL, `contentMarkdown` TEXT NOT NULL, `excerpt` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `pinned` INTEGER NOT NULL, `archived` INTEGER NOT NULL, `trashed` INTEGER NOT NULL, `deletedAt` INTEGER, `sortOrder` INTEGER NOT NULL, `lastImportedAt` INTEGER, `remoteSeenAt` INTEGER, `locked` INTEGER NOT NULL, `isConflictCopy` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contentMarkdown",
+            "columnName": "contentMarkdown",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "excerpt",
+            "columnName": "excerpt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pinned",
+            "columnName": "pinned",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "archived",
+            "columnName": "archived",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trashed",
+            "columnName": "trashed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sortOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastImportedAt",
+            "columnName": "lastImportedAt",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "remoteSeenAt",
+            "columnName": "remoteSeenAt",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "locked",
+            "columnName": "locked",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isConflictCopy",
+            "columnName": "isConflictCopy",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_notes_trashed_pinned_sortOrder",
+            "unique": false,
+            "columnNames": [
+              "trashed",
+              "pinned",
+              "sortOrder"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_notes_trashed_pinned_sortOrder` ON `${TABLE_NAME}` (`trashed`, `pinned`, `sortOrder`)"
+          },
+          {
+            "name": "index_notes_trashed_deletedAt",
+            "unique": false,
+            "columnNames": [
+              "trashed",
+              "deletedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_notes_trashed_deletedAt` ON `${TABLE_NAME}` (`trashed`, `deletedAt`)"
+          },
+          {
+            "name": "index_notes_title_trashed",
+            "unique": false,
+            "columnNames": [
+              "title",
+              "trashed"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_notes_title_trashed` ON `${TABLE_NAME}` (`title`, `trashed`)"
+          },
+          {
+            "name": "index_notes_sortOrder",
+            "unique": false,
+            "columnNames": [
+              "sortOrder"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_notes_sortOrder` ON `${TABLE_NAME}` (`sortOrder`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "tags",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `createdAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "note_tag_cross_ref",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`noteId` TEXT NOT NULL, `tagId` INTEGER NOT NULL, PRIMARY KEY(`noteId`, `tagId`), FOREIGN KEY(`noteId`) REFERENCES `notes`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`tagId`) REFERENCES `tags`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "noteId",
+            "columnName": "noteId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tagId",
+            "columnName": "tagId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "noteId",
+            "tagId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_note_tag_cross_ref_noteId",
+            "unique": false,
+            "columnNames": [
+              "noteId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_note_tag_cross_ref_noteId` ON `${TABLE_NAME}` (`noteId`)"
+          },
+          {
+            "name": "index_note_tag_cross_ref_tagId",
+            "unique": false,
+            "columnNames": [
+              "tagId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_note_tag_cross_ref_tagId` ON `${TABLE_NAME}` (`tagId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "notes",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "noteId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "tags",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "tagId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "ftsVersion": "FTS4",
+        "ftsOptions": {
+          "tokenizer": "simple",
+          "tokenizerArgs": [],
+          "contentTable": "notes",
+          "languageIdColumnName": "",
+          "matchInfo": "FTS4",
+          "notIndexedColumns": [],
+          "prefixSizes": [],
+          "preferredOrder": "ASC"
+        },
+        "contentSyncTriggers": [
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_notes_fts_BEFORE_UPDATE BEFORE UPDATE ON `notes` BEGIN DELETE FROM `notes_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_notes_fts_BEFORE_DELETE BEFORE DELETE ON `notes` BEGIN DELETE FROM `notes_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_notes_fts_AFTER_UPDATE AFTER UPDATE ON `notes` BEGIN INSERT INTO `notes_fts`(`docid`, `title`, `contentMarkdown`, `excerpt`) VALUES (NEW.`rowid`, NEW.`title`, NEW.`contentMarkdown`, NEW.`excerpt`); END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_notes_fts_AFTER_INSERT AFTER INSERT ON `notes` BEGIN INSERT INTO `notes_fts`(`docid`, `title`, `contentMarkdown`, `excerpt`) VALUES (NEW.`rowid`, NEW.`title`, NEW.`contentMarkdown`, NEW.`excerpt`); END"
+        ],
+        "tableName": "notes_fts",
+        "createSql": "CREATE VIRTUAL TABLE IF NOT EXISTS `${TABLE_NAME}` USING FTS4(`title` TEXT NOT NULL, `contentMarkdown` TEXT NOT NULL, `excerpt` TEXT NOT NULL, content=`notes`)",
+        "fields": [
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contentMarkdown",
+            "columnName": "contentMarkdown",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "excerpt",
+            "columnName": "excerpt",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": []
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "note_links",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceNoteId` TEXT NOT NULL, `targetTitle` TEXT NOT NULL, `normalizedTitle` TEXT NOT NULL, `position` INTEGER NOT NULL, PRIMARY KEY(`sourceNoteId`, `position`), FOREIGN KEY(`sourceNoteId`) REFERENCES `notes`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceNoteId",
+            "columnName": "sourceNoteId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetTitle",
+            "columnName": "targetTitle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "normalizedTitle",
+            "columnName": "normalizedTitle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceNoteId",
+            "position"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_note_links_sourceNoteId",
+            "unique": false,
+            "columnNames": [
+              "sourceNoteId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_note_links_sourceNoteId` ON `${TABLE_NAME}` (`sourceNoteId`)"
+          },
+          {
+            "name": "index_note_links_normalizedTitle",
+            "unique": false,
+            "columnNames": [
+              "normalizedTitle"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_note_links_normalizedTitle` ON `${TABLE_NAME}` (`normalizedTitle`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "notes",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceNoteId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "attachments",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `noteId` TEXT NOT NULL, `fileName` TEXT NOT NULL, `mimeType` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`noteId`) REFERENCES `notes`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "noteId",
+            "columnName": "noteId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileName",
+            "columnName": "fileName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mimeType",
+            "columnName": "mimeType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_attachments_noteId",
+            "unique": false,
+            "columnNames": [
+              "noteId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_attachments_noteId` ON `${TABLE_NAME}` (`noteId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "notes",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "noteId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "note_view_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`noteId` TEXT NOT NULL, `caretOffset` INTEGER NOT NULL, `previewIndex` INTEGER NOT NULL, PRIMARY KEY(`noteId`), FOREIGN KEY(`noteId`) REFERENCES `notes`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "noteId",
+            "columnName": "noteId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "caretOffset",
+            "columnName": "caretOffset",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "previewIndex",
+            "columnName": "previewIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "noteId"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": [
+          {
+            "table": "notes",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "noteId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'c4c1488eacf6d29c0dd875541cb72547')"
+    ]
+  }
+}

--- a/app/src/androidTest/java/com/markleaf/notes/data/local/AppDatabaseMigrationTest.kt
+++ b/app/src/androidTest/java/com/markleaf/notes/data/local/AppDatabaseMigrationTest.kt
@@ -101,6 +101,30 @@ class AppDatabaseMigrationTest {
             assertNotNull(cursor)
         }
 
+        // #214: v17→v18 adds `note_view_state`. A legacy note has no row, which
+        // reads as "never left anywhere" — i.e. opens at the top, exactly as it
+        // did before the setting existed.
+        db.openHelper.writableDatabase.query(
+            "SELECT COUNT(*) FROM note_view_state WHERE noteId = '42'"
+        ).use { cursor ->
+            assertTrue(cursor.moveToFirst())
+            assertEquals(0, cursor.getInt(0))
+        }
+
+        // The position is owned by its note: deleting the note takes the row
+        // with it, so nothing has to remember to clean up after a delete.
+        db.openHelper.writableDatabase.run {
+            execSQL("PRAGMA foreign_keys = ON")
+            execSQL(
+                "INSERT INTO note_view_state (noteId, caretOffset, previewIndex) VALUES ('42', 120, 4)"
+            )
+            execSQL("DELETE FROM notes WHERE id = '42'")
+            query("SELECT COUNT(*) FROM note_view_state WHERE noteId = '42'").use { cursor ->
+                assertTrue(cursor.moveToFirst())
+                assertEquals(0, cursor.getInt(0))
+            }
+        }
+
         db.close()
     }
 

--- a/app/src/main/java/com/markleaf/notes/data/local/AppDatabase.kt
+++ b/app/src/main/java/com/markleaf/notes/data/local/AppDatabase.kt
@@ -9,12 +9,14 @@ import androidx.sqlite.db.SupportSQLiteDatabase
 import com.markleaf.notes.data.local.dao.AttachmentDao
 import com.markleaf.notes.data.local.dao.NoteDao
 import com.markleaf.notes.data.local.dao.NoteLinkDao
+import com.markleaf.notes.data.local.dao.NoteViewStateDao
 import com.markleaf.notes.data.local.dao.TagDao
 import com.markleaf.notes.data.local.entity.AttachmentEntity
 import com.markleaf.notes.data.local.entity.NoteEntity
 import com.markleaf.notes.data.local.entity.NoteFtsEntity
 import com.markleaf.notes.data.local.entity.NoteLinkEntity
 import com.markleaf.notes.data.local.entity.NoteTagCrossRef
+import com.markleaf.notes.data.local.entity.NoteViewStateEntity
 import com.markleaf.notes.data.local.entity.TagEntity
 
 @Database(
@@ -24,9 +26,10 @@ import com.markleaf.notes.data.local.entity.TagEntity
         NoteTagCrossRef::class,
         NoteFtsEntity::class,
         NoteLinkEntity::class,
-        AttachmentEntity::class
+        AttachmentEntity::class,
+        NoteViewStateEntity::class
     ],
-    version = 17,
+    version = 18,
     exportSchema = true
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -34,6 +37,7 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun tagDao(): TagDao
     abstract fun noteLinkDao(): NoteLinkDao
     abstract fun attachmentDao(): AttachmentDao
+    abstract fun noteViewStateDao(): NoteViewStateDao
 
     companion object {
         @Volatile
@@ -293,6 +297,28 @@ abstract class AppDatabase : RoomDatabase() {
             }
         }
 
+        // v17 → v18 (#214): remember where each note was left, for the
+        // "Open notes at: where I left off" setting. Its own table rather than
+        // columns on `notes` — see NoteViewStateEntity for why reopening a note
+        // must not be able to touch the note row. Nothing to backfill: a note
+        // with no row has never been left anywhere, which reads as "top".
+        private val MIGRATION_17_18 = object : Migration(17, 18) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS `note_view_state` (
+                        `noteId` TEXT NOT NULL,
+                        `caretOffset` INTEGER NOT NULL,
+                        `previewIndex` INTEGER NOT NULL,
+                        PRIMARY KEY(`noteId`),
+                        FOREIGN KEY(`noteId`) REFERENCES `notes`(`id`)
+                            ON UPDATE NO ACTION ON DELETE CASCADE
+                    )
+                    """.trimIndent()
+                )
+            }
+        }
+
         internal val ALL_MIGRATIONS = arrayOf(
             MIGRATION_4_5,
             MIGRATION_5_6,
@@ -307,7 +333,8 @@ abstract class AppDatabase : RoomDatabase() {
             MIGRATION_13_14,
             MIGRATION_14_15,
             MIGRATION_15_16,
-            MIGRATION_16_17
+            MIGRATION_16_17,
+            MIGRATION_17_18
         )
     }
 }

--- a/app/src/main/java/com/markleaf/notes/data/local/dao/NoteViewStateDao.kt
+++ b/app/src/main/java/com/markleaf/notes/data/local/dao/NoteViewStateDao.kt
@@ -1,0 +1,20 @@
+package com.markleaf.notes.data.local.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.markleaf.notes.data.local.entity.NoteViewStateEntity
+
+/**
+ * Reads and writes the per-note scroll position behind "Open notes at: where I
+ * left off" (#214). One row per note, replaced outright each time.
+ */
+@Dao
+interface NoteViewStateDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(state: NoteViewStateEntity)
+
+    @Query("SELECT * FROM note_view_state WHERE noteId = :noteId")
+    suspend fun getForNote(noteId: String): NoteViewStateEntity?
+}

--- a/app/src/main/java/com/markleaf/notes/data/local/entity/NoteViewStateEntity.kt
+++ b/app/src/main/java/com/markleaf/notes/data/local/entity/NoteViewStateEntity.kt
@@ -1,0 +1,48 @@
+package com.markleaf.notes.data.local.entity
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.PrimaryKey
+
+/**
+ * Where a note was last left, for the "Open notes at: where I left off" setting
+ * (#214).
+ *
+ * Deliberately its own table rather than columns on `notes`. Reopening a note is
+ * not editing it: a position written into the note row would ride along with
+ * every `updateNote` call, and the one field the folder reconcile reads to
+ * decide "has this note changed" is on that same row. Keeping the position out
+ * here means recording it cannot touch `updatedAt`, cannot reorder the
+ * recently-updated list, and cannot reach the mirror file — merely reading a
+ * note must never look like an edit to whatever syncs the user's folder.
+ *
+ * The row is owned by the note and cascades away with it, so nothing needs to
+ * remember to clean it up on delete.
+ */
+@Entity(
+    tableName = "note_view_state",
+    foreignKeys = [
+        ForeignKey(
+            entity = NoteEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["noteId"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ]
+)
+data class NoteViewStateEntity(
+    /** Also the primary key — one position per note. Indexed as the PK, so the
+     *  foreign key needs no index of its own. */
+    @PrimaryKey
+    val noteId: String,
+    /**
+     * Caret offset in the note's markdown. Stored as written and clamped on
+     * read: the text can be shorter by the time the note is opened again — the
+     * note may have been edited in another app, or a sync may have brought in a
+     * smaller version — and an offset past the end must not be trusted.
+     */
+    val caretOffset: Int,
+    /** Index of the rendered preview block that was in view. Clamped on read
+     *  for the same reason. */
+    val previewIndex: Int
+)

--- a/app/src/main/java/com/markleaf/notes/data/settings/AppSettings.kt
+++ b/app/src/main/java/com/markleaf/notes/data/settings/AppSettings.kt
@@ -39,8 +39,34 @@ data class AppSettings(
      *  Settings or by long-pressing the editor's view-toggle icon; a note with
      *  no content yet (a just-created note) still opens in edit so you can start
      *  typing (#200). */
-    val openNotesInPreview: Boolean = false
+    val openNotesInPreview: Boolean = false,
+    /** Where a note is positioned when it opens. Defaults to [OpenNotesAt.TOP],
+     *  which is how Markleaf has always behaved (#214). */
+    val openNotesAt: OpenNotesAt = OpenNotesAt.TOP
 )
+
+/**
+ * Where the editor and preview land when a note opens (#214).
+ *
+ * Requested by someone keeping long append-style notes, for whom the top is the
+ * one part of the note they never want to see. [LAST_POSITION] is the third
+ * value they asked to try: append-style notes want the bottom, but reading-style
+ * ones usually want wherever you stopped.
+ */
+enum class OpenNotesAt {
+    /** The start of the note — the original behaviour, and the default. */
+    TOP,
+
+    /** The end of the note, for notes you only ever add to. */
+    BOTTOM,
+
+    /**
+     * Wherever this note was left last time. The position lives in the app's
+     * own database, never in the note's file, and is only recorded while this
+     * value is selected — turning the setting off stops Markleaf remembering.
+     */
+    LAST_POSITION
+}
 
 /** Notes-list sort orders offered by the top-bar sort menu (#191). */
 enum class NotesSortMode {

--- a/app/src/main/java/com/markleaf/notes/data/settings/AppSettingsRepository.kt
+++ b/app/src/main/java/com/markleaf/notes/data/settings/AppSettingsRepository.kt
@@ -72,7 +72,10 @@ class AppSettingsRepository internal constructor(
                 ?: NotesSortMode.UPDATED_DESC,
             searchTitlesOnly = preferences[SEARCH_TITLES_ONLY] ?: false,
             lastOpenedNoteId = preferences[LAST_OPENED_NOTE_ID],
-            openNotesInPreview = preferences[OPEN_NOTES_IN_PREVIEW] ?: false
+            openNotesInPreview = preferences[OPEN_NOTES_IN_PREVIEW] ?: false,
+            openNotesAt = preferences[OPEN_NOTES_AT]
+                ?.let { value -> enumValueOrDefault(value, OpenNotesAt.TOP) }
+                ?: OpenNotesAt.TOP
         )
     }
 
@@ -263,6 +266,12 @@ class AppSettingsRepository internal constructor(
         }
     }
 
+    suspend fun setOpenNotesAt(where: OpenNotesAt) {
+        persist { preferences ->
+            preferences[OPEN_NOTES_AT] = where.name
+        }
+    }
+
     /**
      * Every write funnels through here inside [NonCancellable]. Settings writes
      * are typically launched from a screen's `rememberCoroutineScope`, and a
@@ -303,5 +312,6 @@ class AppSettingsRepository internal constructor(
         val SEARCH_TITLES_ONLY = booleanPreferencesKey("search_titles_only")
         val LAST_OPENED_NOTE_ID = stringPreferencesKey("last_opened_note_id")
         val OPEN_NOTES_IN_PREVIEW = booleanPreferencesKey("open_notes_in_preview")
+        val OPEN_NOTES_AT = stringPreferencesKey("open_notes_at")
     }
 }

--- a/app/src/main/java/com/markleaf/notes/feature/editor/EditorScreen.kt
+++ b/app/src/main/java/com/markleaf/notes/feature/editor/EditorScreen.kt
@@ -53,6 +53,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -87,12 +88,14 @@ import com.markleaf.notes.core.markdown.preview.TocHeading
 import com.markleaf.notes.core.markdown.preview.extractHeadings
 import com.markleaf.notes.core.text.TitleExtractor
 import com.markleaf.notes.data.local.AppDatabase
+import com.markleaf.notes.data.local.entity.NoteViewStateEntity
 import com.markleaf.notes.data.repository.LocalNoteLinkRepository
 import com.markleaf.notes.data.repository.LocalNoteRepository
 import com.markleaf.notes.data.repository.LocalTagRepository
 import com.markleaf.notes.data.settings.AppSettings
 import com.markleaf.notes.data.settings.AppSettingsRepository
 import com.markleaf.notes.data.settings.MarkdownSyntaxVisibility
+import com.markleaf.notes.data.settings.OpenNotesAt
 import com.markleaf.notes.data.sync.NoteFolderMirror
 import com.markleaf.notes.data.sync.syncFolderUriOrNull
 import com.markleaf.notes.domain.model.Note
@@ -102,6 +105,8 @@ import com.markleaf.notes.util.HapticFeedback
 import com.markleaf.notes.util.ExportPdf
 import com.markleaf.notes.util.ShareNoteUtil
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.delay
@@ -118,6 +123,7 @@ fun EditorScreen(
 ) {
     val context = LocalContext.current
     val db = remember { AppDatabase.getInstance(context) }
+    val viewStateDao = remember { db.noteViewStateDao() }
     val repo = remember { LocalNoteRepository(db) }
     val tagRepo = remember { LocalTagRepository(db) }
     val linkRepo = remember { LocalNoteLinkRepository(db) }
@@ -138,7 +144,7 @@ fun EditorScreen(
     val previewListState = rememberLazyListState()
     var showInfo by remember(noteId) { mutableStateOf(false) }
     var showOutline by remember(noteId) { mutableStateOf(false) }
-    var pendingPreviewScrollIndex by remember(noteId) { mutableStateOf<Int?>(null) }
+    var pendingPreviewScroll by remember(noteId) { mutableStateOf<PreviewScrollRequest?>(null) }
     val shouldPreparePreview = isPreviewMode || showOutline
     val previewLines = remember(editorState.text, shouldPreparePreview) {
         if (shouldPreparePreview) SimpleMarkdownPreview.parse(editorState.text) else emptyList()
@@ -309,10 +315,36 @@ fun EditorScreen(
             // snapshot, which starts on the default before DataStore emits) so
             // an existing note honours "open notes in preview" on its very first
             // frame instead of flashing edit (#200). New notes stay in edit.
-            val openInPreview = settingsRepository.settings.first().openNotesInPreview
+            val persistedSettings = settingsRepository.settings.first()
+            val openInPreview = persistedSettings.openNotesInPreview
             val loadedNote = repo.getNote(noteId)
             val content = loadedNote?.contentMarkdown.orEmpty()
-            editorState = TextFieldValue(content)
+            // Where the note opens (#214). Read from the same persisted
+            // snapshot as the preview setting above, for the same reason: the
+            // collected state starts on the default, so using it here would
+            // land at the top and then jump.
+            val lastPosition = if (persistedSettings.openNotesAt == OpenNotesAt.LAST_POSITION) {
+                viewStateDao.getForNote(noteId)
+            } else {
+                null
+            }
+            val caret = when (persistedSettings.openNotesAt) {
+                OpenNotesAt.TOP -> 0
+                OpenNotesAt.BOTTOM -> content.length
+                OpenNotesAt.LAST_POSITION -> lastPosition?.caretOffset ?: 0
+            }
+            // Clamped, never trusted: the note can be shorter than when the
+            // position was recorded — edited in another app, or a smaller
+            // version brought in by sync.
+            editorState = TextFieldValue(content, TextRange(caret.coerceIn(0, content.length)))
+            pendingPreviewScroll = when (persistedSettings.openNotesAt) {
+                OpenNotesAt.TOP -> null
+                // Clamped against the rendered list when the scroll runs, so
+                // "as far as it goes" is all this has to say.
+                OpenNotesAt.BOTTOM -> PreviewScrollRequest(Int.MAX_VALUE, animate = false)
+                OpenNotesAt.LAST_POSITION ->
+                    lastPosition?.let { PreviewScrollRequest(it.previewIndex, animate = false) }
+            }
             // Only land in preview when there is something to preview. A
             // brand-new note is created first and then opened with a real id
             // (the FAB path in MarkleafNavHost), so `noteId != null` alone would
@@ -381,13 +413,60 @@ fun EditorScreen(
         }
     }
 
-    LaunchedEffect(isPreviewMode, pendingPreviewScrollIndex) {
-        val index = pendingPreviewScrollIndex ?: return@LaunchedEffect
-        if (isPreviewMode) {
-            withFrameNanos { }
-            previewListState.animateScrollToItem(index)
-            pendingPreviewScrollIndex = null
+    // Preview scrolls that have to wait for the preview to exist: the outline's
+    // jump-to-heading, and restoring where the note was left (#214). Held until
+    // the list actually has rows, and clamped against them — the request can name
+    // a block that a shorter note no longer has. Restores are instant; a jump the
+    // user asked for animates, so it reads as movement rather than a cut.
+    LaunchedEffect(isPreviewMode, previewLines.size, pendingPreviewScroll) {
+        val request = pendingPreviewScroll ?: return@LaunchedEffect
+        if (!isPreviewMode || previewLines.isEmpty()) return@LaunchedEffect
+        withFrameNanos { }
+        val target = request.index.coerceIn(0, previewLines.lastIndex)
+        if (request.animate) {
+            previewListState.animateScrollToItem(target)
+        } else {
+            previewListState.scrollToItem(target)
         }
+        pendingPreviewScroll = null
+    }
+
+    // Record where the note was left, for "Open notes at: where I left off".
+    // Only while that value is selected — with the setting off, Markleaf keeps
+    // no record of where anyone was. Debounced, so typing a paragraph is one
+    // write at the end of it rather than one per keystroke, and written while
+    // the screen is still composed so it survives the process being killed
+    // rather than depending on a tidy exit.
+    LaunchedEffect(noteId, isLoaded, appSettings.openNotesAt) {
+        if (noteId == null || !isLoaded) return@LaunchedEffect
+        if (appSettings.openNotesAt != OpenNotesAt.LAST_POSITION) return@LaunchedEffect
+        snapshotFlow {
+            Triple(
+                isPreviewMode,
+                editorState.selection.start,
+                previewListState.firstVisibleItemIndex
+            )
+        }
+            .distinctUntilChanged()
+            // collectLatest + delay rather than debounce(): the operator is
+            // still a preview API, and this is the same behaviour — a new
+            // position cancels the pending write and restarts the wait.
+            .collectLatest { (inPreview, caretOffset, previewIndex) ->
+                delay(POSITION_WRITE_DEBOUNCE_MS)
+                // Only the surface on screen knows anything. While you are
+                // editing, the preview list is not composed and reports 0;
+                // while you are reading, the caret has not moved since you
+                // left the editor. Writing both would have each surface blank
+                // the other's position every time you switched.
+                val stored = viewStateDao.getForNote(noteId)
+                viewStateDao.upsert(
+                    NoteViewStateEntity(
+                        noteId = noteId,
+                        caretOffset = if (inPreview) stored?.caretOffset ?: caretOffset else caretOffset,
+                        previewIndex = if (inPreview) previewIndex else stored?.previewIndex ?: previewIndex
+                    )
+                )
+            }
     }
 
     val isFormattingPreempted =
@@ -428,7 +507,7 @@ fun EditorScreen(
         val offset = heading.sourceLine
             ?.let { MarkdownEditActions.offsetOfLine(editorState.text, it) }
         if (isPreviewMode || offset == null) {
-            pendingPreviewScrollIndex = heading.index
+            pendingPreviewScroll = PreviewScrollRequest(heading.index, animate = true)
             if (!isPreviewMode) isPreviewMode = true
         } else {
             editorState = editorState.copy(selection = TextRange(offset))
@@ -592,14 +671,14 @@ fun EditorScreen(
             label = "Editor preview mode"
         ) { previewMode ->
             if (previewMode) {
-                Column(
+                Box(
                     modifier = Modifier
                         .fillMaxSize()
                         .padding(paddingValues)
                 ) {
                     MarkdownPreviewList(
                         lines = previewLines,
-                        modifier = Modifier.weight(1f, fill = false),
+                        modifier = Modifier.fillMaxSize(),
                         contentPadding = PaddingValues(horizontal = 20.dp, vertical = 12.dp),
                         listState = previewListState,
                         // Tapping a checkbox in the preview flips it in the
@@ -650,6 +729,27 @@ fun EditorScreen(
                             imageAltEditing = path to currentAlt
                         }
                     )
+
+                    // The same jump control as the editor (#214). Here the
+                    // scroll position is known outright, so the direction is
+                    // the honest one rather than inferred from a caret.
+                    if (isLongEnoughToJump(editorState.text) && previewLines.isNotEmpty()) {
+                        val toBottom =
+                            previewListState.firstVisibleItemIndex < previewLines.size / 2
+                        JumpToEndButton(
+                            jumpsToBottom = toBottom,
+                            onClick = {
+                                coroutineScope.launch {
+                                    previewListState.animateScrollToItem(
+                                        if (toBottom) previewLines.lastIndex else 0
+                                    )
+                                }
+                            },
+                            modifier = Modifier
+                                .align(Alignment.BottomEnd)
+                                .padding(end = 20.dp, bottom = 20.dp)
+                        )
+                    }
                 }
             } else {
                 // imePadding() shrinks the editor body when the soft keyboard is up so
@@ -866,6 +966,30 @@ fun EditorScreen(
                                 }
                             }
                         )
+
+                        // Jump to the far end of a long note (#214). Which end
+                        // that is follows the caret: after a jump the caret is
+                        // at the other end, so the button flips and the same
+                        // spot takes you back. Hidden in focus mode, which
+                        // exists to remove exactly this kind of furniture.
+                        if (!isFocusMode && isLongEnoughToJump(editorState.text)) {
+                            val toBottom =
+                                editorState.selection.start < editorState.text.length / 2
+                            JumpToEndButton(
+                                jumpsToBottom = toBottom,
+                                onClick = {
+                                    editorState = editorState.copy(
+                                        selection = TextRange(
+                                            if (toBottom) editorState.text.length else 0
+                                        )
+                                    )
+                                    shouldRequestEditorFocus = true
+                                },
+                                modifier = Modifier
+                                    .align(Alignment.BottomEnd)
+                                    .padding(bottom = 8.dp)
+                            )
+                        }
                     }
 
                     if (quickInsertQuery != null && quickInsertItems.isNotEmpty() && !isFocusMode) {
@@ -993,6 +1117,20 @@ fun EditorScreen(
 }
 private const val MAX_WIKILINK_SUGGESTIONS = 8
 private const val MAX_TAG_SUGGESTIONS = 8
+
+/**
+ * How long the note has to sit still before its position is written (#214).
+ * Long enough that typing a paragraph costs one write rather than dozens,
+ * short enough that putting the phone down mid-note records where you were.
+ */
+private const val POSITION_WRITE_DEBOUNCE_MS = 1_000L
+
+/**
+ * A preview scroll waiting for the preview to be built. [animate] separates the
+ * two callers: restoring where a note was left should already be there when the
+ * note appears, while a jump the user asked for reads better as movement.
+ */
+private data class PreviewScrollRequest(val index: Int, val animate: Boolean)
 
 /**
  * If the cursor sits inside an *unclosed* `[[…` wikilink (no `]]` between

--- a/app/src/main/java/com/markleaf/notes/feature/editor/JumpToEndButton.kt
+++ b/app/src/main/java/com/markleaf/notes/feature/editor/JumpToEndButton.kt
@@ -1,0 +1,67 @@
+package com.markleaf.notes.feature.editor
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SmallFloatingActionButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.markleaf.notes.R
+
+/**
+ * The number of lines a note has to reach before the jump control appears
+ * (#214). Below this a note is at most a screen or two, and scrolling to either
+ * end is a flick — a button would be clutter on every short note in the app.
+ */
+internal const val JUMP_CONTROL_MIN_LINES = 40
+
+/**
+ * Whether [markdown] is long enough to be worth offering a jump.
+ *
+ * Counted on the source text so both surfaces agree: it is the note that is
+ * long, not one rendering of it, and a control that appeared in preview but not
+ * in the editor for the same note would read as a bug.
+ */
+internal fun isLongEnoughToJump(markdown: String): Boolean =
+    markdown.count { it == '\n' } + 1 >= JUMP_CONTROL_MIN_LINES
+
+/**
+ * A small button that jumps to whichever end of the note you are further from
+ * (#214).
+ *
+ * Deliberately not tied to the "open notes at" setting: wanting to get to the
+ * other end of a long note is not the same preference as wanting to start
+ * there, and hiding it behind a toggle would mean the people who need it most
+ * have to know it exists to turn it on.
+ */
+@Composable
+internal fun JumpToEndButton(
+    /** True when the far end is the bottom — i.e. you are nearer the top. */
+    jumpsToBottom: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    SmallFloatingActionButton(
+        onClick = onClick,
+        modifier = modifier,
+        containerColor = MaterialTheme.colorScheme.secondaryContainer,
+        contentColor = MaterialTheme.colorScheme.onSecondaryContainer
+    ) {
+        Icon(
+            imageVector = if (jumpsToBottom) {
+                Icons.Default.KeyboardArrowDown
+            } else {
+                Icons.Default.KeyboardArrowUp
+            },
+            contentDescription = stringResource(
+                if (jumpsToBottom) R.string.jump_to_end else R.string.jump_to_start
+            ),
+            modifier = Modifier.size(24.dp)
+        )
+    }
+}

--- a/app/src/main/java/com/markleaf/notes/feature/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/markleaf/notes/feature/settings/SettingsScreen.kt
@@ -63,6 +63,7 @@ import com.markleaf.notes.data.settings.ColorPalette
 import com.markleaf.notes.data.settings.EditorFont
 import com.markleaf.notes.data.settings.EditorLineWidth
 import com.markleaf.notes.data.settings.MarkdownSyntaxVisibility
+import com.markleaf.notes.data.settings.OpenNotesAt
 import com.markleaf.notes.data.sync.NoteFolderMirror
 import com.markleaf.notes.data.sync.NoteImporter
 import com.markleaf.notes.data.sync.syncFolderUriOrNull
@@ -324,6 +325,40 @@ fun SettingsScreen(
                                     settingsRepository.setOpenNotesInPreview(checked)
                                 }
                             }
+                        )
+                        Spacer(Modifier.height(12.dp))
+                        Text(
+                            text = stringResource(R.string.open_notes_at),
+                            style = MaterialTheme.typography.bodyMedium,
+                            fontWeight = FontWeight.Medium,
+                            color = MaterialTheme.colorScheme.onBackground
+                        )
+                        Spacer(Modifier.height(8.dp))
+                        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                            OpenNotesAt.entries.forEach { where ->
+                                val selected = appSettings.openNotesAt == where
+                                if (selected) {
+                                    Button(onClick = {}) {
+                                        Text(where.localizedLabel())
+                                    }
+                                } else {
+                                    OutlinedButton(
+                                        onClick = {
+                                            scope.launch {
+                                                settingsRepository.setOpenNotesAt(where)
+                                            }
+                                        }
+                                    ) {
+                                        Text(where.localizedLabel())
+                                    }
+                                }
+                            }
+                        }
+                        Spacer(Modifier.height(6.dp))
+                        Text(
+                            text = stringResource(R.string.open_notes_at_description),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
                         )
                     }
 
@@ -869,6 +904,15 @@ private fun EditorLineWidth.localizedLabel(): String {
         EditorLineWidth.NARROW -> stringResource(R.string.line_width_narrow)
         EditorLineWidth.COMFORTABLE -> stringResource(R.string.line_width_comfortable)
         EditorLineWidth.WIDE -> stringResource(R.string.line_width_wide)
+    }
+}
+
+@Composable
+private fun OpenNotesAt.localizedLabel(): String {
+    return when (this) {
+        OpenNotesAt.TOP -> stringResource(R.string.open_notes_at_top)
+        OpenNotesAt.BOTTOM -> stringResource(R.string.open_notes_at_bottom)
+        OpenNotesAt.LAST_POSITION -> stringResource(R.string.open_notes_at_last_position)
     }
 }
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -181,6 +181,13 @@
     <string name="reopen_last_note_description">Beim Start direkt in der zuletzt bearbeiteten Notiz beginnen statt in der Notizenliste.</string>
     <string name="open_notes_in_preview">Notizen in der Vorschau öffnen</string>
     <string name="open_notes_in_preview_description">Beim Öffnen einer Notiz die gerenderte Vorschau statt der Bearbeitungsansicht anzeigen. Neue Notizen öffnen weiterhin zum Bearbeiten. Tipp: Vorschau-/Bearbeiten-Symbol in einer Notiz lange drücken, um dies umzuschalten.</string>
+    <string name="open_notes_at">Notizen öffnen bei</string>
+    <string name="open_notes_at_top">Anfang</string>
+    <string name="open_notes_at_bottom">Ende</string>
+    <string name="open_notes_at_last_position">Letzter Stand</string>
+    <string name="open_notes_at_description">Wo eine Notiz beim Öffnen landet. „Ende“ passt zu Notizen, an die du nur anfügst. „Letzter Stand“ merkt sich die Position jeder Notiz nur in der App — in deine Dateien wird nichts geschrieben.</string>
+    <string name="jump_to_end">Ans Ende springen</string>
+    <string name="jump_to_start">An den Anfang springen</string>
     <string name="view_mode_locked">Notizen öffnen jetzt in der Vorschau</string>
     <string name="view_mode_unlocked">Notizen öffnen jetzt zum Bearbeiten</string>
     <string name="lock_view_mode">Ansichtsmodus sperren</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -181,6 +181,13 @@
     <string name="reopen_last_note_description">Empieza en la nota que editaste por última vez en lugar de la lista de notas.</string>
     <string name="open_notes_in_preview">Abrir notas en vista previa</string>
     <string name="open_notes_in_preview_description">Muestra la vista previa renderizada al abrir una nota en lugar de la vista de edición. Las notas nuevas se abren para editar. Consejo: mantén pulsado el icono de vista previa/editar en una nota para cambiarlo.</string>
+    <string name="open_notes_at">Abrir notas en</string>
+    <string name="open_notes_at_top">Principio</string>
+    <string name="open_notes_at_bottom">Final</string>
+    <string name="open_notes_at_last_position">Donde lo dejé</string>
+    <string name="open_notes_at_description">Dónde queda una nota al abrirla. «Final» va bien con notas a las que solo añades. «Donde lo dejé» recuerda la posición de cada nota solo en la app: no se escribe nada en tus archivos.</string>
+    <string name="jump_to_end">Ir al final</string>
+    <string name="jump_to_start">Ir al principio</string>
     <string name="view_mode_locked">Las notas ahora se abren en vista previa</string>
     <string name="view_mode_unlocked">Las notas ahora se abren en edición</string>
     <string name="lock_view_mode">Bloquear modo de vista</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -181,6 +181,13 @@
     <string name="reopen_last_note_description">Démarre dans la dernière note modifiée plutôt que dans la liste des notes.</string>
     <string name="open_notes_in_preview">Ouvrir les notes en aperçu</string>
     <string name="open_notes_in_preview_description">Afficher l\'aperçu rendu à l\'ouverture d\'une note au lieu de la vue d\'édition. Les nouvelles notes s\'ouvrent toujours en édition. Astuce : appui long sur l\'icône aperçu/modifier dans une note pour basculer.</string>
+    <string name="open_notes_at">Ouvrir les notes à</string>
+    <string name="open_notes_at_top">Début</string>
+    <string name="open_notes_at_bottom">Fin</string>
+    <string name="open_notes_at_last_position">Là où je me suis arrêté</string>
+    <string name="open_notes_at_description">L\'endroit où une note s\'ouvre. « Fin » convient aux notes que vous ne faites que compléter. « Là où je me suis arrêté » retient la position de chaque note dans l\'application uniquement : rien n\'est écrit dans vos fichiers.</string>
+    <string name="jump_to_end">Aller à la fin</string>
+    <string name="jump_to_start">Aller au début</string>
     <string name="view_mode_locked">Les notes s\'ouvrent désormais en aperçu</string>
     <string name="view_mode_unlocked">Les notes s\'ouvrent désormais en édition</string>
     <string name="lock_view_mode">Verrouiller le mode d\'affichage</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -179,6 +179,13 @@
     <string name="reopen_last_note_description">起動時にノート一覧ではなく、最後に編集したノートから始めます。</string>
     <string name="open_notes_in_preview">ノートをプレビューで開く</string>
     <string name="open_notes_in_preview_description">ノートを開いたときに編集画面ではなくプレビューを表示します。新しいノートは編集で開きます。ノート内でプレビュー/編集アイコンを長押しすると切り替えられます。</string>
+    <string name="open_notes_at">ノートを開く位置</string>
+    <string name="open_notes_at_top">先頭</string>
+    <string name="open_notes_at_bottom">末尾</string>
+    <string name="open_notes_at_last_position">前回の位置</string>
+    <string name="open_notes_at_description">ノートを開いたときに表示する位置です。「末尾」は書き足していくノートに向いています。「前回の位置」はノートごとの位置をアプリ内にのみ記憶し、ファイルには何も書き込みません。</string>
+    <string name="jump_to_end">末尾へ移動</string>
+    <string name="jump_to_start">先頭へ移動</string>
     <string name="view_mode_locked">ノートはプレビューで開きます</string>
     <string name="view_mode_unlocked">ノートは編集で開きます</string>
     <string name="lock_view_mode">表示モードをロック</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -179,6 +179,13 @@
     <string name="reopen_last_note_description">앱을 열 때 노트 목록 대신 마지막으로 편집한 노트에서 시작합니다.</string>
     <string name="open_notes_in_preview">노트를 미리보기로 열기</string>
     <string name="open_notes_in_preview_description">노트를 열 때 편집 화면 대신 미리보기를 표시합니다. 새 노트는 편집으로 열립니다. 노트에서 미리보기/편집 아이콘을 길게 누르면 이 설정을 바꿀 수 있습니다.</string>
+    <string name="open_notes_at">노트를 열 위치</string>
+    <string name="open_notes_at_top">맨 위</string>
+    <string name="open_notes_at_bottom">맨 아래</string>
+    <string name="open_notes_at_last_position">마지막 위치</string>
+    <string name="open_notes_at_description">노트를 열었을 때 표시할 위치입니다. \'맨 아래\'는 계속 이어 쓰는 노트에 적합합니다. \'마지막 위치\'는 노트별 위치를 앱 안에만 기억하며 파일에는 아무것도 쓰지 않습니다.</string>
+    <string name="jump_to_end">맨 아래로 이동</string>
+    <string name="jump_to_start">맨 위로 이동</string>
     <string name="view_mode_locked">이제 노트가 미리보기로 열립니다</string>
     <string name="view_mode_unlocked">이제 노트가 편집으로 열립니다</string>
     <string name="lock_view_mode">보기 모드 잠금</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -185,6 +185,13 @@
     <string name="reopen_last_note_description">Start in the note you last edited instead of the notes list.</string>
     <string name="open_notes_in_preview">Open notes in preview</string>
     <string name="open_notes_in_preview_description">Show a note\'s rendered preview when you open it instead of the edit view. New notes still open for editing. Tip: long-press the preview/edit icon in a note to toggle this.</string>
+    <string name="open_notes_at">Open notes at</string>
+    <string name="open_notes_at_top">Top</string>
+    <string name="open_notes_at_bottom">Bottom</string>
+    <string name="open_notes_at_last_position">Where I left off</string>
+    <string name="open_notes_at_description">Where a note lands when you open it. Bottom suits notes you only add to. "Where I left off" remembers each note\'s position in the app only — nothing is written into your files.</string>
+    <string name="jump_to_end">Jump to the end</string>
+    <string name="jump_to_start">Jump to the start</string>
     <string name="view_mode_locked">Notes now open in preview</string>
     <string name="view_mode_unlocked">Notes now open in edit</string>
     <string name="lock_view_mode">Lock view mode</string>

--- a/app/src/test/java/com/markleaf/notes/data/settings/AppSettingsTest.kt
+++ b/app/src/test/java/com/markleaf/notes/data/settings/AppSettingsTest.kt
@@ -28,4 +28,15 @@ class AppSettingsTest {
         assertFalse(settings.searchTitlesOnly)
         assertNull(settings.lastOpenedNoteId)
     }
+
+    /**
+     * "Open notes at" was asked for by someone who wanted the bottom (#214) —
+     * but it was added as an option precisely so nobody else's habits change.
+     * A default of anything but [OpenNotesAt.TOP] would move every existing
+     * user's notes under them on update.
+     */
+    @Test
+    fun notesStillOpenAtTheTopByDefault() {
+        assertEquals(OpenNotesAt.TOP, AppSettings().openNotesAt)
+    }
 }

--- a/app/src/test/java/com/markleaf/notes/feature/editor/JumpToEndButtonTest.kt
+++ b/app/src/test/java/com/markleaf/notes/feature/editor/JumpToEndButtonTest.kt
@@ -1,0 +1,39 @@
+package com.markleaf.notes.feature.editor
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The jump control is meant to appear only on notes long enough to need it
+ * (#214) — a button floating over every two-line note would be clutter in an
+ * app whose whole posture is staying out of the way.
+ */
+class JumpToEndButtonTest {
+
+    @Test
+    fun `a short note gets no jump control`() {
+        assertFalse(isLongEnoughToJump(""))
+        assertFalse(isLongEnoughToJump("just a line"))
+        assertFalse(isLongEnoughToJump("a\nb\nc"))
+    }
+
+    @Test
+    fun `the threshold counts lines, not newlines`() {
+        // A note of exactly the threshold has one fewer newline than it has
+        // lines. Off by one here would hide the control on the first note that
+        // qualifies, which is impossible to notice from the outside.
+        val atThreshold = (1..JUMP_CONTROL_MIN_LINES).joinToString("\n") { "line $it" }
+        val justUnder = (1 until JUMP_CONTROL_MIN_LINES).joinToString("\n") { "line $it" }
+
+        assertEquals(JUMP_CONTROL_MIN_LINES - 1, atThreshold.count { it == '\n' })
+        assertTrue(isLongEnoughToJump(atThreshold))
+        assertFalse(isLongEnoughToJump(justUnder))
+    }
+
+    @Test
+    fun `a long note gets the control however short its lines are`() {
+        assertTrue(isLongEnoughToJump("\n".repeat(200)))
+    }
+}


### PR DESCRIPTION
Closes #214.

Notes always opened at the top. For someone keeping long append-style notes, that is the one part of the note they never want to see. Added as an option rather than a change of behaviour — **the default stays Top**, so nobody who liked things as they were notices anything.

## What changed

**Settings → Notes & search → Open notes at: Top / Bottom / Where I left off.**

The reporter was asked whether "remember where I was" would be more useful than "always bottom" and said they would try it, so it ships as the third value rather than instead of the second.

Alongside it, a **jump-to-the-other-end control** on notes past 40 lines, on both the editor and the preview. Deliberately not behind the setting: wanting to reach the far end of a long note is not the same preference as wanting to start there, and hiding it behind a toggle means the people who need it most have to know it exists first.

## Where the position lives, and why

In its own `note_view_state` table, not on the note row, and never in the note file.

Reopening a note is not editing it. A position stored on `notes` would ride along with every `updateNote` call and would sit next to the field the folder reconcile reads to decide whether a note has changed — merely reading a note must never look like an edit to whatever syncs the user's folder. The row cascades away with its note, so nothing has to clean up after a delete.

Two more things the implementation is careful about:

- **Recorded only while "where I left off" is selected.** With the setting off, Markleaf keeps no record of where anyone was.
- **Each surface only records its own position.** The preview list reports block 0 while you are editing, and the caret does not move while you are reading; writing both would have each surface blank the other's every time you switched.

Offsets are clamped on read — the note can be shorter than when the position was taken, if it was edited elsewhere or a smaller version arrived by sync.

## Verification

- `./gradlew test` and `:app:lintRelease` pass.
- Migration test extended: v17→v18 creates the table, a legacy note has no row (so it opens at the top exactly as before), and deleting a note takes its position with it.
- Unit tests for the default value and the jump threshold.
- Roborazzi goldens re-recorded on the Linux runner, committed separately.
- Checked on the phone AVD across all three values: **Bottom** opens at the last line with no keyboard popping up, **where I left off** reopens mid-note after a reopen, and the jump control appears past the threshold, flips direction after use, and scrolls both surfaces.

New strings are translated into all six locales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)