### PR TITLE
feat(sync): keep note metadata beside the files instead of inside them (#216)

### DIFF
--- a/app/src/main/java/com/markleaf/notes/MainActivity.kt
+++ b/app/src/main/java/com/markleaf/notes/MainActivity.kt
@@ -28,6 +28,7 @@ import com.markleaf.notes.data.settings.EditorFont
 import com.markleaf.notes.data.sync.NoteFolderMirror
 import com.markleaf.notes.data.sync.NoteImporter
 import com.markleaf.notes.data.sync.syncFolderUriOrNull
+import com.markleaf.notes.data.sync.mirrorMetadata
 import com.markleaf.notes.feature.lock.BiometricLockGate
 import com.markleaf.notes.feature.onboarding.WelcomeOnboardingSheet
 import com.markleaf.notes.navigation.MarkleafNavHost
@@ -87,7 +88,8 @@ class MainActivity : FragmentActivity() {
                         folderUri = uri,
                         existing = notes,
                         applyUpdate = { updated -> importer.update(updated) },
-                        applyCreate = { created -> importer.create(created) }
+                        applyCreate = { created -> importer.create(created) },
+                        metadata = settings.mirrorMetadata()
                     )
                 }
                 settingsRepository.setSyncLastSyncedAt(System.currentTimeMillis())

--- a/app/src/main/java/com/markleaf/notes/data/settings/AppSettings.kt
+++ b/app/src/main/java/com/markleaf/notes/data/settings/AppSettings.kt
@@ -42,8 +42,40 @@ data class AppSettings(
     val openNotesInPreview: Boolean = false,
     /** Where a note is positioned when it opens. Defaults to [OpenNotesAt.TOP],
      *  which is how Markleaf has always behaved (#214). */
-    val openNotesAt: OpenNotesAt = OpenNotesAt.TOP
+    val openNotesAt: OpenNotesAt = OpenNotesAt.TOP,
+    /** Where the note↔file mapping is kept. Defaults to
+     *  [SyncMetadataMode.FRONTMATTER], the original behaviour (#216). */
+    val syncMetadataMode: SyncMetadataMode = SyncMetadataMode.FRONTMATTER,
+    /**
+     * This install's id, used to name the sidecar index it owns so two devices
+     * writing the same folder never write the same file. Generated on first use
+     * and never sent anywhere — it exists only to keep filenames apart.
+     */
+    val syncDeviceId: String? = null
 )
+
+/**
+ * Where Markleaf keeps the link between a note and its mirror file (#216).
+ *
+ * Requested by someone whose notes are edited in another app and synced by
+ * Nextcloud, for whom the `---` block at the top of every file is text they did
+ * not write sitting in their notes.
+ */
+enum class SyncMetadataMode {
+    /**
+     * A `---` header at the top of each file. The original behaviour and the
+     * default: the id survives a rename by any tool, and a folder of these
+     * files can be reconstructed anywhere without help.
+     */
+    FRONTMATTER,
+
+    /**
+     * A hidden per-device index beside the notes; the `.md` files hold only
+     * what was typed. Costs the rename resilience and leaves the folder unable
+     * to describe itself without the index — see [SidecarIndex].
+     */
+    SIDECAR
+}
 
 /**
  * Where the editor and preview land when a note opens (#214).

--- a/app/src/main/java/com/markleaf/notes/data/settings/AppSettingsRepository.kt
+++ b/app/src/main/java/com/markleaf/notes/data/settings/AppSettingsRepository.kt
@@ -12,6 +12,7 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import com.markleaf.notes.core.security.PasscodeBackoff
 import com.markleaf.notes.core.security.PasscodeHasher
+import java.util.UUID
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.Flow
@@ -75,7 +76,11 @@ class AppSettingsRepository internal constructor(
             openNotesInPreview = preferences[OPEN_NOTES_IN_PREVIEW] ?: false,
             openNotesAt = preferences[OPEN_NOTES_AT]
                 ?.let { value -> enumValueOrDefault(value, OpenNotesAt.TOP) }
-                ?: OpenNotesAt.TOP
+                ?: OpenNotesAt.TOP,
+            syncMetadataMode = preferences[SYNC_METADATA_MODE]
+                ?.let { value -> enumValueOrDefault(value, SyncMetadataMode.FRONTMATTER) }
+                ?: SyncMetadataMode.FRONTMATTER,
+            syncDeviceId = preferences[SYNC_DEVICE_ID]
         )
     }
 
@@ -272,6 +277,34 @@ class AppSettingsRepository internal constructor(
         }
     }
 
+    suspend fun setSyncMetadataMode(mode: SyncMetadataMode) {
+        persist { preferences ->
+            preferences[SYNC_METADATA_MODE] = mode.name
+        }
+    }
+
+    /**
+     * This install's device id, generating and persisting one on first call.
+     *
+     * Only ever used to name the sidecar index file this device owns (#216), so
+     * that two devices syncing one folder never write the same file. A random
+     * UUID's first segment is short enough to keep the filename readable and
+     * far more than enough to keep a handful of devices apart.
+     */
+    suspend fun getOrCreateSyncDeviceId(): String {
+        val existing = settings.first().syncDeviceId
+        if (!existing.isNullOrBlank()) return existing
+        val generated = UUID.randomUUID().toString().substringBefore('-')
+        persist { preferences ->
+            // Re-check inside the edit: two callers racing must agree on one id,
+            // or the folder collects an orphan index per loser.
+            if (preferences[SYNC_DEVICE_ID].isNullOrBlank()) {
+                preferences[SYNC_DEVICE_ID] = generated
+            }
+        }
+        return settings.first().syncDeviceId ?: generated
+    }
+
     /**
      * Every write funnels through here inside [NonCancellable]. Settings writes
      * are typically launched from a screen's `rememberCoroutineScope`, and a
@@ -313,5 +346,7 @@ class AppSettingsRepository internal constructor(
         val LAST_OPENED_NOTE_ID = stringPreferencesKey("last_opened_note_id")
         val OPEN_NOTES_IN_PREVIEW = booleanPreferencesKey("open_notes_in_preview")
         val OPEN_NOTES_AT = stringPreferencesKey("open_notes_at")
+        val SYNC_METADATA_MODE = stringPreferencesKey("sync_metadata_mode")
+        val SYNC_DEVICE_ID = stringPreferencesKey("sync_device_id")
     }
 }

--- a/app/src/main/java/com/markleaf/notes/data/sync/NoteFolderMirror.kt
+++ b/app/src/main/java/com/markleaf/notes/data/sync/NoteFolderMirror.kt
@@ -7,6 +7,7 @@ import com.markleaf.notes.R
 import com.markleaf.notes.core.text.TitleExtractor
 import com.markleaf.notes.data.settings.AppSettings
 import com.markleaf.notes.data.settings.SyncFileExtension
+import com.markleaf.notes.data.settings.SyncMetadataMode
 import com.markleaf.notes.domain.model.Note
 import java.io.BufferedWriter
 import java.io.File
@@ -14,6 +15,20 @@ import java.io.OutputStreamWriter
 import java.time.Instant
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Where a mirror pass keeps the note↔file link (#216).
+ *
+ * A sealed pair rather than a mode flag plus a nullable device id, so "sidecar
+ * mode with no device id" — an index file nobody owns — cannot be expressed.
+ */
+sealed interface MirrorMetadata {
+    /** A `---` header in each file. The default, and what every folder written before #216 holds. */
+    data object Frontmatter : MirrorMetadata
+
+    /** A hidden index owned by [deviceId]; the note files carry only their text. */
+    data class Sidecar(val deviceId: String) : MirrorMetadata
+}
 
 /**
  * Read/write notes to a user-chosen SAF folder as `.md` / `.txt` files with our
@@ -44,6 +59,9 @@ import java.util.concurrent.ConcurrentHashMap
  *   safely persisted under the old name.
  * - Filename collisions (two notes with the same title) get a " (2)" suffix,
  *   never overwriting an unrelated file.
+ *
+ * An opt-in alternative keeps that bookkeeping in a hidden index beside the
+ * notes instead of inside them — see [MirrorMetadata] and [SidecarIndex] (#216).
  */
 object NoteFolderMirror {
 
@@ -74,10 +92,11 @@ object NoteFolderMirror {
         context: Context,
         folderUri: Uri,
         note: Note,
-        extension: SyncFileExtension = SyncFileExtension.MD
+        extension: SyncFileExtension = SyncFileExtension.MD,
+        metadata: MirrorMetadata = MirrorMetadata.Frontmatter
     ): Boolean {
         val folder = DocumentFile.fromTreeUri(context, folderUri) ?: return false
-        return writeNoteInto(context, folder, note, extension)
+        return writeNoteInto(context, folder, note, extension, metadata)
     }
 
     /**
@@ -93,9 +112,13 @@ object NoteFolderMirror {
         context: Context,
         folder: DocumentFile,
         note: Note,
-        extension: SyncFileExtension
+        extension: SyncFileExtension,
+        metadata: MirrorMetadata = MirrorMetadata.Frontmatter
     ): Boolean {
         if (!folder.canWrite()) return false
+        if (metadata is MirrorMetadata.Sidecar) {
+            return writeNoteSidecar(context, folder, note, extension, metadata.deviceId)
+        }
 
         // Fast path: we remember which document holds this note, its name
         // already matches the title, and it still carries the note's id. One
@@ -127,6 +150,89 @@ object NoteFolderMirror {
         target.name?.let { MirrorFileCache.remember(folder.uri, note.id, target.uri, it) }
         return true
     }
+
+    /**
+     * [writeNoteInto] in sidecar mode: the file gets the note's text and nothing
+     * else, and the bookkeeping goes into this device's index (#216).
+     *
+     * The file is located by the filename the index records, falling back to
+     * adopting an unclaimed file that already carries the note's name — the
+     * same fallback the frontmatter path grew after a lost id forked a copy on
+     * every save (#213). Recording the entry after the write is not optional:
+     * it is what stops the next import seeing an unknown file and importing it
+     * as a second copy of the same note (#140).
+     */
+    private fun writeNoteSidecar(
+        context: Context,
+        folder: DocumentFile,
+        note: Note,
+        extension: SyncFileExtension,
+        deviceId: String
+    ): Boolean {
+        val merged = SidecarStore.load(context, folder, deviceId)
+        val ownEntries = SidecarStore.ownEntries(context, folder, deviceId)
+        val mirrorFiles = folder.listFiles().filter { it.isFile && isMirrorFile(it.name) }
+
+        val recordedName = merged[note.id]?.fileName
+        val existing = recordedName
+            ?.let { name -> mirrorFiles.firstOrNull { it.name.equals(name, ignoreCase = true) } }
+            ?: adoptUnclaimedFile(mirrorFiles, note, merged)
+
+        val ext = existing?.mirrorExtension() ?: extension.value
+        val desiredName = resolveName(note, ext, mirrorFiles, ownFile = existing)
+        val target = existing
+            ?: folder.createFile(mimeTypeFor(ext), desiredName)
+            ?: return false
+
+        // Body first, rename second — a failed rename leaves the bytes safe
+        // under the old name, exactly as in the frontmatter path.
+        val body = note.contentMarkdown
+        if (!writeRawContents(context, target.uri, body)) return false
+        if (existing != null && existing.name != desiredName) {
+            existing.renameTo(desiredName)
+        }
+
+        ownEntries[note.id] = SidecarEntry(
+            noteId = note.id,
+            fileName = target.name ?: desiredName,
+            contentHash = SidecarIndex.hashOf(body),
+            createdAtMillis = note.createdAt.toEpochMilli(),
+            pinned = note.pinned,
+            archived = note.archived
+        )
+        SidecarStore.write(context, folder, deviceId, ownEntries.values)
+        return true
+    }
+
+    /**
+     * A file carrying [note]'s title that no index entry claims — the sidecar
+     * equivalent of the frontmatter path's adoption rule.
+     *
+     * "Unclaimed" is checked against every device's entries, not just ours: a
+     * file another device owns has a note behind it, and taking it would give
+     * two notes one file.
+     */
+    private fun adoptUnclaimedFile(
+        mirrorFiles: List<DocumentFile>,
+        note: Note,
+        merged: Map<String, SidecarEntry>
+    ): DocumentFile? {
+        val base = MirrorFileNames.sanitizeBase(note.title)
+        val claimed = merged.values.mapTo(HashSet()) { it.fileName.lowercase() }
+        return mirrorFiles.firstOrNull { file ->
+            val name = file.name.orEmpty()
+            name.lowercase() !in claimed && MirrorFileNames.isPlainNameFor(name, base)
+        }
+    }
+
+    /** Write [content] verbatim — no header, no trailing additions. */
+    private fun writeRawContents(context: Context, target: Uri, content: String): Boolean =
+        runCatching {
+            context.contentResolver.openOutputStream(target, "wt")?.use { stream ->
+                BufferedWriter(OutputStreamWriter(stream, Charsets.UTF_8)).use { it.write(content) }
+            } ?: return@runCatching false
+            true
+        }.getOrDefault(false)
 
     /** Write [note] (plus any [extraEntries] the file carried) over [target]. */
     private fun writeContents(
@@ -161,9 +267,10 @@ object NoteFolderMirror {
         folderUri: Uri,
         note: Note,
         extension: SyncFileExtension,
+        metadata: MirrorMetadata = MirrorMetadata.Frontmatter,
         onStamped: suspend (Note) -> Unit
     ): Boolean {
-        val wrote = writeNote(context, folderUri, note, extension)
+        val wrote = writeNote(context, folderUri, note, extension, metadata)
         if (wrote) onStamped(note.copy(lastImportedAt = note.updatedAt))
         return wrote
     }
@@ -219,7 +326,12 @@ object NoteFolderMirror {
      * the DB note) is intentionally not implemented to avoid silent data loss
      * when a sync client is mid-flight.
      */
-    fun deleteNote(context: Context, folderUri: Uri, noteId: String): Boolean {
+    fun deleteNote(
+        context: Context,
+        folderUri: Uri,
+        noteId: String,
+        metadata: MirrorMetadata = MirrorMetadata.Frontmatter
+    ): Boolean {
         val folder = DocumentFile.fromTreeUri(context, folderUri) ?: return false
         if (!folder.canWrite()) return false
 
@@ -228,7 +340,21 @@ object NoteFolderMirror {
         MirrorFileCache.forget(noteId)
         var changed = false
         val mirrorFiles = folder.listFiles().filter { it.isFile && isMirrorFile(it.name) }
-        findFileForNote(context, mirrorFiles, noteId)?.let { file ->
+        // In sidecar mode the file carries no id to find it by, so the index is
+        // the only link — and the entry has to go with the file, or the next
+        // pass sees an entry for a note that no longer exists.
+        val target = when (metadata) {
+            is MirrorMetadata.Sidecar -> {
+                val entries = SidecarStore.ownEntries(context, folder, metadata.deviceId)
+                val name = SidecarStore.load(context, folder, metadata.deviceId)[noteId]?.fileName
+                if (entries.remove(noteId) != null) {
+                    SidecarStore.write(context, folder, metadata.deviceId, entries.values)
+                }
+                name?.let { n -> mirrorFiles.firstOrNull { it.name.equals(n, ignoreCase = true) } }
+            }
+            MirrorMetadata.Frontmatter -> findFileForNote(context, mirrorFiles, noteId)
+        }
+        target?.let { file ->
             if (file.delete()) changed = true
         }
         // Also clear the per-note attachments subfolder.
@@ -319,11 +445,12 @@ object NoteFolderMirror {
         folderUri: Uri,
         existing: List<Note>,
         applyUpdate: suspend (Note) -> Unit,
-        applyCreate: suspend (Note) -> Unit
+        applyCreate: suspend (Note) -> Unit,
+        metadata: MirrorMetadata = MirrorMetadata.Frontmatter
     ): ImportResult {
         val folder = DocumentFile.fromTreeUri(context, folderUri)
             ?: return ImportResult(0, 0, 0, 1)
-        return importChangesFrom(context, folder, existing, applyUpdate, applyCreate)
+        return importChangesFrom(context, folder, existing, applyUpdate, applyCreate, metadata)
     }
 
     /**
@@ -335,9 +462,15 @@ object NoteFolderMirror {
         folder: DocumentFile,
         existing: List<Note>,
         applyUpdate: suspend (Note) -> Unit,
-        applyCreate: suspend (Note) -> Unit
+        applyCreate: suspend (Note) -> Unit,
+        metadata: MirrorMetadata = MirrorMetadata.Frontmatter
     ): ImportResult {
         if (!folder.canRead()) return ImportResult(0, 0, 0, 1)
+        if (metadata is MirrorMetadata.Sidecar) {
+            return importChangesSidecar(
+                context, folder, existing, applyUpdate, applyCreate, metadata.deviceId
+            )
+        }
 
         var updated = 0
         var created = 0
@@ -461,8 +594,214 @@ object NoteFolderMirror {
         )
     }
 
+    /**
+     * [importChangesFrom] in sidecar mode (#216).
+     *
+     * Structurally the same pass as the frontmatter one — same Trash rule, same
+     * conflict-copy behaviour — but every decision comes from the index rather
+     * than the file's head, and "has this changed" is a hash comparison rather
+     * than a timestamp one. See [sidecarReconcileAction].
+     *
+     * The index is rewritten once at the end rather than per file: an import
+     * that touches fifty notes should cost the folder one index write, not
+     * fifty, and a sync client watching the folder should see one change.
+     */
+    private suspend fun importChangesSidecar(
+        context: Context,
+        folder: DocumentFile,
+        existing: List<Note>,
+        applyUpdate: suspend (Note) -> Unit,
+        applyCreate: suspend (Note) -> Unit,
+        deviceId: String
+    ): ImportResult {
+        var updated = 0
+        var created = 0
+        var skipped = 0
+        var errors = 0
+        var conflicts = 0
+
+        val byId = existing.associateBy { it.id }
+        val merged = SidecarStore.load(context, folder, deviceId)
+        val byFileName = SidecarIndex.byFileName(merged)
+        val ownEntries = SidecarStore.ownEntries(context, folder, deviceId)
+        val files = folder.listFiles().filter { it.isFile && isMirrorFile(it.name) }
+
+        for (file in files) {
+            val body = runCatching {
+                context.contentResolver.openInputStream(file.uri)?.use { it.readBytes() }
+                    ?.toString(Charsets.UTF_8)
+            }.getOrNull()
+            if (body == null) {
+                errors++
+                continue
+            }
+
+            val fileName = file.name.orEmpty()
+            // A file may still carry a header — written before the mode was
+            // switched, or arriving from a device still in frontmatter mode. Its
+            // block is metadata, not text, and reading it as text would paste it
+            // into the note. Strip it, and use its id when the index has nothing
+            // for this file: an id is a better link than a filename.
+            val parsed = SyncFrontmatter.decode(body)
+            val text = parsed.body
+            val entry = byFileName[fileName.lowercase()]
+            val existingNote = (entry?.noteId ?: parsed.markleafId)?.let(byId::get)
+            val hash = SidecarIndex.hashOf(text)
+            val matchesLastWrite = entry != null && entry.contentHash == hash
+
+            try {
+                when (sidecarReconcileAction(existingNote, matchesLastWrite)) {
+                    Reconcile.SkipTrashed -> skipped++
+                    Reconcile.Skip -> skipped++
+                    Reconcile.Create -> {
+                        val now = Instant.now()
+                        // An entry with no note behind it means the note was
+                        // deleted elsewhere while the file stayed; reusing its
+                        // id keeps the file attached to one note rather than
+                        // spawning a fresh one on every pass.
+                        val createdAt = entry?.createdAtMillis
+                            ?.takeIf { it > 0L }
+                            ?.let(Instant::ofEpochMilli)
+                            ?: parsed.createdAt
+                            ?: now
+                        val newNote = Note(
+                            id = entry?.noteId
+                                // A leftover header still identifies its note —
+                                // a file written before the switch, or by a
+                                // device still in frontmatter mode. Minting a
+                                // fresh id here would give that note two
+                                // identities across devices.
+                                ?: parsed.markleafId
+                                ?: UUID.randomUUID().toString(),
+                            title = TitleExtractor.extractTitle(text),
+                            contentMarkdown = text,
+                            excerpt = TitleExtractor.generateExcerpt(text),
+                            createdAt = createdAt,
+                            updatedAt = now,
+                            pinned = entry?.pinned ?: parsed.pinned ?: false,
+                            archived = entry?.archived ?: parsed.archived ?: false,
+                            lastImportedAt = now,
+                            remoteSeenAt = now
+                        )
+                        applyCreate(newNote)
+                        created++
+                        // The write-back that the frontmatter path performs by
+                        // stamping an id into the file. Without it the next pass
+                        // sees an unclaimed file and imports it again — #140.
+                        ownEntries[newNote.id] = SidecarEntry(
+                            noteId = newNote.id,
+                            fileName = fileName,
+                            contentHash = hash,
+                            createdAtMillis = createdAt.toEpochMilli(),
+                            pinned = newNote.pinned,
+                            archived = newNote.archived
+                        )
+                    }
+                    Reconcile.Conflict -> {
+                        val note = existingNote!!
+                        val baseTitle = TitleExtractor.extractTitle(text)
+                        val duplicate = Note(
+                            id = UUID.randomUUID().toString(),
+                            title = "$baseTitle ${conflictSuffix(context, Instant.now())}",
+                            contentMarkdown = text,
+                            excerpt = TitleExtractor.generateExcerpt(text),
+                            createdAt = Instant.now(),
+                            updatedAt = Instant.now(),
+                            lastImportedAt = Instant.now(),
+                            remoteSeenAt = Instant.now(),
+                            isConflictCopy = true
+                        )
+                        applyCreate(duplicate)
+                        // Record the version we just took a copy of. This is
+                        // what `remoteSeenAt` does on the frontmatter path: it
+                        // stops the next pass copying the same remote version
+                        // again, once a minute, for ever (#217). Nothing the
+                        // user owns moves — the local note is untouched.
+                        ownEntries[note.id] = SidecarEntry(
+                            noteId = note.id,
+                            fileName = fileName,
+                            contentHash = hash,
+                            createdAtMillis = note.createdAt.toEpochMilli(),
+                            pinned = note.pinned,
+                            archived = note.archived
+                        )
+                        conflicts++
+                    }
+                    Reconcile.Overwrite -> {
+                        val note = existingNote!!
+                        val now = Instant.now()
+                        applyUpdate(
+                            note.copy(
+                                title = TitleExtractor.extractTitle(text),
+                                contentMarkdown = text,
+                                excerpt = TitleExtractor.generateExcerpt(text),
+                                updatedAt = now,
+                                lastImportedAt = now,
+                                remoteSeenAt = now
+                            )
+                        )
+                        updated++
+                        ownEntries[note.id] = SidecarEntry(
+                            noteId = note.id,
+                            fileName = fileName,
+                            contentHash = hash,
+                            createdAtMillis = note.createdAt.toEpochMilli(),
+                            pinned = note.pinned,
+                            archived = note.archived
+                        )
+                    }
+                }
+            } catch (e: Exception) {
+                errors++
+            }
+        }
+
+        SidecarStore.write(context, folder, deviceId, ownEntries.values)
+
+        return ImportResult(
+            updated = updated,
+            created = created,
+            skipped = skipped,
+            errors = errors,
+            conflicts = conflicts
+        )
+    }
+
     /** The action the reconcile takes for one mirror file. */
     internal enum class Reconcile { Create, SkipTrashed, Skip, Overwrite, Conflict }
+
+    /**
+     * [reconcileAction]'s counterpart for sidecar mode (#216), deciding from
+     * *content* rather than time.
+     *
+     * With no frontmatter there is no `updated_at`, and the filesystem mtime is
+     * not a usable substitute — a sync client that re-downloads a file bumps it
+     * without changing a byte, so every file would look newer than its note on
+     * every pass. [effectiveFileTimestamp] documents that trap for the case
+     * where it is unavoidable; here it is avoidable, so this asks a question
+     * that needs no clock: does the file still hold what Markleaf last wrote or
+     * accepted there?
+     *
+     * @param existingNote the DB note the index maps this file to, or null when
+     *   no index entry claims it (a hand-dropped file, or one whose index is
+     *   missing).
+     * @param fileMatchesLastWrite whether the file's hash equals the one
+     *   recorded for it. False means somebody else has been in the file.
+     */
+    internal fun sidecarReconcileAction(
+        existingNote: Note?,
+        fileMatchesLastWrite: Boolean
+    ): Reconcile {
+        if (existingNote == null) return Reconcile.Create
+        // Same rule as the frontmatter path: a note in Trash is never
+        // re-imported, or a deletion the user performed comes back (#148).
+        if (existingNote.trashed) return Reconcile.SkipTrashed
+        if (fileMatchesLastWrite) return Reconcile.Skip
+        val lastImport = existingNote.lastImportedAt?.toEpochMilli() ?: 0L
+        val localEditedSinceImport =
+            existingNote.updatedAt.toEpochMilli() > lastImport + SLACK_MILLIS
+        return if (localEditedSinceImport) Reconcile.Conflict else Reconcile.Overwrite
+    }
 
     /**
      * Decide what [importChanges] should do with a single mirror file, purely
@@ -820,3 +1159,20 @@ object NoteFolderMirror {
  */
 fun AppSettings.syncFolderUriOrNull(): Uri? =
     syncFolderUri?.let { raw -> runCatching { Uri.parse(raw) }.getOrNull() }
+
+/**
+ * Where this pass should keep the note↔file link, from settings (#216).
+ *
+ * Sidecar mode needs a device id to name the index it owns. The id is created
+ * when the mode is switched on, so a missing one here means something went
+ * wrong upstream — and the honest response is the default behaviour, not an
+ * index file with no owner that a second device could never tell apart.
+ */
+fun AppSettings.mirrorMetadata(): MirrorMetadata {
+    val deviceId = syncDeviceId
+    return if (syncMetadataMode == SyncMetadataMode.SIDECAR && !deviceId.isNullOrBlank()) {
+        MirrorMetadata.Sidecar(deviceId)
+    } else {
+        MirrorMetadata.Frontmatter
+    }
+}

--- a/app/src/main/java/com/markleaf/notes/data/sync/SidecarIndex.kt
+++ b/app/src/main/java/com/markleaf/notes/data/sync/SidecarIndex.kt
@@ -1,0 +1,220 @@
+package com.markleaf.notes.data.sync
+
+import java.security.MessageDigest
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * The mapping between notes and their mirror files, kept *beside* the notes
+ * instead of inside them (#216).
+ *
+ * Markleaf's default is a `---` frontmatter block at the top of every file,
+ * carrying the note's id and a few flags. It is robust — it survives renames,
+ * and a folder of such files can be reconstructed anywhere — but it is also
+ * text the user never wrote sitting in their notes. This is the opt-in
+ * alternative: the `.md` files hold nothing but what was typed, and the
+ * bookkeeping lives in a hidden index file.
+ *
+ * ## Why there is no timestamp here
+ *
+ * The obvious design keeps an id map and lets the existing reconcile decide
+ * what is newer. It cannot: with no frontmatter there is no `updated_at`, so
+ * [NoteFolderMirror.effectiveFileTimestamp] falls back to the filesystem mtime
+ * — and a sync client that re-downloads a file bumps its mtime without changing
+ * a byte. Every file would look newer than its note on every pass, which is a
+ * conflict storm rather than a sync, and it would hit hardest on exactly the
+ * setups this mode is for.
+ *
+ * So the index stores [SidecarEntry.contentHash] — a digest of what Markleaf
+ * last wrote to that file — and the question becomes "is this file still what
+ * we wrote", which needs no clock at all.
+ *
+ * ## Why one file per device
+ *
+ * A single shared index would be written by every device, and a sync client
+ * resolving that as a conflict would leave one device's view of the folder
+ * silently wrong — reintroducing the duplicate-note bug (#140) in a new place.
+ * Each device therefore writes only [fileNameFor] its own id and never touches
+ * another's; [merge] reads them all, so a second device still learns the first
+ * device's mapping rather than starting blind.
+ */
+object SidecarIndex {
+
+    /** Current on-disk schema. Bumped only if the entry shape changes. */
+    const val SCHEMA_VERSION = 1
+
+    private const val PREFIX = ".markleaf-index-"
+    private const val SUFFIX = ".json"
+
+    /** The index file this device owns. Never write to any other. */
+    fun fileNameFor(deviceId: String): String = "$PREFIX$deviceId$SUFFIX"
+
+    /** Whether [name] is an index file — ours or another device's. */
+    fun isIndexFile(name: String?): Boolean {
+        val n = name ?: return false
+        return n.startsWith(PREFIX) && n.endsWith(SUFFIX) && n.length > PREFIX.length + SUFFIX.length
+    }
+
+    /** The device id inside an index filename, or null if [name] is not one. */
+    fun deviceIdOf(name: String?): String? {
+        if (!isIndexFile(name)) return null
+        return name!!.substring(PREFIX.length, name.length - SUFFIX.length)
+    }
+
+    /**
+     * SHA-256 of [content], hex-encoded.
+     *
+     * Taken over the exact text written to (or read from) the file, so the
+     * comparison is byte-for-byte honest. Truncating it would save a few
+     * kilobytes across a large folder and buy a collision risk that is not
+     * worth reasoning about.
+     */
+    fun hashOf(content: String): String {
+        val digest = MessageDigest.getInstance("SHA-256").digest(content.toByteArray(Charsets.UTF_8))
+        return buildString(digest.size * 2) {
+            for (byte in digest) append("%02x".format(byte))
+        }
+    }
+
+    /**
+     * Serialize [entries] as the index [deviceId] owns.
+     *
+     * Written one entry per line rather than minified: this file lands in the
+     * user's own folder, and a person who opens it to see what Markleaf put
+     * there deserves to be able to read it.
+     */
+    fun encode(deviceId: String, entries: Collection<SidecarEntry>): String {
+        val array = JSONArray()
+        // Sorted so a run that changes nothing produces a byte-identical file —
+        // otherwise every save would look like a change to whatever syncs the
+        // folder, which is the opposite of what this mode is for.
+        for (entry in entries.sortedBy { it.noteId }) {
+            array.put(
+                JSONObject().apply {
+                    put(KEY_ID, entry.noteId)
+                    put(KEY_FILE, entry.fileName)
+                    put(KEY_HASH, entry.contentHash)
+                    put(KEY_CREATED, entry.createdAtMillis)
+                    put(KEY_PINNED, entry.pinned)
+                    put(KEY_ARCHIVED, entry.archived)
+                }
+            )
+        }
+        return buildString {
+            append("{\n")
+            append("  \"$KEY_VERSION\": $SCHEMA_VERSION,\n")
+            append("  \"$KEY_DEVICE\": ${JSONObject.quote(deviceId)},\n")
+            append("  \"$KEY_ENTRIES\": [\n")
+            for (i in 0 until array.length()) {
+                append("    ").append(array.getJSONObject(i).toString())
+                if (i < array.length() - 1) append(",")
+                append("\n")
+            }
+            append("  ]\n")
+            append("}\n")
+        }
+    }
+
+    /**
+     * Parse an index file. Returns null when [raw] is not one we can read —
+     * malformed, truncated mid-sync, or written by a schema we do not know.
+     *
+     * Null is deliberately not an error the caller has to handle specially: an
+     * unreadable index means "we know nothing about these files", which falls
+     * back to matching by filename. Guessing at a half-parsed index is how a
+     * note would get attached to the wrong file.
+     */
+    fun decode(raw: String): ParsedIndex? = runCatching {
+        val root = JSONObject(raw)
+        val version = root.optInt(KEY_VERSION, 0)
+        // A newer schema may mean anything; refuse rather than misread it.
+        if (version <= 0 || version > SCHEMA_VERSION) return@runCatching null
+        val deviceId = root.optString(KEY_DEVICE).takeIf { it.isNotEmpty() }
+            ?: return@runCatching null
+        val array = root.optJSONArray(KEY_ENTRIES) ?: JSONArray()
+        val entries = buildList {
+            for (i in 0 until array.length()) {
+                val obj = array.optJSONObject(i) ?: continue
+                val id = obj.optString(KEY_ID).takeIf { it.isNotEmpty() } ?: continue
+                val file = obj.optString(KEY_FILE).takeIf { it.isNotEmpty() } ?: continue
+                val hash = obj.optString(KEY_HASH).takeIf { it.isNotEmpty() } ?: continue
+                add(
+                    SidecarEntry(
+                        noteId = id,
+                        fileName = file,
+                        contentHash = hash,
+                        createdAtMillis = obj.optLong(KEY_CREATED, 0L),
+                        pinned = obj.optBoolean(KEY_PINNED, false),
+                        archived = obj.optBoolean(KEY_ARCHIVED, false)
+                    )
+                )
+            }
+        }
+        ParsedIndex(deviceId = deviceId, entries = entries)
+    }.getOrNull()
+
+    /**
+     * Combine every index in the folder into one view, keyed by note id.
+     *
+     * [ownDeviceId]'s entries win outright. The hash answers "is this file still
+     * what *we* wrote", so another device's hash cannot stand in for ours —
+     * it describes what that device wrote, which is a different question. Other
+     * devices' entries are used only where we have none, which is exactly the
+     * case that matters: a note this device has never seen, whose id would
+     * otherwise be unknowable and which would import as a brand-new duplicate.
+     */
+    fun merge(ownDeviceId: String, indexes: List<ParsedIndex>): Map<String, SidecarEntry> {
+        val merged = LinkedHashMap<String, SidecarEntry>()
+        for (index in indexes.filter { it.deviceId != ownDeviceId }) {
+            for (entry in index.entries) merged[entry.noteId] = entry
+        }
+        for (index in indexes.filter { it.deviceId == ownDeviceId }) {
+            for (entry in index.entries) merged[entry.noteId] = entry
+        }
+        return merged
+    }
+
+    /**
+     * The merged view keyed by filename, for walking the folder — where a
+     * filename is what we hold and the note id is what we need.
+     *
+     * Two notes cannot share a name in one folder (the mirror's collision guard
+     * sees to that), but two *devices* can disagree about one note's name after
+     * a rename. Later wins, and [merge] has already put our own entries last.
+     */
+    fun byFileName(merged: Map<String, SidecarEntry>): Map<String, SidecarEntry> =
+        merged.values.associateBy { it.fileName.lowercase() }
+
+    private const val KEY_VERSION = "version"
+    private const val KEY_DEVICE = "device"
+    private const val KEY_ENTRIES = "entries"
+    private const val KEY_ID = "id"
+    private const val KEY_FILE = "file"
+    private const val KEY_HASH = "hash"
+    private const val KEY_CREATED = "created"
+    private const val KEY_PINNED = "pinned"
+    private const val KEY_ARCHIVED = "archived"
+}
+
+/**
+ * One note's bookkeeping: which file holds it, what we last wrote there, and
+ * the flags that used to travel in the frontmatter.
+ *
+ * [createdAtMillis], [pinned] and [archived] live here because they have
+ * nowhere else to go once the block is gone. That is the honest cost of this
+ * mode: a folder read without its index yields notes dated today and unpinned.
+ */
+data class SidecarEntry(
+    val noteId: String,
+    val fileName: String,
+    val contentHash: String,
+    val createdAtMillis: Long,
+    val pinned: Boolean,
+    val archived: Boolean
+)
+
+/** One index file's contents. */
+data class ParsedIndex(
+    val deviceId: String,
+    val entries: List<SidecarEntry>
+)

--- a/app/src/main/java/com/markleaf/notes/data/sync/SidecarMigration.kt
+++ b/app/src/main/java/com/markleaf/notes/data/sync/SidecarMigration.kt
@@ -1,0 +1,163 @@
+package com.markleaf.notes.data.sync
+
+import android.content.Context
+import android.net.Uri
+import androidx.documentfile.provider.DocumentFile
+import com.markleaf.notes.domain.model.Note
+import java.io.BufferedWriter
+import java.io.OutputStreamWriter
+
+/**
+ * Converts a mirror folder between the two metadata modes (#216).
+ *
+ * Switching the setting alone would leave every existing file carrying a header
+ * that is now meaningless, and the user was promised the folder would actually
+ * be cleaned rather than waiting for four hundred notes to each be edited. Both
+ * directions run over the folder once and rewrite each file in place.
+ *
+ * **Note bodies are never altered.** Converting *to* sidecar removes the header
+ * Markleaf itself wrote and keeps everything below it; converting *back* puts a
+ * header on top of the text that is already there. A file that never had a
+ * header is left exactly as it is.
+ */
+object SidecarMigration {
+
+    /** What a conversion did, for the UI to report. */
+    data class Result(val converted: Int, val skipped: Int, val errors: Int)
+
+    /**
+     * Strip the frontmatter from every mirror file and record what it said in
+     * [deviceId]'s index.
+     *
+     * The header is the only place a pre-switch folder holds the note id and the
+     * created/pinned/archived flags, so it is read before it is removed —
+     * dropping it first would orphan every file in the folder.
+     */
+    fun toSidecar(context: Context, folderUri: Uri, deviceId: String): Result {
+        val folder = DocumentFile.fromTreeUri(context, folderUri) ?: return Result(0, 0, 1)
+        if (!folder.canWrite()) return Result(0, 0, 1)
+
+        var converted = 0
+        var skipped = 0
+        var errors = 0
+        val entries = SidecarStore.ownEntries(context, folder, deviceId)
+
+        for (file in folder.listFiles()) {
+            if (!file.isFile || !isMirrorFileName(file.name)) continue
+            val raw = read(context, file)
+            if (raw == null) {
+                errors++
+                continue
+            }
+            val parsed = SyncFrontmatter.decode(raw)
+            val name = file.name.orEmpty()
+            if (!parsed.hasFrontmatter) {
+                // Nothing to strip. Still worth an entry when we can name the
+                // note behind it, so the first import does not treat a file we
+                // already own as a stranger.
+                skipped++
+                continue
+            }
+            val noteId = parsed.markleafId
+            if (noteId == null) {
+                // A header with no id of ours in it belongs to another tool.
+                // Removing it would destroy metadata we did not write.
+                skipped++
+                continue
+            }
+            if (!write(context, file.uri, parsed.body)) {
+                errors++
+                continue
+            }
+            entries[noteId] = SidecarEntry(
+                noteId = noteId,
+                fileName = name,
+                contentHash = SidecarIndex.hashOf(parsed.body),
+                createdAtMillis = parsed.createdAt?.toEpochMilli() ?: 0L,
+                pinned = parsed.pinned ?: false,
+                archived = parsed.archived ?: false
+            )
+            converted++
+        }
+
+        SidecarStore.write(context, folder, deviceId, entries.values)
+        return Result(converted, skipped, errors)
+    }
+
+    /**
+     * Put the frontmatter back on every file the index knows about, then drop
+     * this device's index.
+     *
+     * [notes] supplies the values the header carries; a file whose note is gone
+     * is left alone rather than guessed at. Only *our* index is removed — the
+     * others belong to other devices, and deleting a file this device did not
+     * write is the rule that keeps a mid-flight sync client from losing data.
+     */
+    fun toFrontmatter(
+        context: Context,
+        folderUri: Uri,
+        deviceId: String,
+        notes: List<Note>
+    ): Result {
+        val folder = DocumentFile.fromTreeUri(context, folderUri) ?: return Result(0, 0, 1)
+        if (!folder.canWrite()) return Result(0, 0, 1)
+
+        var converted = 0
+        var skipped = 0
+        var errors = 0
+        val byId = notes.associateBy { it.id }
+        val merged = SidecarStore.load(context, folder, deviceId)
+        val byName = SidecarIndex.byFileName(merged)
+
+        for (file in folder.listFiles()) {
+            if (!file.isFile || !isMirrorFileName(file.name)) continue
+            val name = file.name.orEmpty()
+            val note = byName[name.lowercase()]?.noteId?.let(byId::get)
+            if (note == null) {
+                skipped++
+                continue
+            }
+            val raw = read(context, file)
+            if (raw == null) {
+                errors++
+                continue
+            }
+            // Already headed — a file another device wrote before the switch.
+            if (SyncFrontmatter.decode(raw).hasFrontmatter) {
+                skipped++
+                continue
+            }
+            if (write(context, file.uri, SyncFrontmatter.encode(note.copy(contentMarkdown = raw)))) {
+                converted++
+            } else {
+                errors++
+            }
+        }
+
+        folder.findFile(SidecarIndex.fileNameFor(deviceId))?.let { own ->
+            // Ours to remove: we created it, it means nothing once the mode is
+            // off, and a stale copy would be misread if the mode came back on.
+            runCatching { own.delete() }
+        }
+        SidecarStore.forget()
+        return Result(converted, skipped, errors)
+    }
+
+    private fun isMirrorFileName(name: String?): Boolean {
+        val n = name?.lowercase() ?: return false
+        return n.endsWith(".md") || n.endsWith(".txt")
+    }
+
+    private fun read(context: Context, file: DocumentFile): String? = runCatching {
+        context.contentResolver.openInputStream(file.uri)?.use {
+            it.readBytes().toString(Charsets.UTF_8)
+        }
+    }.getOrNull()
+
+    private fun write(context: Context, target: Uri, content: String): Boolean = runCatching {
+        context.contentResolver.openOutputStream(target, "wt")?.use { stream ->
+            BufferedWriter(OutputStreamWriter(stream, Charsets.UTF_8)).use { it.write(content) }
+        } ?: return@runCatching false
+        true
+    }.getOrDefault(false)
+}

--- a/app/src/main/java/com/markleaf/notes/data/sync/SidecarStore.kt
+++ b/app/src/main/java/com/markleaf/notes/data/sync/SidecarStore.kt
@@ -1,0 +1,88 @@
+package com.markleaf.notes.data.sync
+
+import android.content.Context
+import androidx.documentfile.provider.DocumentFile
+import java.io.BufferedWriter
+import java.io.OutputStreamWriter
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Reads and writes the sidecar index files in a mirror folder (#216).
+ *
+ * [SidecarIndex] is the pure format; this is the part that touches storage. It
+ * holds this device's index in memory between calls so a note save costs one
+ * write rather than a read-modify-write, and skips the write entirely when the
+ * encoded bytes have not changed — a folder that syncs should not see its index
+ * touched by a save that changed nothing.
+ */
+internal object SidecarStore {
+
+    /**
+     * Last content written per folder, so an unchanged index is not rewritten.
+     * Keyed by folder Uri + device, as [MirrorFileCache] is: one process can
+     * mirror to only one folder at a time today, but nothing here depends on
+     * that and a stale entry across a folder change would be a real bug.
+     */
+    private val lastWritten = ConcurrentHashMap<String, String>()
+
+    /** Every index in [folder], ours and other devices'. Unreadable ones are skipped. */
+    fun readAll(context: Context, folder: DocumentFile): List<ParsedIndex> =
+        folder.listFiles()
+            .filter { it.isFile && SidecarIndex.isIndexFile(it.name) }
+            .mapNotNull { file ->
+                runCatching {
+                    context.contentResolver.openInputStream(file.uri)?.use {
+                        it.readBytes().toString(Charsets.UTF_8)
+                    }
+                }.getOrNull()?.let(SidecarIndex::decode)
+            }
+
+    /**
+     * The merged view of every index, with [deviceId]'s entries winning.
+     * See [SidecarIndex.merge] for why another device's hash cannot stand in
+     * for our own.
+     */
+    fun load(context: Context, folder: DocumentFile, deviceId: String): Map<String, SidecarEntry> =
+        SidecarIndex.merge(deviceId, readAll(context, folder))
+
+    /**
+     * Write [entries] as [deviceId]'s index. Best-effort: a failure here leaves
+     * the notes themselves intact and costs only the mapping, which the next
+     * pass rebuilds by filename.
+     */
+    fun write(
+        context: Context,
+        folder: DocumentFile,
+        deviceId: String,
+        entries: Collection<SidecarEntry>
+    ): Boolean {
+        val encoded = SidecarIndex.encode(deviceId, entries)
+        val key = "${folder.uri}|$deviceId"
+        if (lastWritten[key] == encoded) return true
+
+        val name = SidecarIndex.fileNameFor(deviceId)
+        return runCatching {
+            val target = folder.findFile(name)
+                ?: folder.createFile("application/json", name)
+                ?: return@runCatching false
+            context.contentResolver.openOutputStream(target.uri, "wt")?.use { stream ->
+                BufferedWriter(OutputStreamWriter(stream, Charsets.UTF_8)).use { it.write(encoded) }
+            } ?: return@runCatching false
+            lastWritten[key] = encoded
+            true
+        }.getOrDefault(false)
+    }
+
+    /** Only this device's own entries, which are the ones it may rewrite. */
+    fun ownEntries(
+        context: Context,
+        folder: DocumentFile,
+        deviceId: String
+    ): MutableMap<String, SidecarEntry> {
+        val own = readAll(context, folder).firstOrNull { it.deviceId == deviceId }
+        return own?.entries?.associateBy { it.noteId }?.toMutableMap() ?: mutableMapOf()
+    }
+
+    /** Drop the cached copy — used by tests and when the mirror folder changes. */
+    fun forget() = lastWritten.clear()
+}

--- a/app/src/main/java/com/markleaf/notes/feature/editor/EditorScreen.kt
+++ b/app/src/main/java/com/markleaf/notes/feature/editor/EditorScreen.kt
@@ -98,6 +98,7 @@ import com.markleaf.notes.data.settings.MarkdownSyntaxVisibility
 import com.markleaf.notes.data.settings.OpenNotesAt
 import com.markleaf.notes.data.sync.NoteFolderMirror
 import com.markleaf.notes.data.sync.syncFolderUriOrNull
+import com.markleaf.notes.data.sync.mirrorMetadata
 import com.markleaf.notes.domain.model.Note
 import com.markleaf.notes.util.AttachmentManager
 import com.markleaf.notes.util.ExportUtil
@@ -384,7 +385,13 @@ fun EditorScreen(
                     // text (#155). Removing the lock re-includes it on the next save.
                     if (!updatedNote.locked) {
                         val ok = withContext(Dispatchers.IO) {
-                            val wrote = NoteFolderMirror.writeNote(context, uri, updatedNote, appSettings.syncFileExtension)
+                            val wrote = NoteFolderMirror.writeNote(
+                                context,
+                                uri,
+                                updatedNote,
+                                appSettings.syncFileExtension,
+                                appSettings.mirrorMetadata()
+                            )
                             if (wrote) {
                                 val attachments = AttachmentManager.filesForNote(context, noteId)
                                 if (attachments.isNotEmpty()) {

--- a/app/src/main/java/com/markleaf/notes/feature/lock/LockedNotesScreen.kt
+++ b/app/src/main/java/com/markleaf/notes/feature/lock/LockedNotesScreen.kt
@@ -65,6 +65,7 @@ import com.markleaf.notes.data.settings.AppSettingsRepository
 import com.markleaf.notes.data.settings.LockPasscodeAttempt
 import com.markleaf.notes.data.sync.NoteFolderMirror
 import com.markleaf.notes.data.sync.syncFolderUriOrNull
+import com.markleaf.notes.data.sync.mirrorMetadata
 import com.markleaf.notes.domain.model.Note
 import com.markleaf.notes.ui.component.EmptyState
 import com.markleaf.notes.ui.viewmodel.LockedNotesViewModel
@@ -361,7 +362,8 @@ private fun LockedNotesList(
                                         context,
                                         uri,
                                         note.copy(locked = false),
-                                        appSettings.syncFileExtension
+                                        appSettings.syncFileExtension,
+                                        appSettings.mirrorMetadata()
                                     ) { stamped -> viewModel.stampMirrored(stamped) }
                                 }
                             }

--- a/app/src/main/java/com/markleaf/notes/feature/notes/NotesListScreen.kt
+++ b/app/src/main/java/com/markleaf/notes/feature/notes/NotesListScreen.kt
@@ -81,6 +81,7 @@ import com.markleaf.notes.data.settings.AppSettingsRepository
 import com.markleaf.notes.data.settings.NotesSortMode
 import com.markleaf.notes.data.sync.NoteFolderMirror
 import com.markleaf.notes.data.sync.syncFolderUriOrNull
+import com.markleaf.notes.data.sync.mirrorMetadata
 import com.markleaf.notes.domain.model.Note
 import com.markleaf.notes.navigation.LocalNavAnimatedVisibilityScope
 import com.markleaf.notes.navigation.LocalSharedTransitionScope
@@ -450,7 +451,12 @@ fun NotesListScreen(
                                     appSettings.syncFolderUriOrNull()?.let { uri ->
                                         scope.launch {
                                             withContext(Dispatchers.IO) {
-                                                NoteFolderMirror.deleteNote(context, uri, note.id)
+                                                NoteFolderMirror.deleteNote(
+                                                    context,
+                                                    uri,
+                                                    note.id,
+                                                    appSettings.mirrorMetadata()
+                                                )
                                             }
                                         }
                                     }

--- a/app/src/main/java/com/markleaf/notes/feature/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/markleaf/notes/feature/settings/SettingsScreen.kt
@@ -64,9 +64,12 @@ import com.markleaf.notes.data.settings.EditorFont
 import com.markleaf.notes.data.settings.EditorLineWidth
 import com.markleaf.notes.data.settings.MarkdownSyntaxVisibility
 import com.markleaf.notes.data.settings.OpenNotesAt
+import com.markleaf.notes.data.settings.SyncMetadataMode
 import com.markleaf.notes.data.sync.NoteFolderMirror
 import com.markleaf.notes.data.sync.NoteImporter
+import com.markleaf.notes.data.sync.SidecarMigration
 import com.markleaf.notes.data.sync.syncFolderUriOrNull
+import com.markleaf.notes.data.sync.mirrorMetadata
 import com.markleaf.notes.feature.lock.canUseBiometric
 import com.markleaf.notes.util.ExportAllNotes
 import com.markleaf.notes.util.HapticFeedback
@@ -88,6 +91,10 @@ fun SettingsScreen(
     val appSettings by settingsRepository.settings.collectAsState(initial = AppSettings())
     val noteRepository = remember { LocalNoteRepository(AppDatabase.getInstance(context.applicationContext)) }
     val noteImporter = remember { NoteImporter(AppDatabase.getInstance(context.applicationContext)) }
+    // Switching metadata mode rewrites every file in the folder. Disabling the
+    // control while it runs stops a second switch starting on top of the first,
+    // which would have two passes rewriting the same files.
+    var metadataSwitchBusy by remember { mutableStateOf(false) }
     val exportAllLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.OpenDocumentTree()
     ) { folderUri ->
@@ -131,7 +138,8 @@ fun SettingsScreen(
                             context,
                             folderUri,
                             note,
-                            appSettings.syncFileExtension
+                            appSettings.syncFileExtension,
+                            appSettings.mirrorMetadata()
                         ) { stamped -> noteRepository.updateNote(stamped) }
                         if (wrote) written++
                     }
@@ -448,6 +456,45 @@ fun SettingsScreen(
                     SyncSection(
                         folderUri = appSettings.syncFolderUri,
                         lastSyncedAt = appSettings.syncLastSyncedAt,
+                        metadataMode = appSettings.syncMetadataMode,
+                        metadataBusy = metadataSwitchBusy,
+                        onMetadataModeChange = { mode ->
+                            val uri = appSettings.syncFolderUriOrNull()
+                                ?: return@SyncSection
+                            if (mode == appSettings.syncMetadataMode) return@SyncSection
+                            scope.launch {
+                                metadataSwitchBusy = true
+                                // Convert the folder before flipping the setting.
+                                // The other order would leave a window where the
+                                // mode says "no headers" while every file still
+                                // has one — and an import landing in that window
+                                // would read each header as note text.
+                                val result = withContext(Dispatchers.IO) {
+                                    val deviceId = settingsRepository.getOrCreateSyncDeviceId()
+                                    when (mode) {
+                                        SyncMetadataMode.SIDECAR ->
+                                            SidecarMigration.toSidecar(context, uri, deviceId)
+                                        SyncMetadataMode.FRONTMATTER ->
+                                            SidecarMigration.toFrontmatter(
+                                                context,
+                                                uri,
+                                                deviceId,
+                                                noteRepository.getAllNotes()
+                                            )
+                                    }
+                                }
+                                settingsRepository.setSyncMetadataMode(mode)
+                                metadataSwitchBusy = false
+                                Toast.makeText(
+                                    context,
+                                    context.getString(
+                                        R.string.sync_metadata_switched_format,
+                                        result.converted
+                                    ),
+                                    Toast.LENGTH_SHORT
+                                ).show()
+                            }
+                        },
                         onPickFolder = { syncFolderLauncher.launch(null) },
                         onSyncNow = {
                             val uri = appSettings.syncFolderUriOrNull() ?: return@SyncSection
@@ -467,7 +514,8 @@ fun SettingsScreen(
                                         },
                                         applyCreate = { created ->
                                             noteImporter.create(created)
-                                        }
+                                        },
+                                        metadata = appSettings.mirrorMetadata()
                                     )
                                 }
                                 settingsRepository.setSyncLastSyncedAt(System.currentTimeMillis())
@@ -579,6 +627,9 @@ fun SettingsScreen(
 private fun SyncSection(
     folderUri: String?,
     lastSyncedAt: Long?,
+    metadataMode: SyncMetadataMode,
+    metadataBusy: Boolean,
+    onMetadataModeChange: (SyncMetadataMode) -> Unit,
     onPickFolder: () -> Unit,
     onSyncNow: () -> Unit,
     onStopSync: () -> Unit,
@@ -658,6 +709,47 @@ private fun SyncSection(
                 }
             }
         }
+        if (!folderUri.isNullOrBlank()) {
+            Spacer(Modifier.height(16.dp))
+            Text(
+                text = stringResource(R.string.sync_metadata_mode),
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Medium,
+                color = MaterialTheme.colorScheme.onBackground
+            )
+            Spacer(Modifier.height(8.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                SyncMetadataMode.entries.forEach { mode ->
+                    val selected = metadataMode == mode
+                    if (selected) {
+                        Button(onClick = {}, enabled = !metadataBusy) {
+                            Text(mode.localizedLabel())
+                        }
+                    } else {
+                        OutlinedButton(
+                            onClick = { onMetadataModeChange(mode) },
+                            enabled = !metadataBusy
+                        ) {
+                            Text(mode.localizedLabel())
+                        }
+                    }
+                }
+            }
+            Spacer(Modifier.height(6.dp))
+            Text(
+                text = stringResource(R.string.sync_metadata_mode_description),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            if (metadataMode == SyncMetadataMode.SIDECAR) {
+                Spacer(Modifier.height(6.dp))
+                Text(
+                    text = stringResource(R.string.sync_metadata_sidecar_costs),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
         Spacer(Modifier.height(12.dp))
         Button(
             onClick = onSyncCenterClick,
@@ -665,6 +757,14 @@ private fun SyncSection(
         ) {
             Text(stringResource(R.string.sync_center_title))
         }
+    }
+}
+
+@Composable
+private fun SyncMetadataMode.localizedLabel(): String {
+    return when (this) {
+        SyncMetadataMode.FRONTMATTER -> stringResource(R.string.sync_metadata_mode_frontmatter)
+        SyncMetadataMode.SIDECAR -> stringResource(R.string.sync_metadata_mode_sidecar)
     }
 }
 

--- a/app/src/main/java/com/markleaf/notes/feature/sync/SyncCenterScreen.kt
+++ b/app/src/main/java/com/markleaf/notes/feature/sync/SyncCenterScreen.kt
@@ -34,6 +34,7 @@ import com.markleaf.notes.data.settings.SyncFileExtension
 import com.markleaf.notes.data.sync.NoteFolderMirror
 import com.markleaf.notes.data.sync.NoteImporter
 import com.markleaf.notes.data.sync.syncFolderUriOrNull
+import com.markleaf.notes.data.sync.mirrorMetadata
 import com.markleaf.notes.domain.model.Note
 import com.markleaf.notes.ui.viewmodel.SyncCenterViewModel
 import com.markleaf.notes.util.HapticFeedback
@@ -88,7 +89,8 @@ fun SyncCenterScreen(
                             context,
                             folderUri,
                             note,
-                            appSettings.syncFileExtension
+                            appSettings.syncFileExtension,
+                            appSettings.mirrorMetadata()
                         ) { stamped -> noteRepository.updateNote(stamped) }
                         if (wrote) written++
                     }
@@ -226,7 +228,8 @@ fun SyncCenterScreen(
                                                     },
                                                     applyCreate = { created ->
                                                         noteImporter.create(created)
-                                                    }
+                                                    },
+                                                    metadata = appSettings.mirrorMetadata()
                                                 )
                                             }
                                             settingsRepository.setSyncLastSyncedAt(System.currentTimeMillis())
@@ -475,7 +478,9 @@ fun SyncCenterScreen(
                             appSettings.syncFolderUriOrNull()?.let { uri ->
                                 scope.launch {
                                     withContext(Dispatchers.IO) {
-                                        NoteFolderMirror.deleteNote(context, uri, note.id)
+                                        NoteFolderMirror.deleteNote(
+                                            context, uri, note.id, appSettings.mirrorMetadata()
+                                        )
                                     }
                                 }
                             }

--- a/app/src/main/java/com/markleaf/notes/feature/trash/TrashScreen.kt
+++ b/app/src/main/java/com/markleaf/notes/feature/trash/TrashScreen.kt
@@ -47,6 +47,7 @@ import com.markleaf.notes.data.settings.AppSettings
 import com.markleaf.notes.data.settings.AppSettingsRepository
 import com.markleaf.notes.data.sync.NoteFolderMirror
 import com.markleaf.notes.data.sync.syncFolderUriOrNull
+import com.markleaf.notes.data.sync.mirrorMetadata
 import com.markleaf.notes.domain.model.Note
 import com.markleaf.notes.ui.viewmodel.TrashViewModel
 import com.markleaf.notes.util.AttachmentManager
@@ -176,7 +177,9 @@ fun TrashScreen(
                         appSettings.syncFolderUriOrNull()?.let { uri ->
                             scope.launch {
                                 withContext(Dispatchers.IO) {
-                                    NoteFolderMirror.deleteNote(context, uri, note.id)
+                                    NoteFolderMirror.deleteNote(
+                                        context, uri, note.id, appSettings.mirrorMetadata()
+                                    )
                                 }
                             }
                         }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -210,6 +210,12 @@
     <string name="sync_status_folder_format">Ordner: %1$s</string>
     <string name="sync_status_last_synced_format">Zuletzt synchronisiert: %1$s</string>
     <string name="sync_status_last_synced_never">Zuletzt synchronisiert: nie</string>
+    <string name="sync_metadata_mode">Notiz-Metadaten</string>
+    <string name="sync_metadata_mode_frontmatter">In der Datei</string>
+    <string name="sync_metadata_mode_sidecar">Neben den Dateien</string>
+    <string name="sync_metadata_mode_description">Markleaf muss wissen, welche Datei zu welcher Notiz gehört. Standardmäßig schreibt es dafür einen kleinen `---`-Kopf an den Anfang jeder Datei. „Neben den Dateien“ legt das stattdessen in einem versteckten Index ab, sodass Ihre Notizen nur enthalten, was Sie geschrieben haben.</string>
+    <string name="sync_metadata_sidecar_costs">Kompromisse: Wird eine Datei außerhalb von Markleaf umbenannt, kann die Verbindung zur Notiz verloren gehen; ein ohne Index kopierter Ordner verliert Erstelldatum und Anheftung jeder Notiz.</string>
+    <string name="sync_metadata_switched_format">%1$d Dateien umgestellt.</string>
     <string name="sync_behavior_summary">· Speichert ca. 1 Sekunde nach jeder Bearbeitung in den Ordner.\n· „Jetzt synchronisieren“ holt Änderungen von anderen Geräten.\n· Konflikte: Die zuletzt geänderte Version gewinnt.\n· Löschungen werden nicht synchronisiert – verwalte den Papierkorb auf jedem Gerät.</string>
     <string name="sync_pick_folder">Sync-Ordner wählen</string>
     <string name="sync_change_folder">Ordner ändern</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -210,6 +210,12 @@
     <string name="sync_status_folder_format">Carpeta: %1$s</string>
     <string name="sync_status_last_synced_format">Última sincronización: %1$s</string>
     <string name="sync_status_last_synced_never">Última sincronización: nunca</string>
+    <string name="sync_metadata_mode">Metadatos de las notas</string>
+    <string name="sync_metadata_mode_frontmatter">En el archivo</string>
+    <string name="sync_metadata_mode_sidecar">Junto a los archivos</string>
+    <string name="sync_metadata_mode_description">Markleaf necesita saber qué archivo corresponde a cada nota. De forma predeterminada escribe una pequeña cabecera `---` al principio de cada archivo. «Junto a los archivos» guarda esa información en un índice oculto, para que tus notas contengan solo lo que escribiste.</string>
+    <string name="sync_metadata_sidecar_costs">Contrapartidas: renombrar un archivo fuera de Markleaf puede romper su vínculo con la nota, y una carpeta copiada sin su índice pierde la fecha de creación y el anclaje de cada nota.</string>
+    <string name="sync_metadata_switched_format">%1$d archivos convertidos.</string>
     <string name="sync_behavior_summary">· Guarda en la carpeta ~1 segundo después de cada edición.\n· \"Sincronizar ahora\" trae los cambios de otros dispositivos.\n· Conflictos: gana la edición más reciente.\n· Los borrados no se sincronizan — gestiona la papelera en cada dispositivo.</string>
     <string name="sync_pick_folder">Elegir carpeta de sincronización</string>
     <string name="sync_change_folder">Cambiar carpeta</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -210,6 +210,12 @@
     <string name="sync_status_folder_format">Dossier : %1$s</string>
     <string name="sync_status_last_synced_format">Dernière synchronisation : %1$s</string>
     <string name="sync_status_last_synced_never">Dernière synchronisation : jamais</string>
+    <string name="sync_metadata_mode">Métadonnées des notes</string>
+    <string name="sync_metadata_mode_frontmatter">Dans le fichier</string>
+    <string name="sync_metadata_mode_sidecar">À côté des fichiers</string>
+    <string name="sync_metadata_mode_description">Markleaf doit savoir quel fichier correspond à quelle note. Par défaut, il écrit un petit en-tête `---` en haut de chaque fichier. « À côté des fichiers » place cette information dans un index masqué, pour que vos notes ne contiennent que ce que vous avez écrit.</string>
+    <string name="sync_metadata_sidecar_costs">Contreparties : renommer un fichier hors de Markleaf peut rompre son lien avec la note, et un dossier copié sans son index perd la date de création et l’épinglage de chaque note.</string>
+    <string name="sync_metadata_switched_format">%1$d fichiers convertis.</string>
     <string name="sync_behavior_summary">· Sauvegarde dans le dossier ~1 seconde après chaque modification.\n· \"Synchroniser maintenant\" récupère les modifications des autres appareils.\n· Conflits : la modification la plus récente l\'emporte.\n· Les suppressions ne sont pas synchronisées — gérez la corbeille sur chaque appareil.</string>
     <string name="sync_pick_folder">Choisir le dossier de synchronisation</string>
     <string name="sync_change_folder">Changer de dossier</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -207,6 +207,12 @@
     <string name="sync_status_folder_format">フォルダ: %1$s</string>
     <string name="sync_status_last_synced_format">最終同期: %1$s</string>
     <string name="sync_status_last_synced_never">最終同期: なし</string>
+    <string name="sync_metadata_mode">ノートのメタデータ</string>
+    <string name="sync_metadata_mode_frontmatter">ファイル内</string>
+    <string name="sync_metadata_mode_sidecar">ファイルの隣</string>
+    <string name="sync_metadata_mode_description">Markleaf はどのファイルがどのノートかを知る必要があります。既定では各ファイルの先頭に小さな `---` ヘッダーを書きます。「ファイルの隣」を選ぶとその情報を隠し索引に置くので、ノートには書いた内容だけが残ります。</string>
+    <string name="sync_metadata_sidecar_costs">注意点: Markleaf の外でファイル名を変更するとノートとの対応が切れることがあり、索引なしでフォルダーだけを複製すると各ノートの作成日とピン留め状態が失われます。</string>
+    <string name="sync_metadata_switched_format">%1$d 件のファイルを変換しました。</string>
     <string name="sync_behavior_summary">· 編集の約 1 秒後にフォルダへ保存します。\n· 「今すぐ同期」で他端末の変更を取り込みます。\n· 競合: 最新の編集を優先します。\n· 削除は同期されません — ゴミ箱は各端末で個別に管理してください。</string>
     <string name="sync_pick_folder">同期フォルダを選択</string>
     <string name="sync_change_folder">フォルダを変更</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -207,6 +207,12 @@
     <string name="sync_status_folder_format">현재 폴더: %1$s</string>
     <string name="sync_status_last_synced_format">마지막 동기화: %1$s</string>
     <string name="sync_status_last_synced_never">마지막 동기화: 아직 없음</string>
+    <string name="sync_metadata_mode">노트 메타데이터</string>
+    <string name="sync_metadata_mode_frontmatter">파일 안에</string>
+    <string name="sync_metadata_mode_sidecar">파일 옆에</string>
+    <string name="sync_metadata_mode_description">Markleaf는 어떤 파일이 어떤 노트인지 알아야 합니다. 기본값은 각 파일 맨 위에 작은 `---` 헤더를 쓰는 것입니다. ‘파일 옆에’를 고르면 그 정보를 숨김 색인에 두므로 노트에는 직접 쓴 내용만 남습니다.</string>
+    <string name="sync_metadata_sidecar_costs">감수할 점: Markleaf 밖에서 파일 이름을 바꾸면 노트와의 연결이 끓길 수 있고, 색인 없이 폴더만 복사하면 노트별 생성 날짜와 고정 상태가 사라집니다.</string>
+    <string name="sync_metadata_switched_format">파일 %1$d개를 변환했습니다.</string>
     <string name="sync_behavior_summary">· 편집하고 약 1초 뒤 폴더에 자동으로 저장됩니다.\n· \"지금 동기화\"를 누르면 다른 기기의 변경 내용을 가져옵니다.\n· 같은 노트가 양쪽에서 바뀌면 더 최근에 수정한 쪽이 남습니다.\n· 삭제는 동기화되지 않습니다 — 각 기기에서 따로 정리해 주세요.</string>
     <string name="sync_pick_folder">동기화 폴더 선택</string>
     <string name="sync_change_folder">폴더 변경</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -214,6 +214,12 @@
     <string name="sync_status_folder_format">Folder: %1$s</string>
     <string name="sync_status_last_synced_format">Last synced: %1$s</string>
     <string name="sync_status_last_synced_never">Last synced: never</string>
+    <string name="sync_metadata_mode">Note metadata</string>
+    <string name="sync_metadata_mode_frontmatter">In the file</string>
+    <string name="sync_metadata_mode_sidecar">Beside the files</string>
+    <string name="sync_metadata_mode_description">Markleaf needs to know which file holds which note. By default it writes a small `---` header at the top of each file. “Beside the files” keeps that in a hidden index instead, so your notes contain only what you wrote.</string>
+    <string name="sync_metadata_sidecar_costs">Trade-offs: renaming a file outside Markleaf can break its link to the note, and a folder copied without its index loses each note’s created date and pinned state.</string>
+    <string name="sync_metadata_switched_format">Converted %1$d files.</string>
     <string name="sync_behavior_summary">· Saves to the folder ~1 second after each edit.\n· \"Sync now\" pulls in changes from other devices.\n· Conflicts: the most recent edit wins.\n· Deletions are not synced — manage trash on each device.</string>
     <string name="sync_pick_folder">Choose sync folder</string>
     <string name="sync_change_folder">Change folder</string>

--- a/app/src/test/java/com/markleaf/notes/data/sync/SidecarReconcileLogicTest.kt
+++ b/app/src/test/java/com/markleaf/notes/data/sync/SidecarReconcileLogicTest.kt
@@ -1,0 +1,118 @@
+package com.markleaf.notes.data.sync
+
+import com.markleaf.notes.data.sync.NoteFolderMirror.Reconcile
+import com.markleaf.notes.domain.model.Note
+import java.time.Instant
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * The sidecar reconcile matrix (#216) — the decision made for one mirror file
+ * when the metadata lives beside the notes rather than inside them.
+ *
+ * Deliberately the same shape as [NoteFolderMirrorConflictLogicTest], because
+ * the two paths must agree on everything except how "has this file changed" is
+ * answered: by content here, by timestamp there.
+ */
+class SidecarReconcileLogicTest {
+
+    private fun note(
+        updatedAtMs: Long,
+        lastImportMs: Long? = null,
+        trashed: Boolean = false,
+        archived: Boolean = false
+    ) = Note(
+        id = "n1",
+        title = "T",
+        contentMarkdown = "T",
+        excerpt = "T",
+        createdAt = Instant.ofEpochMilli(0),
+        updatedAt = Instant.ofEpochMilli(updatedAtMs),
+        trashed = trashed,
+        archived = archived,
+        lastImportedAt = lastImportMs?.let { Instant.ofEpochMilli(it) }
+    )
+
+    private fun action(existing: Note?, matches: Boolean) =
+        NoteFolderMirror.sidecarReconcileAction(existing, matches)
+
+    @Test
+    fun `a file no entry claims becomes a new note`() {
+        assertEquals(Reconcile.Create, action(existing = null, matches = false))
+        // Even a hash that happens to match nothing in particular.
+        assertEquals(Reconcile.Create, action(existing = null, matches = true))
+    }
+
+    /** #148: re-importing a trashed note resurrects a deletion the user made. */
+    @Test
+    fun `a trashed note is never re-imported`() {
+        assertEquals(
+            Reconcile.SkipTrashed,
+            action(note(updatedAtMs = 1_000, trashed = true), matches = false)
+        )
+    }
+
+    @Test
+    fun `an archived note still takes edits`() {
+        assertEquals(
+            Reconcile.Overwrite,
+            action(note(updatedAtMs = 1_000, lastImportMs = 1_000, archived = true), matches = false)
+        )
+    }
+
+    /**
+     * The whole point of hashing. A sync client re-downloading a file bumps its
+     * mtime without changing a byte; the timestamp path has to reason around
+     * that, and this one simply never asks.
+     */
+    @Test
+    fun `an unchanged file is skipped however old the note looks`() {
+        assertEquals(Reconcile.Skip, action(note(updatedAtMs = 0), matches = true))
+        assertEquals(
+            Reconcile.Skip,
+            action(note(updatedAtMs = 9_999_999, lastImportMs = 0), matches = true)
+        )
+    }
+
+    @Test
+    fun `a changed file with no local edit overwrites`() {
+        assertEquals(
+            Reconcile.Overwrite,
+            action(note(updatedAtMs = 5_000, lastImportMs = 5_000), matches = false)
+        )
+    }
+
+    @Test
+    fun `a changed file with a local edit conflicts`() {
+        assertEquals(
+            Reconcile.Conflict,
+            action(note(updatedAtMs = 60_000, lastImportMs = 5_000), matches = false)
+        )
+    }
+
+    /**
+     * A note that has never been imported has a null stamp. Treating that as
+     * "edited locally" would send the very first genuine remote edit down the
+     * conflict path — the #217 defect, in the shape it would take here.
+     */
+    @Test
+    fun `a never-imported note within the clock slack is not a conflict`() {
+        assertEquals(
+            Reconcile.Overwrite,
+            action(note(updatedAtMs = 1_000, lastImportMs = null), matches = false)
+        )
+    }
+
+    @Test
+    fun `an edit inside the clock slack is not treated as a local edit`() {
+        // 2s slack for filesystem clocks, same constant as the timestamp path.
+        assertEquals(
+            Reconcile.Overwrite,
+            action(note(updatedAtMs = 6_000, lastImportMs = 5_000), matches = false)
+        )
+        assertEquals(
+            Reconcile.Conflict,
+            action(note(updatedAtMs = 8_000, lastImportMs = 5_000), matches = false)
+        )
+    }
+}

--- a/app/src/testDebug/java/com/markleaf/notes/data/sync/SidecarIndexTest.kt
+++ b/app/src/testDebug/java/com/markleaf/notes/data/sync/SidecarIndexTest.kt
@@ -1,0 +1,144 @@
+package com.markleaf.notes.data.sync
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+/**
+ * The sidecar index format and its cross-device merge (#216).
+ *
+ * Robolectric rather than a plain JVM test because the encoder uses `org.json`,
+ * which the unit-test `android.jar` only stubs.
+ */
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [33])
+class SidecarIndexTest {
+
+    @Test
+    fun `round-trips every field`() {
+        val entries = listOf(
+            entry("note-1", "First.md", "aaa", created = 1_000L, pinned = true),
+            entry("note-2", "Second.txt", "bbb", archived = true)
+        )
+
+        val parsed = SidecarIndex.decode(SidecarIndex.encode("dev1", entries))!!
+
+        assertEquals("dev1", parsed.deviceId)
+        assertEquals(entries.sortedBy { it.noteId }, parsed.entries)
+    }
+
+    /**
+     * The file lands in a folder something else is syncing. If a pass that
+     * changed nothing produced different bytes, every save would look like a
+     * change worth uploading — the opposite of what this mode is for.
+     */
+    @Test
+    fun `encoding is stable regardless of input order`() {
+        val a = entry("z-note", "Z.md", "1")
+        val b = entry("a-note", "A.md", "2")
+
+        assertEquals(
+            SidecarIndex.encode("dev1", listOf(a, b)),
+            SidecarIndex.encode("dev1", listOf(b, a))
+        )
+    }
+
+    @Test
+    fun `refuses input it cannot trust`() {
+        assertNull(SidecarIndex.decode("not json at all"))
+        assertNull(SidecarIndex.decode("{}"))
+        // A schema from a future version may mean anything.
+        assertNull(SidecarIndex.decode("""{"version":99,"device":"d","entries":[]}"""))
+        // No device id: an index nobody owns cannot be told apart from ours.
+        assertNull(SidecarIndex.decode("""{"version":1,"entries":[]}"""))
+    }
+
+    @Test
+    fun `skips entries missing the fields that identify a file`() {
+        val raw = """
+            {"version":1,"device":"d","entries":[
+              {"id":"ok","file":"A.md","hash":"h"},
+              {"id":"no-file","hash":"h"},
+              {"file":"B.md","hash":"h"},
+              {"id":"no-hash","file":"C.md"}
+            ]}
+        """.trimIndent()
+
+        val parsed = SidecarIndex.decode(raw)!!
+
+        assertEquals(listOf("ok"), parsed.entries.map { it.noteId })
+    }
+
+    /**
+     * Our own hash answers "is this file still what *we* wrote". Another
+     * device's answers a different question, so it must never stand in.
+     */
+    @Test
+    fun `our own entry wins over another device's`() {
+        val ours = ParsedIndex("me", listOf(entry("n", "Ours.md", "our-hash")))
+        val theirs = ParsedIndex("them", listOf(entry("n", "Theirs.md", "their-hash")))
+
+        val merged = SidecarIndex.merge("me", listOf(theirs, ours))
+
+        assertEquals("our-hash", merged.getValue("n").contentHash)
+        assertEquals("Ours.md", merged.getValue("n").fileName)
+    }
+
+    /**
+     * The case that matters on a second device: without picking the other
+     * device's entry up, the note has no known id and imports as a duplicate.
+     */
+    @Test
+    fun `another device's entry fills a gap we have`() {
+        val ours = ParsedIndex("me", listOf(entry("mine", "Mine.md", "h1")))
+        val theirs = ParsedIndex("them", listOf(entry("theirs", "Theirs.md", "h2")))
+
+        val merged = SidecarIndex.merge("me", listOf(ours, theirs))
+
+        assertEquals(setOf("mine", "theirs"), merged.keys)
+        assertEquals("h2", merged.getValue("theirs").contentHash)
+    }
+
+    @Test
+    fun `filename lookup is case-insensitive`() {
+        val merged = SidecarIndex.merge("me", listOf(ParsedIndex("me", listOf(entry("n", "Notes.md", "h")))))
+
+        assertEquals("n", SidecarIndex.byFileName(merged)["notes.md"]?.noteId)
+    }
+
+    @Test
+    fun `index files are recognised by name and yield their device`() {
+        val name = SidecarIndex.fileNameFor("abc123")
+
+        assertEquals(".markleaf-index-abc123.json", name)
+        assertTrue(SidecarIndex.isIndexFile(name))
+        assertEquals("abc123", SidecarIndex.deviceIdOf(name))
+        // A note file must never be taken for an index.
+        assertFalse(SidecarIndex.isIndexFile("Notes.md"))
+        assertFalse(SidecarIndex.isIndexFile(".markleaf-index-.json"))
+        assertNull(SidecarIndex.deviceIdOf("Notes.md"))
+    }
+
+    @Test
+    fun `hash distinguishes content and survives a round trip`() {
+        assertEquals(SidecarIndex.hashOf("hello"), SidecarIndex.hashOf("hello"))
+        assertNotEquals(SidecarIndex.hashOf("hello"), SidecarIndex.hashOf("hello "))
+        // Hex SHA-256.
+        assertEquals(64, SidecarIndex.hashOf("hello").length)
+    }
+
+    private fun entry(
+        id: String,
+        file: String,
+        hash: String,
+        created: Long = 0L,
+        pinned: Boolean = false,
+        archived: Boolean = false
+    ) = SidecarEntry(id, file, hash, created, pinned, archived)
+}


### PR DESCRIPTION
Implements the design specced in #216. **Frontmatter stays the default** — this is an opt-in mode under **Settings → Multi-device sync → Note metadata**.

## Why the obvious design does not work

Writing the spec changed the shape twice, both times after reading what the sync code actually depends on rather than what I remembered it depending on.

**1. No timestamps anywhere.** The naive version keeps an id map and lets the existing reconcile decide what is newer. It cannot: with no header there is no `updated_at`, so `effectiveFileTimestamp` falls back to the filesystem mtime — and there is a comment in that function, from an earlier bug, warning that a sync client re-downloading a file bumps mtime without changing a byte. Every file would look newer than its note on every pass. That is a conflict storm, and it would hit hardest on exactly the Nextcloud-style setups this mode is for.

So the index stores a **hash of what Markleaf last wrote or accepted**, and the question becomes "is this file still what we wrote" — which needs no clock. `sidecarReconcileAction` is a pure function with the same Trash and local-edit rules as the timestamp path.

**2. One index per device.** A single shared `.markleaf-index.json` would be written by every device, and a sync client resolving *that* as a conflict would leave one device's view of the folder silently wrong — rebuilding #140 in a new place. Each device owns `.markleaf-index-<device>.json` and writes only its own; reads merge them all, with our own entries winning, so a second device still learns the first device's mapping instead of starting blind.

## Switching modes

The conversion runs **in the same action, before the setting flips**. The other order leaves a window where the mode says "no headers" while every file still has one, and an import landing in that window would read each header as note text. Note bodies are never altered — converting strips only the header Markleaf itself wrote, and converting back puts one on top of the text already there.

Switching off also removes *our* index. Other devices' indexes are theirs to remove.

## Verification

`./gradlew test` and `:app:lintRelease` pass. New unit tests cover the JSON round-trip, stable encoding, the cross-device merge rules, and the full reconcile matrix.

Checked end-to-end on the phone AVD against a real SAF folder:

| | |
|---|---|
| Switch to sidecar | headers stripped from 6 files, index written with ids, created dates and pinned state preserved |
| Hand-dropped file | imported once, entry recorded, **file itself untouched** — the write-back goes to the index, not the note |
| Four more sync passes | still 7 entries, 7 files, no duplicate (#140 does not recur) |
| External edit | picked up, new hash recorded, no header written back |
| `touch` with no content change | **nothing happens** — the scenario that motivated the whole design |
| Switch back | every header restored with its original `markleaf_id` and `created_at`, index removed, bodies intact |

New strings are translated into all six locales.

## Known costs, as stated in the issue

- A file renamed outside Markleaf can lose its link (frontmatter survives any rename).
- A folder copied without its index loses each note's created date and pinned state.
- The index is rewritten on each note save; for a large folder that is worth revisiting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)