### PR TITLE
fix(i18n): localise the sync relative-time labels

### DIFF
--- a/app/src/main/java/com/markleaf/notes/feature/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/markleaf/notes/feature/settings/SettingsScreen.kt
@@ -71,6 +71,7 @@ import com.markleaf.notes.data.sync.SidecarMigration
 import com.markleaf.notes.data.sync.syncFolderUriOrNull
 import com.markleaf.notes.data.sync.mirrorMetadata
 import com.markleaf.notes.feature.lock.canUseBiometric
+import com.markleaf.notes.ui.component.elapsedTimeLabel
 import com.markleaf.notes.util.ExportAllNotes
 import com.markleaf.notes.util.HapticFeedback
 import kotlinx.coroutines.Dispatchers
@@ -673,7 +674,7 @@ private fun SyncSection(
             )
             Text(
                 text = if (lastSyncedAt != null) {
-                    stringResource(R.string.sync_status_last_synced_format, formatRelative(lastSyncedAt))
+                    stringResource(R.string.sync_status_last_synced_format, elapsedTimeLabel(lastSyncedAt))
                 } else {
                     stringResource(R.string.sync_status_last_synced_never)
                 },
@@ -777,16 +778,6 @@ private fun humanReadableTreePath(uriString: String): String {
     val afterTree = decoded.substringAfterLast("/tree/", decoded)
     val afterColon = afterTree.substringAfter(":", afterTree)
     return afterColon.ifBlank { afterTree }
-}
-
-private fun formatRelative(epochMillis: Long): String {
-    val deltaMs = System.currentTimeMillis() - epochMillis
-    return when {
-        deltaMs < 60_000 -> "방금 전"
-        deltaMs < 3_600_000 -> "${deltaMs / 60_000}분 전"
-        deltaMs < 86_400_000 -> "${deltaMs / 3_600_000}시간 전"
-        else -> "${deltaMs / 86_400_000}일 전"
-    }
 }
 
 /**

--- a/app/src/main/java/com/markleaf/notes/feature/sync/SyncCenterScreen.kt
+++ b/app/src/main/java/com/markleaf/notes/feature/sync/SyncCenterScreen.kt
@@ -36,6 +36,7 @@ import com.markleaf.notes.data.sync.NoteImporter
 import com.markleaf.notes.data.sync.syncFolderUriOrNull
 import com.markleaf.notes.data.sync.mirrorMetadata
 import com.markleaf.notes.domain.model.Note
+import com.markleaf.notes.ui.component.elapsedTimeLabel
 import com.markleaf.notes.ui.viewmodel.SyncCenterViewModel
 import com.markleaf.notes.util.HapticFeedback
 import kotlinx.coroutines.Dispatchers
@@ -198,7 +199,7 @@ fun SyncCenterScreen(
                                 )
                                 Text(
                                     text = if (appSettings.syncLastSyncedAt != null) {
-                                        stringResource(R.string.sync_status_last_synced_format, formatRelative(appSettings.syncLastSyncedAt!!))
+                                        stringResource(R.string.sync_status_last_synced_format, elapsedTimeLabel(appSettings.syncLastSyncedAt!!))
                                     } else {
                                         stringResource(R.string.sync_status_last_synced_never)
                                     },
@@ -448,7 +449,10 @@ fun SyncCenterScreen(
                                 }
                                 
                                 Text(
-                                    text = "Updated: ${formatRelative(note.updatedAt.toEpochMilli())}",
+                                    text = stringResource(
+                                        R.string.conflict_note_updated_format,
+                                        elapsedTimeLabel(note.updatedAt.toEpochMilli())
+                                    ),
                                     style = MaterialTheme.typography.bodySmall,
                                     color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
                                 )
@@ -509,14 +513,4 @@ private fun humanReadableTreePath(uriString: String): String {
     val afterTree = decoded.substringAfterLast("/tree/", decoded)
     val afterColon = afterTree.substringAfter(":", afterTree)
     return afterColon.ifBlank { afterTree }
-}
-
-private fun formatRelative(epochMillis: Long): String {
-    val deltaMs = System.currentTimeMillis() - epochMillis
-    return when {
-        deltaMs < 60_000 -> "방금 전"
-        deltaMs < 3_600_000 -> "${deltaMs / 60_000}분 전"
-        deltaMs < 86_400_000 -> "${deltaMs / 3_600_000}시간 전"
-        else -> "${deltaMs / 86_400_000}일 전"
-    }
 }

--- a/app/src/main/java/com/markleaf/notes/ui/component/RelativeTime.kt
+++ b/app/src/main/java/com/markleaf/notes/ui/component/RelativeTime.kt
@@ -1,0 +1,43 @@
+package com.markleaf.notes.ui.component
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import com.markleaf.notes.R
+
+private const val MINUTE_MS = 60_000L
+private const val HOUR_MS = 60 * MINUTE_MS
+private const val DAY_MS = 24 * HOUR_MS
+
+/**
+ * "just now" / "3 minutes ago" for the sync status rows.
+ *
+ * Settings and the Sync Center each carried a private copy of this that built
+ * the label out of Korean literals, so every other locale read "Last synced:
+ * 3시간 전" — the same defect as the hardcoded conflict-copy suffix in #217.
+ * One shared composable now, resolved through `<plurals>` so en/de/es/fr get
+ * singular and plural forms while ja/ko get their single form.
+ *
+ * [now] is a parameter rather than a `System.currentTimeMillis()` call in the
+ * body so a test can pin the moment and exercise each bucket; the buckets are
+ * relative to it and would otherwise drift between assertion and render.
+ */
+@Composable
+fun elapsedTimeLabel(epochMillis: Long, now: Long = System.currentTimeMillis()): String {
+    val deltaMs = (now - epochMillis).coerceAtLeast(0L)
+    return when {
+        deltaMs < MINUTE_MS -> stringResource(R.string.elapsed_just_now)
+        deltaMs < HOUR_MS -> {
+            val minutes = (deltaMs / MINUTE_MS).toInt()
+            pluralStringResource(R.plurals.elapsed_minutes_ago, minutes, minutes)
+        }
+        deltaMs < DAY_MS -> {
+            val hours = (deltaMs / HOUR_MS).toInt()
+            pluralStringResource(R.plurals.elapsed_hours_ago, hours, hours)
+        }
+        else -> {
+            val days = (deltaMs / DAY_MS).toInt()
+            pluralStringResource(R.plurals.elapsed_days_ago, days, days)
+        }
+    }
+}

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -126,6 +126,20 @@
     <string name="relative_yesterday">Gestern %1$s</string>
     <string name="relative_days_ago">Vor %1$d Tagen</string>
 
+    <string name="elapsed_just_now">gerade eben</string>
+    <plurals name="elapsed_minutes_ago">
+        <item quantity="one">vor %1$d Minute</item>
+        <item quantity="other">vor %1$d Minuten</item>
+    </plurals>
+    <plurals name="elapsed_hours_ago">
+        <item quantity="one">vor %1$d Stunde</item>
+        <item quantity="other">vor %1$d Stunden</item>
+    </plurals>
+    <plurals name="elapsed_days_ago">
+        <item quantity="one">vor %1$d Tag</item>
+        <item quantity="other">vor %1$d Tagen</item>
+    </plurals>
+
     <string name="search_notes_hint">Notizen durchsuchen…</string>
     <string name="type_to_search_notes">Tippen, um Notizen zu durchsuchen</string>
     <string name="no_results_found">Keine Ergebnisse gefunden</string>
@@ -352,4 +366,5 @@
     <string name="conflict_center_empty_desc">Alle gespiegelten Notizen sind perfekt synchronisiert.</string>
     <string name="conflict_delete_confirm_title">Konfliktkopie löschen?</string>
     <string name="conflict_delete_confirm_desc">Diese Konfliktkopie wird dauerhaft gelöscht.</string>
+    <string name="conflict_note_updated_format">Aktualisiert: %1$s</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -126,6 +126,20 @@
     <string name="relative_yesterday">Ayer %1$s</string>
     <string name="relative_days_ago">hace %1$d días</string>
 
+    <string name="elapsed_just_now">ahora mismo</string>
+    <plurals name="elapsed_minutes_ago">
+        <item quantity="one">hace %1$d minuto</item>
+        <item quantity="other">hace %1$d minutos</item>
+    </plurals>
+    <plurals name="elapsed_hours_ago">
+        <item quantity="one">hace %1$d hora</item>
+        <item quantity="other">hace %1$d horas</item>
+    </plurals>
+    <plurals name="elapsed_days_ago">
+        <item quantity="one">hace %1$d día</item>
+        <item quantity="other">hace %1$d días</item>
+    </plurals>
+
     <string name="search_notes_hint">Buscar notas...</string>
     <string name="type_to_search_notes">Escribe para buscar notas</string>
     <string name="no_results_found">No se encontraron resultados</string>
@@ -352,4 +366,5 @@
     <string name="conflict_center_empty_desc">Todas las notas reflejadas están perfectamente sincronizadas.</string>
     <string name="conflict_delete_confirm_title">¿Eliminar copia en conflicto?</string>
     <string name="conflict_delete_confirm_desc">Esta copia en conflicto será eliminada permanentemente.</string>
+    <string name="conflict_note_updated_format">Actualizado: %1$s</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -126,6 +126,20 @@
     <string name="relative_yesterday">Hier %1$s</string>
     <string name="relative_days_ago">Il y a %1$d jours</string>
 
+    <string name="elapsed_just_now">à l\'instant</string>
+    <plurals name="elapsed_minutes_ago">
+        <item quantity="one">il y a %1$d minute</item>
+        <item quantity="other">il y a %1$d minutes</item>
+    </plurals>
+    <plurals name="elapsed_hours_ago">
+        <item quantity="one">il y a %1$d heure</item>
+        <item quantity="other">il y a %1$d heures</item>
+    </plurals>
+    <plurals name="elapsed_days_ago">
+        <item quantity="one">il y a %1$d jour</item>
+        <item quantity="other">il y a %1$d jours</item>
+    </plurals>
+
     <string name="search_notes_hint">Rechercher des notes...</string>
     <string name="type_to_search_notes">Saisissez du texte pour rechercher des notes</string>
     <string name="no_results_found">Aucun résultat trouvé</string>
@@ -352,5 +366,6 @@
     <string name="conflict_center_empty_desc">Toutes les notes mises en miroir sont parfaitement synchronisées.</string>
     <string name="conflict_delete_confirm_title">Supprimer la copie de conflit ?</string>
     <string name="conflict_delete_confirm_desc">Cette copie de conflit sera définitivement supprimée.</string>
+    <string name="conflict_note_updated_format">Modifiée : %1$s</string>
 
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -125,6 +125,17 @@
     <string name="relative_yesterday">昨日 %1$s</string>
     <string name="relative_days_ago">%1$d日前</string>
 
+    <string name="elapsed_just_now">たった今</string>
+    <plurals name="elapsed_minutes_ago">
+        <item quantity="other">%1$d分前</item>
+    </plurals>
+    <plurals name="elapsed_hours_ago">
+        <item quantity="other">%1$d時間前</item>
+    </plurals>
+    <plurals name="elapsed_days_ago">
+        <item quantity="other">%1$d日前</item>
+    </plurals>
+
     <string name="search_notes_hint">ノートを検索...</string>
     <string name="type_to_search_notes">入力してノートを検索</string>
     <string name="no_results_found">結果が見つかりません</string>
@@ -347,4 +358,5 @@
     <string name="conflict_center_empty_desc">ミラーリングされたすべてのノートが完全に同期されています。</string>
     <string name="conflict_delete_confirm_title">競合コピーを削除しますか？</string>
     <string name="conflict_delete_confirm_desc">この競合コピーは完全に削除されます。</string>
+    <string name="conflict_note_updated_format">更新: %1$s</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -125,6 +125,17 @@
     <string name="relative_yesterday">어제 %1$s</string>
     <string name="relative_days_ago">%1$d일 전</string>
 
+    <string name="elapsed_just_now">방금 전</string>
+    <plurals name="elapsed_minutes_ago">
+        <item quantity="other">%1$d분 전</item>
+    </plurals>
+    <plurals name="elapsed_hours_ago">
+        <item quantity="other">%1$d시간 전</item>
+    </plurals>
+    <plurals name="elapsed_days_ago">
+        <item quantity="other">%1$d일 전</item>
+    </plurals>
+
     <string name="search_notes_hint">노트 검색...</string>
     <string name="type_to_search_notes">검색어를 입력하세요</string>
     <string name="no_results_found">검색 결과가 없습니다</string>
@@ -347,5 +358,6 @@
     <string name="conflict_center_empty_desc">모든 미러링 노트가 완벽히 동기화되어 있습니다.</string>
     <string name="conflict_delete_confirm_title">충돌 사본을 삭제할까요?</string>
     <string name="conflict_delete_confirm_desc">이 충돌 사본은 영구히 삭제되며 복구할 수 없습니다.</string>
+    <string name="conflict_note_updated_format">수정: %1$s</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -130,6 +130,22 @@
     <string name="relative_yesterday">Yesterday %1$s</string>
     <string name="relative_days_ago">%1$d days ago</string>
 
+    <!-- Elapsed time since a timestamp, for the sync status rows. Distinct from
+         the relative_* strings above, which name a calendar day. -->
+    <string name="elapsed_just_now">just now</string>
+    <plurals name="elapsed_minutes_ago">
+        <item quantity="one">%1$d minute ago</item>
+        <item quantity="other">%1$d minutes ago</item>
+    </plurals>
+    <plurals name="elapsed_hours_ago">
+        <item quantity="one">%1$d hour ago</item>
+        <item quantity="other">%1$d hours ago</item>
+    </plurals>
+    <plurals name="elapsed_days_ago">
+        <item quantity="one">%1$d day ago</item>
+        <item quantity="other">%1$d days ago</item>
+    </plurals>
+
     <string name="search_notes_hint">Search notes...</string>
     <string name="type_to_search_notes">Type to search notes</string>
     <string name="no_results_found">No results found</string>
@@ -356,5 +372,6 @@
     <string name="conflict_center_empty_desc">All mirrored notes are perfectly in sync.</string>
     <string name="conflict_delete_confirm_title">Delete conflict copy?</string>
     <string name="conflict_delete_confirm_desc">This conflict copy will be permanently deleted.</string>
+    <string name="conflict_note_updated_format">Updated: %1$s</string>
 
 </resources>

--- a/app/src/testDebug/java/com/markleaf/notes/ui/component/ElapsedTimeLabelTest.kt
+++ b/app/src/testDebug/java/com/markleaf/notes/ui/component/ElapsedTimeLabelTest.kt
@@ -1,0 +1,126 @@
+package com.markleaf.notes.ui.component
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+/**
+ * Guards the sync status labels against the defect that shipped them: both
+ * Settings and the Sync Center built "3시간 전" from Korean literals, so German,
+ * English, Spanish, French and Japanese devices all read the Korean.
+ *
+ * The buckets are pinned against an explicit [NOW] rather than the wall clock —
+ * with `System.currentTimeMillis()` inside the helper, a fixed input drifts
+ * across a bucket boundary between the render and the assertion.
+ */
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [33], qualifiers = "w360dp-h640dp-mdpi")
+class ElapsedTimeLabelTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun englishReadsEachBucket() {
+        assertEquals(
+            listOf(
+                "just now",
+                "just now",
+                "1 minute ago",
+                "59 minutes ago",
+                "1 hour ago",
+                "23 hours ago",
+                "1 day ago",
+                "5 days ago"
+            ),
+            labelsForEachBucket()
+        )
+    }
+
+    /** German has to inflect: `vor 1 Minute` but `vor 59 Minuten`. */
+    @Test
+    @Config(sdk = [33], qualifiers = "de-rDE-w360dp-h640dp-mdpi")
+    fun germanReadsGermanNotKorean() {
+        assertEquals(
+            listOf(
+                "gerade eben",
+                "gerade eben",
+                "vor 1 Minute",
+                "vor 59 Minuten",
+                "vor 1 Stunde",
+                "vor 23 Stunden",
+                "vor 1 Tag",
+                "vor 5 Tagen"
+            ),
+            labelsForEachBucket()
+        )
+    }
+
+    /** The "just now" case carries an apostrophe that has to survive escaping. */
+    @Test
+    @Config(sdk = [33], qualifiers = "fr-rFR-w360dp-h640dp-mdpi")
+    fun frenchKeepsItsApostrophe() {
+        assertEquals("à l'instant", labelsForEachBucket().first())
+    }
+
+    /** Korean keeps exactly what it read before the strings were extracted. */
+    @Test
+    @Config(sdk = [33], qualifiers = "ko-rKR-w360dp-h640dp-mdpi")
+    fun koreanIsUnchanged() {
+        assertEquals(
+            listOf(
+                "방금 전",
+                "방금 전",
+                "1분 전",
+                "59분 전",
+                "1시간 전",
+                "23시간 전",
+                "1일 전",
+                "5일 전"
+            ),
+            labelsForEachBucket()
+        )
+    }
+
+    /** A timestamp from the future (clock skew across devices) stays at "just now". */
+    @Test
+    fun futureTimestampDoesNotFallThroughToDays() {
+        assertEquals("just now", labelsFor(-90 * MINUTE).single())
+    }
+
+    private fun labelsForEachBucket(): List<String> = labelsFor(
+        0,
+        59 * SECOND,
+        MINUTE,
+        59 * MINUTE + 59 * SECOND,
+        HOUR,
+        23 * HOUR + 59 * MINUTE,
+        DAY,
+        5 * DAY + 3 * HOUR
+    )
+
+    private fun labelsFor(vararg elapsed: Long): List<String> {
+        val labels = mutableListOf<String>()
+        composeRule.setContent {
+            labels.clear()
+            for (millis in elapsed) {
+                labels += elapsedTimeLabel(epochMillis = NOW - millis, now = NOW)
+            }
+        }
+        composeRule.waitForIdle()
+        return labels.toList()
+    }
+
+    private companion object {
+        /** Any fixed instant; the helper only ever looks at the difference. */
+        const val NOW = 1_700_000_000_000L
+
+        const val SECOND = 1_000L
+        const val MINUTE = 60 * SECOND
+        const val HOUR = 60 * MINUTE
+        const val DAY = 24 * HOUR
+    }
+}


### PR DESCRIPTION
## The defect

`SettingsScreen.kt` and `SyncCenterScreen.kt` each carried a private, byte-identical `formatRelative` that built its label out of Korean literals:

```kotlin
deltaMs < 3_600_000 -> "${deltaMs / 60_000}분 전"
```

Its result is interpolated into `sync_status_last_synced_format`, which *is* translated into all six locales — so German, English, Spanish, French and Japanese users read **"Last synced: 3시간 전"**. Same class of defect as the hardcoded conflict-copy suffix fixed in #217, in a second and third place.

## The fix

**New string resources in all six locales.** `elapsed_just_now` as a plain string, and `elapsed_minutes_ago` / `elapsed_hours_ago` / `elapsed_days_ago` as `<plurals>` so en/de/es/fr inflect (`vor 1 Minute` vs `vor 3 Minuten`) while ja/ko keep their single `other` form, matching the convention in `tag_note_count_format`. Korean output is unchanged character for character.

The `elapsed_*` prefix deliberately avoids the existing `relative_*` family — those are calendar-day based ("Today 14:03", "Yesterday 14:03") and mean something different.

**One shared helper.** Both private copies are gone, replaced by `elapsedTimeLabel` in `ui/component/RelativeTime.kt`. Having two copies is precisely what let the same bug exist in two places.

It takes `now` as a parameter rather than calling `System.currentTimeMillis()` in the body. That is what makes the buckets testable: with the clock read inside, any fixed input drifts across a bucket boundary between the render and the assertion.

**The `"Updated: "` prefix** on the Conflict Center cards was a hardcoded *English* literal every locale saw. It is now `conflict_note_updated_format`.

## Verification

`./gradlew test :app:lintRelease` — **BUILD SUCCESSFUL**

- `ElapsedTimeLabelTest` (new, 5 tests) pins `now` and asserts every bucket in en, de, fr and ko, using the method-level `@Config(qualifiers = "ko-rKR-…")` pattern the repo already uses. It also covers a future timestamp from cross-device clock skew.
- `ResourceParityTest` and `UntranslatedStringTest` pass on all three unit-test variants. The latter flattens `<plurals>` to `name[quantity]`, so it also guards es/ja against being left as English — no allowlist entry was needed.
- `lintRelease`: 63 warnings, **0 errors**, 0 `MissingTranslation`.

No snapshot golden changes: the Settings golden renders the `lastSyncedAt == null` path, which still reads `sync_status_last_synced_never`.

## Known follow-up, not addressed here

Lint reports `MissingQuantity` for es/fr — CLDR wants a `many` form. This is pre-existing (`replace_all_done_format` already triggers it), the new plurals follow the same `one`/`other` convention as the rest of the file, and `many` only applies at 1,000,000+, which these buckets never reach. Sweeping every plural to include `many` is a separate call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
