### PR TITLE
feat(preview): stop flattening H4-H6 into H3 (#255)

### DIFF
--- a/app/src/main/java/com/markleaf/notes/core/markdown/CommonMarkPreviewAdapter.kt
+++ b/app/src/main/java/com/markleaf/notes/core/markdown/CommonMarkPreviewAdapter.kt
@@ -143,7 +143,12 @@ internal object CommonMarkPreviewAdapter {
         val type = when (node.level) {
             1 -> PreviewLineType.H1
             2 -> PreviewLineType.H2
-            else -> PreviewLineType.H3
+            3 -> PreviewLineType.H3
+            4 -> PreviewLineType.H4
+            5 -> PreviewLineType.H5
+            // commonmark caps ATX headings at 6, so `else` is 6 rather than a
+            // fallback for anything deeper.
+            else -> PreviewLineType.H6
         }
         val text = collectText(node)
         return PreviewLine(

--- a/app/src/main/java/com/markleaf/notes/core/markdown/SimpleMarkdownPreview.kt
+++ b/app/src/main/java/com/markleaf/notes/core/markdown/SimpleMarkdownPreview.kt
@@ -4,6 +4,13 @@ enum class PreviewLineType {
     H1,
     H2,
     H3,
+    // H4–H6 used to collapse into H3, which was invisible while the preview was
+    // the only consumer — three sizes read as "a heading" either way. The
+    // outline screen made it visible: indentation is its only level cue, so a
+    // note nesting past three levels rendered as a flat list (#255).
+    H4,
+    H5,
+    H6,
     BULLET,
     CHECKBOX_DONE,
     CHECKBOX_TODO,
@@ -266,6 +273,15 @@ object SimpleMarkdownPreview {
     private fun parseLine(line: String): PreviewLine {
         return when {
             line.isBlank() -> PreviewLine("", PreviewLineType.EMPTY)
+            // Longest marker first. `startsWith("### ")` is already false for
+            // `#### ` — the fourth character is `#`, not a space — but ordering
+            // by length keeps that from being something a reader has to work out.
+            line.startsWith("###### ") ->
+                PreviewLine(line.removePrefix("###### ").trim(), PreviewLineType.H6)
+            line.startsWith("##### ") ->
+                PreviewLine(line.removePrefix("##### ").trim(), PreviewLineType.H5)
+            line.startsWith("#### ") ->
+                PreviewLine(line.removePrefix("#### ").trim(), PreviewLineType.H4)
             line.startsWith("### ") -> PreviewLine(line.removePrefix("### ").trim(), PreviewLineType.H3)
             line.startsWith("## ") -> PreviewLine(line.removePrefix("## ").trim(), PreviewLineType.H2)
             line.startsWith("# ") -> PreviewLine(line.removePrefix("# ").trim(), PreviewLineType.H1)

--- a/app/src/main/java/com/markleaf/notes/core/markdown/preview/MarkdownPreviewList.kt
+++ b/app/src/main/java/com/markleaf/notes/core/markdown/preview/MarkdownPreviewList.kt
@@ -140,6 +140,28 @@ fun PreviewLineRenderer(
             color = MaterialTheme.colorScheme.secondary,
             modifier = Modifier.padding(top = 6.dp, bottom = 4.dp)
         )
+        // H4–H6 continue down the same type scale rather than getting a
+        // treatment of their own. The last two also drop to the muted colour:
+        // by that depth the heading is closer to a label than a section title,
+        // and six visually distinct heading styles in one note is noise.
+        PreviewLineType.H4 -> Text(
+            text = line.text,
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.secondary,
+            modifier = Modifier.padding(top = 6.dp, bottom = 4.dp)
+        )
+        PreviewLineType.H5 -> Text(
+            text = line.text,
+            style = MaterialTheme.typography.titleSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(top = 4.dp, bottom = 2.dp)
+        )
+        PreviewLineType.H6 -> Text(
+            text = line.text,
+            style = MaterialTheme.typography.labelLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(top = 4.dp, bottom = 2.dp)
+        )
         PreviewLineType.BULLET -> InlineMarkdownText(
             line = line,
             leadingMarker = "• ",
@@ -389,7 +411,7 @@ internal fun findFootnoteDefIndex(lines: List<PreviewLine>, label: String): Int 
 /**
  * A heading entry for the table of contents: its [index] into the rendered
  * [PreviewLine] list (so the same `animateScrollToItem` used for footnote jumps
- * lands on the heading), the display [text], and the [level] (1..3).
+ * lands on the heading), the display [text], and the [level] (1..6).
  *
  * [sourceLine] is the 0-based line the heading occupies in the note's own text.
  * The rendered index can only ever scroll the preview; jumping while the user
@@ -405,7 +427,7 @@ data class TocHeading(
 )
 
 /**
- * Extracts the H1/H2/H3 outline from rendered [lines] for the table of contents.
+ * Extracts the H1–H6 outline from rendered [lines] for the table of contents.
  * The index matches the LazyColumn item index, so tapping an entry can scroll the
  * preview to that heading. Lifted out of the UI so it can be unit-tested.
  */
@@ -415,6 +437,9 @@ internal fun extractHeadings(lines: List<PreviewLine>): List<TocHeading> =
             PreviewLineType.H1 -> 1
             PreviewLineType.H2 -> 2
             PreviewLineType.H3 -> 3
+            PreviewLineType.H4 -> 4
+            PreviewLineType.H5 -> 5
+            PreviewLineType.H6 -> 6
             else -> null
         }
         level?.let {

--- a/app/src/test/java/com/markleaf/notes/core/markdown/preview/TocHeadingsTest.kt
+++ b/app/src/test/java/com/markleaf/notes/core/markdown/preview/TocHeadingsTest.kt
@@ -58,20 +58,41 @@ class TocHeadingsTest {
     }
 
     @Test
-    fun `outline only ever contains heading levels one through three`() {
-        // The preview model only has H1/H2/H3, so however the parser buckets a
-        // deeper heading, extractHeadings must never emit a level outside 1..3.
+    fun `a heading deeper than three keeps its own level`() {
+        // This asserted `level in 1..3` until #255: the preview model stopped at
+        // H3 and bucketed everything deeper into it. Invisible while the preview
+        // was the only consumer, and wrong once the outline screen shipped —
+        // indentation is its only level cue, so a deeply nested note read flat.
         val md = """
             # Top
 
             ## Mid
 
             #### Deeper
+
+            ###### Deepest
         """.trimIndent()
         val headings = extractHeadings(SimpleMarkdownPreview.parse(md))
-        assertTrue(headings.isNotEmpty())
-        assertTrue(headings.all { it.level in 1..3 })
-        assertTrue(headings.any { it.text == "Top" })
+        assertEquals(listOf("Top", "Mid", "Deeper", "Deepest"), headings.map { it.text })
+        assertEquals(listOf(1, 2, 4, 6), headings.map { it.level })
+        // Six is the deepest ATX heading commonmark recognises, so nothing
+        // should ever land outside this range.
+        assertTrue(headings.all { it.level in 1..6 })
+    }
+
+    /**
+     * A run of `#` with no space is not a heading, and a seventh level does not
+     * exist — both stay body text rather than clamping to H6.
+     */
+    @Test
+    fun `hashes that do not form a heading stay out of the outline`() {
+        val md = """
+            ####### Seven hashes
+
+            #NoSpace
+        """.trimIndent()
+
+        assertEquals(emptyList<TocHeading>(), extractHeadings(SimpleMarkdownPreview.parse(md)))
     }
 
     /**


### PR DESCRIPTION
The first of the correctness items on the v2.30.0 hardening tracker (#255).

`CommonMarkPreviewAdapter.renderHeading` mapped `node.level` to 1/2/else, so H4, H5 and H6 all became `PreviewLineType.H3` — identical in the preview and identical in the outline.

That was invisible for as long as the preview was the only consumer; three sizes read as "a heading" either way. **The outline screen made it visible.** Its rows are deliberately uniform, with indentation as the only thing carrying the level (#215), so a note nesting past three levels rendered as a flat list of same-indent entries.

## What changed

- `PreviewLineType` gains `H4`, `H5`, `H6`. The commonmark adapter maps all six levels, and `parseHandRolled` learns the same three markers so the retained fallback parser cannot disagree with the real one.
- The preview continues down the Material type scale — `titleMedium`, `titleSmall`, `labelLarge` — rather than inventing a treatment per level. H5 and H6 also drop to the muted colour: at that depth a heading is closer to a label than a section title, and six visually distinct heading styles in one note is noise.
- `extractHeadings` emits 4, 5 and 6, so the outline indents them.

## A test that changed meaning

`TocHeadingsTest` asserted `headings.all { it.level in 1..3 }` — that pinned the flattening as *intended* behaviour, which was right when #215 scoped the fix out and is wrong now. It asserts the levels round-trip instead, and gains a case that seven hashes and a hash with no space stay body text rather than clamping to H6.

## Goldens

Unaffected. The outline snapshot fixture only uses levels 1–3, and the 24dp-per-level indent is unchanged. Worth noting for later: a note using all six levels now indents to 120dp, which is tight on a phone — but only reachable by a note that actually nests six deep, so it did not seem worth changing the indent for every existing note.

## Verification

`./gradlew test` (debug + release) and `:app:lintRelease` pass. Roborazzi verification is left to the Linux runner as usual.

The other two correctness items on #255 — `isLongEnoughToJump` counting source lines, and the editor's jump direction being inferred from the caret — are untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)