### PR TITLE
build: pin the Gradle distribution with distributionSha256Sum (#246)

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -87,11 +87,18 @@ into one. `./gradlew :app:foo -Pbar=baz` reached Gradle as the single task name
 nothing tripped over it for the project's whole life.
 
 **Never hand-edit these four files.** Regenerate them together so the scripts,
-the jar and the properties stay a matched set from one distribution:
+the jar and the properties stay a matched set from one distribution — and pass
+the distribution checksum in the same command:
 
 ```powershell
-.\gradlew.bat wrapper --gradle-version <version>
+.\gradlew.bat wrapper --gradle-version <version> --gradle-distribution-sha256-sum <sum>
 ```
+
+**`distributionUrl` and `distributionSha256Sum` move together or not at all.**
+Bumping the version without the matching sum leaves the old checksum in place
+and every wrapper-driven build fails — CI, local, release. `<sum>` is Gradle's
+published checksum for the distribution, from
+`https://downloads.gradle.org/distributions/gradle-<version>-bin.zip.sha256`.
 
 Use `gradlew.bat`, not the POSIX script, and expect `cmd` to complain at the end
 of the run — it re-reads the batch file it is executing while the task rewrites
@@ -102,10 +109,23 @@ Afterwards, verify:
 - the jar's SHA-256 matches Gradle's published checksum,
 - `gradlew` is committed with LF and `gradlew.bat` with CRLF,
 - a genuinely multi-argument call works from a POSIX shell —
-  `./gradlew :app:tasks -PsomeProperty=value`.
+  `./gradlew :app:tasks -PsomeProperty=value`,
+- the distribution checksum is enforced, on a **clean** `GRADLE_USER_HOME`. A
+  machine that already has that distribution unpacked never re-verifies it, so
+  a wrong sum looks fine locally and breaks everywhere else:
 
-`distributionSha256Sum` is still unset, so the *distribution* download is
-unpinned even though the wrapper jar is now verifiable. Worth adding.
+```powershell
+$env:GRADLE_USER_HOME = "$env:TEMP\gradle-home-check"; .\gradlew.bat --version
+```
+
+For 8.9 the distribution sum is
+`d725d707bfabd4dfdc958c624003b3c80accc03f7037b5122c4b1d0ef15cecab` (#246).
+
+F-Droid does not use any of this. `fdroidserver` deletes `gradlew`,
+`gradlew.bat` and `gradle-wrapper.jar` from the checkout and builds with
+`gradlew-fdroid`, which reads `gradle-wrapper.properties` only to pull the
+version out of `distributionUrl` and then verifies its own download against the
+F-Droid gradle-transparency-log. Pinning covers every other build path.
 
 ## R8 (Minification + Resource Shrinking)
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionSha256Sum=d725d707bfabd4dfdc958c624003b3c80accc03f7037b5122c4b1d0ef15cecab
 distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true


### PR DESCRIPTION
Closes #246.

`validateDistributionUrl=true` only checks that the URL *looks like* a Gradle distribution URL. Whatever that URL serves is unzipped and executed, and it is the thing that builds every APK — including the ones F-Droid reproduces and the ones users install. #241 made `gradle-wrapper.jar` verifiable and left the distribution it downloads unpinned.

## The change

```diff
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionSha256Sum=d725d707bfabd4dfdc958c624003b3c80accc03f7037b5122c4b1d0ef15cecab
 distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
```

Regenerated with the wrapper task, not hand-edited, so the four wrapper files stay a matched set as `docs/RELEASE.md` requires:

```powershell
.\gradlew.bat wrapper --gradle-version 8.9 --gradle-distribution-sha256-sum d725d707…cecab
```

## Where the sum comes from

`https://downloads.gradle.org/distributions/gradle-8.9-bin.zip.sha256` → `d725d707bfabd4dfdc958c624003b3c80accc03f7037b5122c4b1d0ef15cecab`.

The wrapper confirms it independently: given a wrong sum it prints the actual checksum of what it just downloaded, and that value is the published one (see the negative test below).

## Verification — on a clean `GRADLE_USER_HOME`, both ways

A machine that already has the distribution unpacked never re-verifies it, so a run against the normal cache proves nothing. Both runs below used a fresh `GRADLE_USER_HOME` and re-downloaded the distribution.

**Correct sum** — downloads, verifies, starts:

```
Downloading https://services.gradle.org/distributions/gradle-8.9-bin.zip
............10%.......…100%
Welcome to Gradle 8.9!
Gradle 8.9   (exit 0)
```

**Zeroed sum** — refuses to build:

```
Exception in thread "main" java.lang.RuntimeException: Verification of Gradle distribution failed!
Expected checksum: '0000000000000000000000000000000000000000000000000000000000000000'
  Actual checksum: 'd725d707bfabd4dfdc958c624003b3c80accc03f7037b5122c4b1d0ef15cecab'
   (exit 1)
```

## Docs

`docs/RELEASE.md` now states the constraint this adds — **`distributionUrl` and `distributionSha256Sum` move together or every wrapper-driven build fails** — gives the regeneration command with both flags, and adds the clean-cache check to the post-regeneration list. It replaces the paragraph that said pinning was still worth doing.

## F-Droid: unaffected, and here is why

Checked against `fdroidserver` rather than assumed:

- `fdroidserver/scanner.py` removes `gradle-wrapper.jar`, `gradlew`, `gradlew.bat` from the checkout; `fdroidserver/build.py` does `del_files(['gradlew', 'gradlew.bat'])` too.
- `fdroidserver/common.py` sets the build command to `shutil.which('gradlew-fdroid')`.
- `gradlew-fdroid` parses `gradle-wrapper.properties` with a regex over **`distributionUrl` only**, to pick which locally installed Gradle to use, then verifies its own download against the F-Droid gradle-transparency-log.

So F-Droid never reads `distributionSha256Sum`, and the key it does read is unchanged. `metadata/com.markleaf.notes.yml` needs no edit.

Build-infrastructure only: no app code, no user-visible change, so no `CHANGELOG.md` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)