### PR TITLE
test: track line-broken Compose calls in the hardcoded-text scan

### DIFF
--- a/app/src/test/java/com/markleaf/notes/HardcodedStringTest.kt
+++ b/app/src/test/java/com/markleaf/notes/HardcodedStringTest.kt
@@ -96,6 +96,11 @@ class HardcodedStringTest {
      *
      * Comment lines are skipped: the codebase explains several Korean-facing
      * behaviours in Korean prose, and those explanations are not shipped text.
+     *
+     * A literal that starts its own line is matched against the previous line as
+     * well: `Text(` and the text it renders are line-broken all over this
+     * codebase, and a sink that only ever looked at one line would miss every
+     * one of them.
      */
     private fun scan(predicate: (sink: String?, literal: String) -> Boolean): List<Finding> {
         val root = File("src/main/java")
@@ -107,6 +112,9 @@ class HardcodedStringTest {
         val findings = mutableListOf<Finding>()
         root.walkTopDown().filter { it.isFile && it.extension == "kt" }.forEach { file ->
             val relative = file.relativeTo(root).invariantSeparatorsPath
+            // The last line that could have left a call open. Comment lines never
+            // replace it, so a comment between the call and its text is harmless.
+            var previous = ""
             file.readLines().forEachIndexed { index, line ->
                 val trimmed = line.trimStart()
                 if (COMMENT_STARTS.any { trimmed.startsWith(it) }) return@forEachIndexed
@@ -114,12 +122,17 @@ class HardcodedStringTest {
                     val literal = match.groupValues[1]
                     // Up to, not including, the opening quote — the sink
                     // patterns anchor on the end of what precedes the literal.
+                    // Nothing but indentation there means the call, if any, is
+                    // still open from the line above.
                     val beforeLiteral = line.take(match.range.first)
-                    val sink = UI_SINKS.firstOrNull { it.toRegex().containsMatchIn(beforeLiteral) }
+                    val context =
+                        if (beforeLiteral.isBlank()) previous + beforeLiteral else beforeLiteral
+                    val sink = UI_SINKS.firstOrNull { it.toRegex().containsMatchIn(context) }
                     if (predicate(sink, literal)) {
                         findings += Finding(relative, index + 1, literal)
                     }
                 }
+                if (trimmed.isNotEmpty()) previous = line
             }
         }
         return findings.sortedBy { it.toString() }


### PR DESCRIPTION
Follow-up to #263. Codex left this finding on that PR and it was merged before the finding was answered, so the fix lands separately.

## The blind spot

`scan()` judged a literal by `line.take(match.range.first)` — the part of **its own line** before the opening quote — and every `UI_SINKS` pattern anchors with `$`. So the sink had to sit on the literal's own line:

```kotlin
Text("Updated:")        // caught
Text(
    "Updated:"          // sink == null, walked straight through
)
```

`src/main` line-breaks a sink call at 119 sites, so the second shape is the common one. That is exactly where a shipped English literal — the shape of the Conflict Center `Updated:` this guard was written for — got past it.

## The fix

A literal that starts its own line is now matched against the previous line as well. Comment lines never become that previous line, so a comment sitting between a call and its text does not blind the scan either.

## Verification

A probe file under `src/main` holding `Text(` and `"Updated:"` on separate lines, run against both scanners:

| scanner | result |
| --- | --- |
| before | `BUILD SUCCESSFUL` — missed it |
| after | `uiCallsTakeNoLiteralText FAILED` — caught it |

Probe removed afterwards. No literal already in the tree is newly caught, and `testDebugUnitTest` is green on the full suite.
