### PR TITLE
ci(release): publish the GitLab release from GitHub, and document two release traps (#252)

### DIFF
--- a/.github/scripts/mirror-release-to-gitlab.sh
+++ b/.github/scripts/mirror-release-to-gitlab.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+#
+# Publish a GitLab Release for the current tag from GitHub Actions (#252).
+#
+# GitLab's own tag pipeline used to do this (`publish_gitlab_release` in
+# .gitlab-ci.yml). It stopped: the free shared-runner minutes are a monthly
+# quota, the quota ran out, and every pipeline since has failed with
+# `ci_quota_exceeded` before reaching the release stage. Eight releases shipped
+# that way -- v2.28.0 through v2.31.0 -- while GitLab's newest Release stayed at
+# v2.27.2, and D064 went on describing GitLab as the off-machine permanent copy
+# of the AAB and mapping the whole time.
+#
+# The Packages and Releases APIs do not consume CI minutes. Only the *pipeline*
+# did. So this runs on the GitHub runner, which is free for public
+# repositories, and uploads the same four files to the same Generic Package
+# Registry path glab used -- existing v2.27.2 links keep working and new ones
+# match them.
+#
+# The tag must already exist on GitLab. Release order is GitLab first, GitHub
+# second (docs/mirror-runbook.md), so by the time the GitHub tag job runs it
+# does; this fails loudly rather than creating a tag, because creating one here
+# would invert that order.
+#
+# Requires GITLAB_TOKEN with the `api` scope. The mirror-push token only needs
+# `write_repository`, which is not enough to write packages or releases -- a
+# token with the narrower scope fails at the first upload with 401/403 and the
+# message says so.
+
+set -euo pipefail
+
+PROJECT="jeiel85%2Fmarkleaf-android"
+API="https://gitlab.com/api/v4/projects/${PROJECT}"
+PACKAGE_NAME="markleaf-android"
+DIST_DIR="${DIST_DIR:-dist}"
+
+TAG="${GITHUB_REF_NAME:?GITHUB_REF_NAME is not set}"
+
+if [ -z "${GITLAB_TOKEN:-}" ]; then
+  echo "::error::GITLAB_TOKEN secret is missing. Create a GitLab Project Access Token with the 'api' scope and register it -- see docs/mirror-runbook.md."
+  exit 1
+fi
+
+auth=(--header "PRIVATE-TOKEN: ${GITLAB_TOKEN}")
+
+# Fail on a token that cannot do the job, before uploading anything. A
+# write_repository-only token reads fine and writes nothing, so the first
+# meaningful check is a write-scoped read: the packages list.
+probe_status="$(curl -sS -o /dev/null -w '%{http_code}' "${auth[@]}" "${API}/packages?per_page=1" || true)"
+case "$probe_status" in
+  200) ;;
+  401|403)
+    echo "::error::GITLAB_TOKEN was rejected for the Packages API (HTTP ${probe_status}). The token needs the 'api' scope; 'write_repository' alone cannot publish packages or releases."
+    exit 1
+    ;;
+  *)
+    echo "::error::Could not reach the GitLab Packages API (HTTP ${probe_status}). Not treating that as success -- the mirror is unverified."
+    exit 1
+    ;;
+esac
+
+# The tag has to be on GitLab already. Creating it here would invert the
+# documented GitLab-first order and could double-fire the release paths.
+tag_status="$(curl -sS -o /dev/null -w '%{http_code}' "${auth[@]}" "${API}/repository/tags/${TAG}" || true)"
+if [ "$tag_status" != "200" ]; then
+  echo "::error::Tag ${TAG} is not on GitLab (HTTP ${tag_status}). Push the tag to GitLab first, then re-run this job."
+  exit 1
+fi
+
+# Already published: re-running the tag job must not fail, and must not
+# silently produce a second release either.
+release_status="$(curl -sS -o /dev/null -w '%{http_code}' "${auth[@]}" "${API}/releases/${TAG}" || true)"
+if [ "$release_status" = "200" ]; then
+  echo "GitLab already has a Release for ${TAG}; nothing to do."
+  echo "GitLab Release \`${TAG}\` already existed -- left untouched." >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
+  exit 0
+fi
+
+shopt -s nullglob
+files=("${DIST_DIR}"/*)
+shopt -u nullglob
+if [ "${#files[@]}" -ne 4 ]; then
+  echo "::error::Expected 4 files in ${DIST_DIR} (apk, aab, mapping, release notes), found ${#files[@]}."
+  printf '  %s\n' "${files[@]}"
+  exit 1
+fi
+
+notes=""
+for f in "${files[@]}"; do
+  case "$f" in *-release-notes.txt) notes="$f" ;; esac
+done
+if [ -z "$notes" ] || [ ! -s "$notes" ]; then
+  echo "::error::No non-empty *-release-notes.txt in ${DIST_DIR}. The GitLab release body is the six-locale notes file, not CHANGELOG.md."
+  exit 1
+fi
+
+# Same registry coordinates glab used, so links on older releases and links on
+# this one address the same package.
+links_json=""
+for f in "${files[@]}"; do
+  name="$(basename "$f")"
+  url="${API}/packages/generic/${PACKAGE_NAME}/${TAG}/${name}"
+
+  echo "Uploading ${name}"
+  status="$(curl -sS -o /dev/null -w '%{http_code}' --request PUT "${auth[@]}" --upload-file "$f" "$url" || true)"
+  case "$status" in
+    200|201) ;;
+    401|403)
+      echo "::error::Upload of ${name} was rejected (HTTP ${status}). The token needs the 'api' scope."
+      exit 1
+      ;;
+    *)
+      echo "::error::Upload of ${name} failed (HTTP ${status})."
+      exit 1
+      ;;
+  esac
+
+  links_json="${links_json}${links_json:+,}$(
+    python3 -c 'import json,sys; print(json.dumps({"name": sys.argv[1], "url": sys.argv[2], "link_type": "package"}))' \
+      "$name" "$url"
+  )"
+done
+
+body="$(python3 -c '
+import json, sys
+tag, notes_path, links = sys.argv[1], sys.argv[2], sys.argv[3]
+with open(notes_path, encoding="utf-8") as fh:
+    description = fh.read()
+print(json.dumps({
+    "name": tag,
+    "tag_name": tag,
+    "description": description,
+    "assets": {"links": json.loads("[" + links + "]")},
+}))
+' "$TAG" "$notes" "$links_json")"
+
+status="$(printf '%s' "$body" | curl -sS -o /tmp/gitlab-release.json -w '%{http_code}' \
+  --request POST "${auth[@]}" \
+  --header 'Content-Type: application/json' \
+  --data-binary @- \
+  "${API}/releases" || true)"
+
+if [ "$status" != "201" ]; then
+  echo "::error::Creating the GitLab Release for ${TAG} failed (HTTP ${status})."
+  cat /tmp/gitlab-release.json || true
+  exit 1
+fi
+
+echo "GitLab Release ${TAG} published with ${#files[@]} package assets."
+echo "GitLab Release \`${TAG}\` published with ${#files[@]} package assets." >> "${GITHUB_STEP_SUMMARY:-/dev/null}"

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -385,10 +385,19 @@ jobs:
           ' CHANGELOG.md > release-notes.md
           test -s release-notes.md
 
+      # Idempotent so the job can be re-run. The GitLab publish below can fail
+      # for reasons that are fixed outside this workflow — a token scope, a tag
+      # not yet on GitLab — and the fix is "re-run the job". `gh release create`
+      # fails on an existing release, so without this the re-run would die here
+      # and never reach the step that actually needed retrying.
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          if gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" > /dev/null 2>&1; then
+            echo "GitHub release $GITHUB_REF_NAME already exists; leaving it untouched."
+            exit 0
+          fi
           gh release create "$GITHUB_REF_NAME" \
             "markleaf-${GITHUB_REF_NAME}.apk" \
             --repo "$GITHUB_REPOSITORY" \

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -394,3 +394,33 @@ jobs:
             --repo "$GITHUB_REPOSITORY" \
             --title "$(cat release-title.txt)" \
             --notes-file release-notes.md
+
+      # The four versioned files the GitLab Release carries. Built here rather
+      # than on GitLab because GitLab's tag pipeline has not run since its
+      # monthly CI minutes ran out (#252) — the APIs below do not consume them,
+      # only the pipeline did.
+      #
+      # assembleRelease and bundleRelease already ran above; this re-runs them
+      # as dependencies, finds them up to date, and copies the outputs out under
+      # their versioned names alongside the six-locale notes.
+      - name: Export versioned release artifacts
+        env:
+          MARKLEAF_RELEASE_STORE_FILE: release/markleaf-release.p12
+          MARKLEAF_RELEASE_STORE_PASSWORD: ${{ secrets.MARKLEAF_RELEASE_STORE_PASSWORD }}
+          MARKLEAF_RELEASE_KEY_ALIAS: ${{ secrets.MARKLEAF_RELEASE_KEY_ALIAS }}
+          MARKLEAF_RELEASE_KEY_PASSWORD: ${{ secrets.MARKLEAF_RELEASE_KEY_PASSWORD }}
+          ORG_GRADLE_PROJECT_markleaf.requireReleaseSigning: "true"
+        run: |
+          rm -rf dist
+          ./gradlew :app:exportReleaseArtifacts -Pmarkleaf.releaseExportDir=dist
+          ls -lh dist
+
+      # After the GitHub release, deliberately: GitHub is the primary path and
+      # must not be blocked by the mirror. A failure here still reddens the job
+      # — a mirror that quietly does nothing is what #247 was about.
+      - name: Publish the GitLab release
+        env:
+          GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
+        run: |
+          chmod +x .github/scripts/mirror-release-to-gitlab.sh
+          ./.github/scripts/mirror-release-to-gitlab.sh

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -113,7 +113,9 @@ package_signed_release:
     paths:
       - dist/
   rules:
-    - if: '$CI_COMMIT_TAG =~ /^v\d+\.\d+\.\d+$/'
+    # See publish_gitlab_release: this job exists only to feed it, so the two
+    # share one switch.
+    - if: '$CI_COMMIT_TAG =~ /^v\d+\.\d+\.\d+$/ && $GITLAB_RELEASE_FROM_CI == "true"'
 
 publish_gitlab_release:
   stage: release
@@ -136,4 +138,16 @@ publish_gitlab_release:
       --use-package-registry
       --no-update
   rules:
-    - if: '$CI_COMMIT_TAG =~ /^v\d+\.\d+\.\d+$/'
+    # Off by default since #252. GitHub Actions publishes the GitLab Release
+    # now (.github/scripts/mirror-release-to-gitlab.sh) because the Packages
+    # and Releases APIs cost no CI minutes, while this pipeline needs them —
+    # and the quota running out is what left eight releases unmirrored.
+    #
+    # The path is kept, not deleted, for the case it was built for: GitHub
+    # unavailable, GitLab releasing on its own (that has happened once, when
+    # GitHub flagged the account in July). Set the project variable
+    # GITLAB_RELEASE_FROM_CI=true then, and unset it afterwards.
+    #
+    # Exclusive by construction: with the variable unset this job never runs,
+    # so the two paths cannot both publish one tag and race to a 409.
+    - if: '$CI_COMMIT_TAG =~ /^v\d+\.\d+\.\d+$/ && $GITLAB_RELEASE_FROM_CI == "true"'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,12 +149,14 @@ GitLab CI용 산출물은 `-Pmarkleaf.releaseExportDir=<dir>`와 함께
    남기고 `pwsh scripts/verify-release-export.ps1`로 확인한다 — `D:\Build`는 CI가 볼 수 없는
    로컬 경로라 이 단계가 빠져도 아무것도 실패하지 않으며, 실제로 v2.27.2부터 v2.29.0까지
    여섯 릴리스가 AAB·mapping 없이 지나갔다(#247). 그다음 `vX.Y.Z` 태그를 GitLab 먼저,
-   GitHub 다음으로 푸시한다. 같은 태그가 양쪽에서
-   독립적으로 서명 빌드를 돌리지만 **릴리스에 붙는 자산은 다르다** — GitHub Release는 APK
-   하나만, GitLab Release는 Generic Package Registry를 통해 AAB와 mapping까지 포함한다
+   GitHub 다음으로 푸시한다. **릴리스에 붙는 자산은 양쪽이 다르다** — GitHub Release는
+   APK 하나만, GitLab Release는 Generic Package Registry를 통해 AAB와 mapping까지 포함한다
    (AAB를 GitHub에 올리지 않는 이유는 D062, mapping을 빼고 30일 아티팩트로만 두는 이유는
-   D064). GitHub 태그는 F-Droid 자동 픽업도 발동하므로
-   별도 F-Droid 제출 단계는 없다.
+   D064). 단 **GitLab Release를 만드는 주체는 이제 GitHub 태그 잡이다**(#252) —
+   GitLab CI 무료 분이 소진돼 태그 파이프라인이 `ci_quota_exceeded`로 죽으면서 여덟
+   릴리스가 미러되지 않았고, Packages·Releases API는 CI 분을 쓰지 않으므로 GitHub
+   러너에서 올린다. GitLab 태그를 먼저 미는 순서는 그대로다(잡이 태그 존재를 확인한다).
+   GitHub 태그는 F-Droid 자동 픽업도 발동하므로 별도 F-Droid 제출 단계는 없다.
    릴리스 커밋은 `git add -A`로 만들지 않는다 — 변경 파일을 명시적으로 stage하거나 커밋 전
    working tree가 릴리스 대상만 담고 있는지 확인한다(무관한 작업이 태그에 섞여 나가는 것을
    막기 위함, v2.24.0에서 landing-i18n 유입 사고 → #154).

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -64,6 +64,26 @@ The signed APK is written to:
 app/build/outputs/apk/release/app-release.apk
 ```
 
+### Building from a worktree
+
+Both signing inputs are gitignored at the repository root — `/.secrets/` and
+`/release-signing.properties` in `.gitignore` — so they exist only in the
+checkout where they were created. A `git worktree` is a separate checkout, and
+concurrent sessions now make that the normal place to work, so a release built
+there fails at signing until both are copied across:
+
+```powershell
+Copy-Item <main-checkout>\release-signing.properties .
+New-Item -ItemType Directory -Force .secrets | Out-Null
+Copy-Item <main-checkout>\.secrets\markleaf-release.p12 .secrets\
+```
+
+The failure without them is not obviously about a missing file — the build
+reports unsigned output, or `-Pmarkleaf.requireReleaseSigning=true` fails
+without naming the worktree as the reason. Copy, never move: the main checkout
+has to keep its own copy. Nothing prunes these from a worktree, so delete the
+worktree rather than leaving a keystore behind in it (#252).
+
 ## The Gradle Wrapper
 
 `gradle/wrapper/gradle-wrapper.jar` is a binary in the build path, and F-Droid
@@ -369,6 +389,30 @@ Three assertions:
   release time, after the release commit already exists — de-DE and fr-FR were
   once written at 526 and 525 characters and were caught only by counting them
   by hand (#167).
+
+#### Aim the English draft at ~380 characters
+
+Both checks above run *after* the six files are written, so an overrun means
+rewriting all of them. That has happened at four cuts now (#167, then de/es/fr
+at v2.30.0, then en-US at v2.31.0), and always the same way: the English note
+fit, so it looked done.
+
+It is not evidence the set fits. German compounds and the Romance languages run
+consistently longer than the English source — v2.29.1's first draft came in at
+545 for fr-FR and 517 for es-ES against an English note that was comfortably
+inside the limit. Roughly 380 characters of English is what v2.29.1 settled at
+and what leaves the translations room; at 450 the English passes and at least
+one translation will not.
+
+Count before translating, not after:
+
+```powershell
+(Get-Content -Raw fastlane/metadata/android/en-US/changelogs/<versionCode>.txt).Trim().Length
+```
+
+`verify-release-notes.ps1` warns from 450 (90% of the limit) so a note that
+squeaks in still says so — but the warning has no teeth, and four of six
+locales sat in that band at v2.31.0 (#252, #255, #262).
 - `CHANGELOG.md` and `CHANGELOG.ko.md` carry the same version sections in the
   same order with the same dates, and both have a section for the current
   `versionName`. Titles are translations, so they are not compared.
@@ -439,7 +483,7 @@ outputs.
 
 ## GitLab Release Assets
 
-GitLab tag pipelines call `:app:exportReleaseArtifacts` with an explicit
+The GitHub tag job calls `:app:exportReleaseArtifacts` with an explicit
 `markleaf.releaseExportDir`. The task exports four flat, versioned files:
 
 - `markleaf-vX.Y.Z-vcN.apk`
@@ -447,10 +491,42 @@ GitLab tag pipelines call `:app:exportReleaseArtifacts` with an explicit
 - `markleaf-vX.Y.Z-vcN.mapping.txt`
 - `markleaf-vX.Y.Z-vcN-release-notes.txt`
 
-The release job uploads them to the GitLab Generic Package Registry through
-`glab release create --use-package-registry`. Release links therefore point to
-persistent package files rather than expiring CI job artifacts. Job artifacts
-are retained only long enough to transfer the files between CI stages.
+`.github/scripts/mirror-release-to-gitlab.sh` uploads them to the GitLab
+Generic Package Registry and creates the Release with links to them. Release
+links therefore point to persistent package files rather than expiring CI job
+artifacts.
+
+### Why the GitHub runner publishes the GitLab release
+
+This used to be `publish_gitlab_release` in `.gitlab-ci.yml`, and it stopped
+working. GitLab's free shared-runner minutes are a monthly quota; the quota ran
+out and every pipeline since has failed with `ci_quota_exceeded` before
+reaching the release stage. Eight releases shipped that way — v2.28.0 through
+v2.31.0 — while GitLab's newest Release stayed at v2.27.2 and D064 went on
+describing GitLab as the off-machine permanent copy of the AAB and mapping
+(#252).
+
+The Packages and Releases **APIs do not consume CI minutes**; only the pipeline
+did. Publishing from the GitHub runner, which is free for public repositories,
+restores the mirror without touching the quota. The package coordinates are the
+ones `glab` used, so links on v2.27.2 and links on later releases address the
+same registry path.
+
+Two things this depends on:
+
+- **`GITLAB_TOKEN` needs the `api` scope.** The mirror-push token only needs
+  `write_repository`, which cannot write packages or releases. The script
+  probes the Packages API before uploading anything and fails with that
+  message rather than part-publishing.
+- **The tag must already be on GitLab.** Release order is GitLab first, GitHub
+  second, so it is by the time the GitHub job runs. The script refuses rather
+  than creating the tag itself, which would invert that order.
+
+The GitLab-side path is kept but switched off: `package_signed_release` and
+`publish_gitlab_release` now also require the project variable
+`GITLAB_RELEASE_FROM_CI=true`. That is for the case it was built for — GitHub
+unavailable and GitLab releasing on its own. With the variable unset the two
+paths cannot both publish one tag.
 
 The local Play Console hand-off remains separate:
 

--- a/docs/mirror-runbook.md
+++ b/docs/mirror-runbook.md
@@ -92,8 +92,18 @@ git push github vX.Y.Z
 
 1. **GitLab에서 Project Access Token 발급.** 프로젝트 → Settings → Access Tokens.
    - Role: **Maintainer** (보호된 `main`에 push하려면 필요하다)
-   - Scope: **`write_repository`** 하나만
+   - Scope: **`write_repository`** + **`api`**
    - Expiry: GitLab이 만료일을 강제한다(최대 1년). **날짜를 적어 둘 것** — 아래 갱신 항목 참조.
+
+   `api`는 #252에서 추가로 필요해졌다. 같은 토큰을 릴리스 태그 잡도
+   쓰는데(`.github/scripts/mirror-release-to-gitlab.sh`), Package Registry 업로드와
+   Release 생성은 `write_repository`로는 안 된다. 이미 `write_repository`만으로
+   발급된 토큰이 있다면 **재발급이 필요하다** — GitLab은 기존 토큰의 스코프를
+   나중에 넓혀 주지 않는다. 재발급 후 같은 이름(`GITLAB_TOKEN`)으로 GitHub 시크릿을
+   덮어쓰면 mirror-push는 그대로 동작한다.
+
+   스코프가 모자란 채로 태그를 밀면 릴리스 잡이 업로드 전에 멈추고
+   `The token needs the 'api' scope` 를 남긴다. 절반만 올라간 상태로 끝나지 않는다.
 2. **GitHub에 시크릿 등록.** 저장소 → Settings → Secrets and variables → Actions →
    New repository secret. 이름은 정확히 **`GITLAB_TOKEN`**.
 3. **확인.** Actions 탭 → **Mirror push** → Run workflow. 또는 아무 PR이나 머지하면


### PR DESCRIPTION
Three items from the v2.29.1 hardening tracker (#252), picked up during a sweep over the open issue backlog.

## The GitLab mirror has not carried a release since v2.27.2

Measured against the API rather than assumed: GitLab's newest Release is still `v2.27.2 (2026-07-21)`, and this morning's pipeline failed with `ci_quota_exceeded` on every job. Eight releases have shipped since — v2.28.0 through v2.31.0 — while D064 went on describing GitLab as the off-machine permanent copy of the AAB and mapping.

**Refs were never the problem.** `mirror-push` keeps `main` and the tags in sync and the daily `mirror-check` has been green throughout, so all eight tags are on GitLab. What is missing is the Release object and its attached artifacts, and only the GitLab pipeline could create them.

The Packages and Releases **APIs do not consume CI minutes** — only the pipeline did. So the tag job on the GitHub runner (free for public repositories) now exports the four versioned files and publishes them itself, at the same Generic Package Registry coordinates `glab` used, so links on v2.27.2 and links on later releases address the same path.

- `.github/scripts/mirror-release-to-gitlab.sh` probes the Packages API **before uploading anything**, so a token that cannot do the job fails with that message rather than part-publishing. It refuses to create the tag — doing so would invert the documented GitLab-first order — and exits cleanly if the release already exists, so re-running a tag job is safe.
- The step runs *after* the GitHub release on purpose: GitHub is the primary path and must not be blocked by the mirror. A failure still reddens the job, because a mirror that quietly does nothing is the #247 defect.
- `package_signed_release` and `publish_gitlab_release` now also require `GITLAB_RELEASE_FROM_CI=true`. That path is kept, not deleted, for the case it was built for — GitHub unavailable and GitLab releasing on its own, which happened when GitHub flagged the account in July. With the variable unset the two paths cannot both publish one tag.

### ⚠️ This needs a token change before it can work

`GITLAB_TOKEN` currently carries `write_repository`, which cannot write packages or releases, and GitLab does not widen an existing token's scope. Re-issue the Project Access Token with `api` added and overwrite the same secret — `mirror-push` keeps working unchanged. Until then the release job will fail at the probe with a message naming the scope. `docs/mirror-runbook.md` now says this at the point where the token is created.

The eight already-missing releases are **not** backfilled here; that needs the same token plus artifacts that only exist locally for the more recent ones.

## Two release traps that were documented nowhere

- **Worktree builds.** `release-signing.properties` and `.secrets/markleaf-release.p12` are gitignored at the repository root, so a worktree has neither and `bundleRelease` fails without naming that as the reason. Worktrees are now the normal place to work.
- **Store-note length.** The checks run after all six locales are written, so an overrun means rewriting the set — which has happened at four cuts (#167, de/es/fr at v2.30.0, en-US at v2.31.0), every time because the English note fit. It is not evidence the set fits: German and the Romance languages run consistently longer. ~380 characters of English is what v2.29.1 settled at and what leaves the translations room.

## Verification

`bash -n` and a YAML parse on both workflows. The JSON assembly run against a fixture whose release notes carry Hangul, quotes and angle brackets — round-trips intact. Both token guards exercised against the live GitLab API (GET only; nothing was written): missing token and rejected token each produce the intended message and exit 1.

The upload and release-creation paths themselves cannot be exercised until a tag runs with an `api`-scoped token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)