### PR TITLE
perf(sync): stop re-reading the sidecar index on every note save (#262)

### DIFF
--- a/app/src/main/java/com/markleaf/notes/data/sync/NoteFolderMirror.kt
+++ b/app/src/main/java/com/markleaf/notes/data/sync/NoteFolderMirror.kt
@@ -169,14 +169,21 @@ object NoteFolderMirror {
         extension: SyncFileExtension,
         deviceId: String
     ): Boolean {
-        val merged = SidecarStore.load(context, folder, deviceId)
         val ownEntries = SidecarStore.ownEntries(context, folder, deviceId)
         val mirrorFiles = folder.listFiles().filter { it.isFile && isMirrorFile(it.name) }
 
-        val recordedName = merged[note.id]?.fileName
-        val existing = recordedName
+        // Our own index answers this for every note we have already written, so
+        // the common save never reads another device's file. Falling back to the
+        // merged view costs a folder listing plus a parse of every index, and it
+        // is only needed for a note this device has not seen before (#262).
+        val existing = ownEntries[note.id]?.fileName
             ?.let { name -> mirrorFiles.firstOrNull { it.name.equals(name, ignoreCase = true) } }
-            ?: adoptUnclaimedFile(mirrorFiles, note, merged)
+            ?: run {
+                val merged = SidecarStore.load(context, folder, deviceId)
+                merged[note.id]?.fileName
+                    ?.let { name -> mirrorFiles.firstOrNull { it.name.equals(name, ignoreCase = true) } }
+                    ?: adoptUnclaimedFile(mirrorFiles, note, merged)
+            }
 
         val ext = existing?.mirrorExtension() ?: extension.value
         val desiredName = resolveName(note, ext, mirrorFiles, ownFile = existing)
@@ -346,7 +353,11 @@ object NoteFolderMirror {
         val target = when (metadata) {
             is MirrorMetadata.Sidecar -> {
                 val entries = SidecarStore.ownEntries(context, folder, metadata.deviceId)
-                val name = SidecarStore.load(context, folder, metadata.deviceId)[noteId]?.fileName
+                // Our own entry names the file for anything this device wrote.
+                // Only a note we have never written needs the merged view, and
+                // paying for it on every delete is what #262 was about.
+                val name = entries[noteId]?.fileName
+                    ?: SidecarStore.load(context, folder, metadata.deviceId)[noteId]?.fileName
                 if (entries.remove(noteId) != null) {
                     SidecarStore.write(context, folder, metadata.deviceId, entries.values)
                 }

--- a/app/src/main/java/com/markleaf/notes/data/sync/SidecarStore.kt
+++ b/app/src/main/java/com/markleaf/notes/data/sync/SidecarStore.kt
@@ -9,21 +9,34 @@ import java.util.concurrent.ConcurrentHashMap
 /**
  * Reads and writes the sidecar index files in a mirror folder (#216).
  *
- * [SidecarIndex] is the pure format; this is the part that touches storage. It
- * holds this device's index in memory between calls so a note save costs one
- * write rather than a read-modify-write, and skips the write entirely when the
- * encoded bytes have not changed — a folder that syncs should not see its index
- * touched by a save that changed nothing.
+ * [SidecarIndex] is the pure format; this is the part that touches storage, and
+ * storage here is SAF — where listing a folder is the expensive call and every
+ * note save goes through this class.
+ *
+ * ## What is cached, and what deliberately is not
+ *
+ * **This device's own index is held in memory** and treated as the authority
+ * once loaded. Only this device writes that file, so re-reading it before each
+ * save told us nothing we did not already know — and it cost a folder listing
+ * plus a full parse every time. Holding it also removes a lost-update window:
+ * two writes that each read the same on-disk copy, added an entry and wrote
+ * back would drop one of the two entries.
+ *
+ * **Other devices' indexes are never cached.** They change outside this
+ * process, and a stale copy would attach a note to the wrong file. Every read
+ * of the merged view goes to disk (#262).
  */
 internal object SidecarStore {
 
-    /**
-     * Last content written per folder, so an unchanged index is not rewritten.
-     * Keyed by folder Uri + device, as [MirrorFileCache] is: one process can
-     * mirror to only one folder at a time today, but nothing here depends on
-     * that and a stale entry across a folder change would be a real bug.
-     */
-    private val lastWritten = ConcurrentHashMap<String, String>()
+    /** This device's entries plus the bytes last written, per folder+device. */
+    private class OwnIndex(
+        val entries: MutableMap<String, SidecarEntry>,
+        var lastWritten: String?
+    )
+
+    private val own = ConcurrentHashMap<String, OwnIndex>()
+
+    private fun keyOf(folder: DocumentFile, deviceId: String) = "${folder.uri}|$deviceId"
 
     /** Every index in [folder], ours and other devices'. Unreadable ones are skipped. */
     fun readAll(context: Context, folder: DocumentFile): List<ParsedIndex> =
@@ -39,16 +52,53 @@ internal object SidecarStore {
 
     /**
      * The merged view of every index, with [deviceId]'s entries winning.
-     * See [SidecarIndex.merge] for why another device's hash cannot stand in
-     * for our own.
+     *
+     * Always hits the disk, because the point of it is the *other* devices'
+     * entries. Callers that only need our own should use [ownEntries], which is
+     * cached — see [NoteFolderMirror] for the save path that was reading both.
      */
-    fun load(context: Context, folder: DocumentFile, deviceId: String): Map<String, SidecarEntry> =
-        SidecarIndex.merge(deviceId, readAll(context, folder))
+    fun load(context: Context, folder: DocumentFile, deviceId: String): Map<String, SidecarEntry> {
+        val indexes = readAll(context, folder)
+        // The disk pass just told us what our own file holds; adopt it if we
+        // have not loaded it yet, so a later ownEntries call costs nothing.
+        val ours = own.computeIfAbsent(keyOf(folder, deviceId)) {
+            val onDisk = indexes.firstOrNull { it.deviceId == deviceId }
+            OwnIndex(
+                onDisk?.entries?.associateByTo(mutableMapOf()) { it.noteId } ?: mutableMapOf(),
+                null
+            )
+        }.entries
+        // Others from disk, our own from memory. The cached copy is the
+        // authority — it may already hold entries this pass added that have not
+        // reached the file yet, and merging the file's version over them would
+        // hand the caller a view that disagrees with what the next write emits.
+        return SidecarIndex.merge(deviceId, indexes.filterNot { it.deviceId == deviceId }) + ours
+    }
+
+    /**
+     * This device's own entries — the ones it may rewrite.
+     *
+     * The returned map is the live cached copy: callers mutate it and then call
+     * [write], which is how a save records its entry.
+     */
+    fun ownEntries(
+        context: Context,
+        folder: DocumentFile,
+        deviceId: String
+    ): MutableMap<String, SidecarEntry> =
+        own.computeIfAbsent(keyOf(folder, deviceId)) {
+            val ours = readAll(context, folder).firstOrNull { it.deviceId == deviceId }
+            OwnIndex(ours?.entries?.associateByTo(mutableMapOf()) { it.noteId } ?: mutableMapOf(), null)
+        }.entries
 
     /**
      * Write [entries] as [deviceId]'s index. Best-effort: a failure here leaves
      * the notes themselves intact and costs only the mapping, which the next
      * pass rebuilds by filename.
+     *
+     * Skips the write when the bytes are unchanged. [SidecarIndex.encode] sorts,
+     * so a pass that changed nothing produces an identical file and a folder
+     * that syncs does not see it touched.
      */
     fun write(
         context: Context,
@@ -57,8 +107,8 @@ internal object SidecarStore {
         entries: Collection<SidecarEntry>
     ): Boolean {
         val encoded = SidecarIndex.encode(deviceId, entries)
-        val key = "${folder.uri}|$deviceId"
-        if (lastWritten[key] == encoded) return true
+        val cached = own[keyOf(folder, deviceId)]
+        if (cached?.lastWritten == encoded) return true
 
         val name = SidecarIndex.fileNameFor(deviceId)
         return runCatching {
@@ -68,21 +118,17 @@ internal object SidecarStore {
             context.contentResolver.openOutputStream(target.uri, "wt")?.use { stream ->
                 BufferedWriter(OutputStreamWriter(stream, Charsets.UTF_8)).use { it.write(encoded) }
             } ?: return@runCatching false
-            lastWritten[key] = encoded
+            cached?.lastWritten = encoded
             true
         }.getOrDefault(false)
     }
 
-    /** Only this device's own entries, which are the ones it may rewrite. */
-    fun ownEntries(
-        context: Context,
-        folder: DocumentFile,
-        deviceId: String
-    ): MutableMap<String, SidecarEntry> {
-        val own = readAll(context, folder).firstOrNull { it.deviceId == deviceId }
-        return own?.entries?.associateBy { it.noteId }?.toMutableMap() ?: mutableMapOf()
-    }
-
-    /** Drop the cached copy — used by tests and when the mirror folder changes. */
-    fun forget() = lastWritten.clear()
+    /**
+     * Drop everything remembered about every folder.
+     *
+     * Called when the folder stops being a sidecar folder — switching the mode
+     * off deletes our index, and a cached copy would otherwise be written back
+     * on the next save as if nothing had happened.
+     */
+    fun forget() = own.clear()
 }

--- a/app/src/testDebug/java/com/markleaf/notes/data/sync/SidecarStoreTest.kt
+++ b/app/src/testDebug/java/com/markleaf/notes/data/sync/SidecarStoreTest.kt
@@ -1,0 +1,163 @@
+package com.markleaf.notes.data.sync
+
+import android.content.Context
+import androidx.documentfile.provider.DocumentFile
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import java.io.File
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+/**
+ * How [SidecarStore] talks to storage (#262).
+ *
+ * Every note save goes through this class, and on SAF the folder listing is the
+ * expensive call. The original version read the whole folder twice per save —
+ * once for the merged view and once for our own entries — then wrote the index.
+ * These tests pin what is cached and, just as importantly, what is not.
+ *
+ * Runs over a real temp directory through `DocumentFile.fromFile`, so the file
+ * counting below measures actual reads rather than a mock's expectations.
+ */
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [33])
+class SidecarStoreTest {
+
+    @get:Rule
+    val temp = TemporaryFolder()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private lateinit var folder: DocumentFile
+
+    @Before
+    fun setUp() {
+        folder = DocumentFile.fromFile(temp.root)
+        SidecarStore.forget()
+    }
+
+    @After
+    fun tearDown() = SidecarStore.forget()
+
+    @Test
+    fun `own entries survive a write and a reload from disk`() {
+        val entries = SidecarStore.ownEntries(context, folder, DEVICE)
+        entries["n1"] = entry("n1", "First.md")
+        assertTrue(SidecarStore.write(context, folder, DEVICE, entries.values))
+
+        SidecarStore.forget()
+        val reloaded = SidecarStore.ownEntries(context, folder, DEVICE)
+
+        assertEquals(setOf("n1"), reloaded.keys)
+        assertEquals("First.md", reloaded.getValue("n1").fileName)
+    }
+
+    /**
+     * The cached map is the live one a save mutates, so a second call has to
+     * hand back the same entries rather than a fresh copy off disk — otherwise
+     * a save's record would be dropped before it was written.
+     */
+    @Test
+    fun `own entries are the same live map across calls`() {
+        SidecarStore.ownEntries(context, folder, DEVICE)["n1"] = entry("n1", "First.md")
+
+        assertEquals(setOf("n1"), SidecarStore.ownEntries(context, folder, DEVICE).keys)
+    }
+
+    /** An unchanged index must not be rewritten — a synced folder should not see it touched. */
+    @Test
+    fun `writing identical entries twice touches the file once`() {
+        val entries = SidecarStore.ownEntries(context, folder, DEVICE)
+        entries["n1"] = entry("n1", "First.md")
+        SidecarStore.write(context, folder, DEVICE, entries.values)
+
+        val indexFile = File(temp.root, SidecarIndex.fileNameFor(DEVICE))
+        val firstWrite = indexFile.lastModified()
+        indexFile.setLastModified(firstWrite - 10_000)
+        val movedBack = indexFile.lastModified()
+
+        assertTrue(SidecarStore.write(context, folder, DEVICE, entries.values))
+
+        assertEquals(
+            "an unchanged index was rewritten",
+            movedBack,
+            indexFile.lastModified()
+        )
+    }
+
+    /**
+     * Another device's file changes outside this process, so it is read fresh
+     * every time. Caching it would attach a note to the wrong file.
+     */
+    @Test
+    fun `another device's index is re-read rather than cached`() {
+        writeForeignIndex(entry("theirs", "Theirs.md"))
+        assertEquals("Theirs.md", SidecarStore.load(context, folder, DEVICE)["theirs"]?.fileName)
+
+        writeForeignIndex(entry("theirs", "Renamed.md"))
+
+        assertEquals("Renamed.md", SidecarStore.load(context, folder, DEVICE)["theirs"]?.fileName)
+    }
+
+    /**
+     * The merged view has to agree with what the next write will emit. Our own
+     * cached entries can be ahead of the file, and taking the file's version
+     * over them would hand a caller a note→file link that is about to change.
+     */
+    @Test
+    fun `merged view prefers our cached entry over the one on disk`() {
+        val entries = SidecarStore.ownEntries(context, folder, DEVICE)
+        entries["n1"] = entry("n1", "Old.md")
+        SidecarStore.write(context, folder, DEVICE, entries.values)
+        // A rename recorded in memory, not yet flushed.
+        entries["n1"] = entry("n1", "New.md")
+
+        assertEquals("New.md", SidecarStore.load(context, folder, DEVICE)["n1"]?.fileName)
+    }
+
+    /**
+     * Switching the mode off deletes our index. A cached copy written back on
+     * the next save would resurrect a mapping the user asked to remove.
+     */
+    @Test
+    fun `forget drops entries so a deleted index does not come back`() {
+        SidecarStore.ownEntries(context, folder, DEVICE)["n1"] = entry("n1", "First.md")
+        SidecarStore.forget()
+
+        assertTrue(SidecarStore.ownEntries(context, folder, DEVICE).isEmpty())
+    }
+
+    @Test
+    fun `an unreadable index is skipped rather than guessed at`() {
+        File(temp.root, SidecarIndex.fileNameFor("broken")).writeText("{ not json")
+
+        assertTrue(SidecarStore.readAll(context, folder).isEmpty())
+        assertNull(SidecarStore.load(context, folder, DEVICE)["anything"])
+    }
+
+    private fun writeForeignIndex(vararg entries: SidecarEntry) {
+        File(temp.root, SidecarIndex.fileNameFor(OTHER_DEVICE))
+            .writeText(SidecarIndex.encode(OTHER_DEVICE, entries.toList()))
+    }
+
+    private fun entry(id: String, file: String) = SidecarEntry(
+        noteId = id,
+        fileName = file,
+        contentHash = SidecarIndex.hashOf(file),
+        createdAtMillis = 0L,
+        pinned = false,
+        archived = false
+    )
+
+    private companion object {
+        const val DEVICE = "dev1"
+        const val OTHER_DEVICE = "dev2"
+    }
+}


### PR DESCRIPTION
Closes the index-write item in #262.

## What it cost before

A save in sidecar mode listed the mirror folder **three times** and parsed every index file in it **twice** — `load()` and `ownEntries()` each called `readAll()`. On SAF the folder listing is the expensive call, and this ran on every autosave. The issue described this as a read plus a write; reading the code while fixing it, it was worse than that.

## What changed

**This device's own index is now held in memory.** Only this device writes that file, so re-reading it before each save told us nothing we did not already know. It also closes a lost-update window: two writes that each read the same on-disk copy, added an entry and wrote back would drop one of the two.

**Other devices' indexes are still read from disk every time.** They change outside this process, and a stale copy would attach a note to the wrong file. That cached-vs-fresh distinction is the whole design, so there is a test for each half.

**The merged view is consulted only when our own index misses** — a note this device has not written before. The common autosave is now one folder listing and one write. `deleteNote` got the same treatment.

**`load()` overlays our cached entries** on the disk view rather than merging the file's copy of our own index, so the merged view cannot disagree with what the next write will emit.

## Verification

`./gradlew test` and `:app:lintRelease` pass. Seven new `SidecarStoreTest` cases run over a real temp directory through `DocumentFile.fromFile`, so they measure actual file behaviour rather than a mock's expectations.

Checked on the phone AVD against a real SAF folder — the point being that behaviour is **unchanged**, not merely faster:

| | |
|---|---|
| Three edits to one note | index stays at 6 entries, recorded hash equals `sha256sum` of the file |
| Four sync passes | 6 entries, 6 files, no duplicate |
| `touch` on an unchanged file | still a no-op |
| File rewritten outside the app | still imported; note shows the new text, entry hash follows it |

## A note on the device run

Two of my blind coordinate taps during this session landed in an unrelated screen, which briefly looked like "the external edit was not imported". It was not a regression — the sync had simply never run. Re-done with the screen verified before each tap, and the result above is from that run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)