### PR TITLE
fix(trash): key trash rows and slim the action buttons

### DIFF
--- a/app/src/main/java/com/markleaf/notes/feature/trash/TrashScreen.kt
+++ b/app/src/main/java/com/markleaf/notes/feature/trash/TrashScreen.kt
@@ -113,7 +113,7 @@ fun TrashScreen(
                 LazyColumn(
                     modifier = Modifier.fillMaxSize()
                 ) {
-                    items(trashedNotes) { note ->
+                    items(trashedNotes, key = { it.id }) { note ->
                         Column(
                             modifier = Modifier
                                 .fillMaxWidth()
@@ -132,11 +132,11 @@ fun TrashScreen(
                                     modifier = Modifier.weight(1f)
                                 )
                                 Row {
-                                    Button(onClick = { viewModel.restoreFromTrash(note.id) }) {
+                                    TextButton(onClick = { viewModel.restoreFromTrash(note.id) }) {
                                         Text(stringResource(R.string.restore))
                                     }
                                     Spacer(modifier = Modifier.width(8.dp))
-                                    Button(onClick = {
+                                    TextButton(onClick = {
                                         noteToDelete = note
                                         showDeleteConfirm.value = true
                                     }) {


### PR DESCRIPTION
## Summary

Addresses the two hardening candidates recorded for v2.32.3 in the standing tracker (#262) after the #298 trash-actions fix (PR #299). Both are small, pre-existing issues in `TrashScreen.kt` — neither was introduced by the #298 fix.

### 1. Key the trash list rows

`items(trashedNotes)` → `items(trashedNotes, key = { it.id })`.

TrashScreen was the **last** `items()` call in the app without a key — ArchiveScreen, LockedNotesScreen, NotesListScreen, SearchScreen, SyncCenterScreen and QuickSwitcherDialog all pass one. Without a key, LazyColumn tracks rows by position, so restoring or deleting a note could leave the wrong row briefly visible or animate incorrectly. `Note.id` is a Room `@PrimaryKey` (UUID), so keys are unique.

### 2. Slim the inline action buttons

The inline Restore/Delete actions switch from `Button` to `TextButton` — the standard Material 3 pattern for list-row actions. TextButton's smaller horizontal padding (~24dp less per button) leaves the title more room on narrow screens with long localized labels (e.g. German "Wiederherstellen"), while both actions stay visible and tappable. This also gives the #298 title-ellipsis fix more headroom, since the title's `weight(1f)` region grows as the buttons shrink.

The AlertDialog's "Delete forever" confirm stays a filled `Button` on purpose — it is the destructive confirmation, while the inline Delete is only the entry point that opens the dialog.

## Verification

- `:app:testDebugUnitTest` — passes, including the #298 regression test `TrashScreenTest` (buttons found by text, unaffected by the style change)
- `:app:lintRelease` — passes

## Notes

- No new tests: key behavior is framework-internal (consistent with every other screen), and the existing regression test already covers the visible-buttons contract.
- Non-blocking follow-up (delete button in error color) left as a hardening candidate rather than bundled here.