### PR TITLE
test: extract and pin the editor's debounced autosave (#262)

### DIFF
--- a/app/src/main/java/com/markleaf/notes/feature/editor/DebouncedSaver.kt
+++ b/app/src/main/java/com/markleaf/notes/feature/editor/DebouncedSaver.kt
@@ -1,0 +1,48 @@
+package com.markleaf.notes.feature.editor
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.update
+
+/**
+ * The editor's debounced autosave gate (#262).
+ *
+ * The editor bumps a trigger on every edit and formatting action; this gate
+ * turns a burst of triggers into **one save of the latest text**. Two
+ * properties are load-bearing and both live here so they can be tested:
+ *
+ * 1. **Restart cancels the pending save.** Each [requestSave] restarts the
+ *    timer, so a second tap inside the debounce window cancels the first
+ *    save rather than queueing it — a stale save can never land after a newer
+ *    one and "revert" a change the user already saw take.
+ * 2. **Content is read when the timer fires, not when the trigger arrived.**
+ *    [readContent] runs after the delay, so the persisted text is always the
+ *    text as of the last edit, even if the user typed during the quiet
+ *    second.
+ *
+ * The caller owns the actual persistence ([save]); this class owns only the
+ * timing and ordering. [run] is a long-lived collector — launch it once per
+ * note and keep it alive for the note's lifetime.
+ */
+internal class DebouncedSaver(
+    private val debounceMillis: Long,
+    private val readContent: () -> String,
+    private val save: suspend (String) -> Unit
+) {
+    private val triggers = MutableStateFlow(0)
+
+    /** Bump the trigger. Safe from any thread; only the fact that it changed matters. */
+    fun requestSave() {
+        triggers.update { it + 1 }
+    }
+
+    suspend fun run() {
+        triggers.collectLatest { count ->
+            if (count > 0) {
+                delay(debounceMillis)
+                save(readContent())
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/markleaf/notes/feature/editor/EditorScreen.kt
+++ b/app/src/main/java/com/markleaf/notes/feature/editor/EditorScreen.kt
@@ -141,7 +141,64 @@ fun EditorScreen(
     val coroutineScope = rememberCoroutineScope()
 
     var editorState by remember(noteId) { mutableStateOf(TextFieldValue("")) }
-    var saveTrigger by remember(noteId) { mutableStateOf(0) }
+    val titleSource = appSettings.noteTitleSource
+    // The persistence behind the debounce gate: reads the note fresh from the
+    // DB so a save never clobbers a newer row, then updates the sync mirror
+    // when one is configured (#262).
+    suspend fun autosave(content: String) {
+        val id = noteId ?: return
+        val currentNote = repo.getNote(id)
+        if (currentNote != null) {
+            val updatedNote = currentNote.copy(
+                title = TitleExtractor.extractTitle(content, appSettings.noteTitleSource),
+                contentMarkdown = content,
+                excerpt = TitleExtractor.generateExcerpt(content, appSettings.noteTitleSource),
+                updatedAt = java.time.Instant.now()
+            )
+            repo.updateNote(updatedNote)
+            tagRepo.reindexTagsForNote(id, content)
+            linkRepo.reindexLinksForNote(id, content)
+            appSettings.syncFolderUriOrNull()?.let { uri ->
+                // Never mirror a locked note to the sync folder — the Locked
+                // space is meant to stay on-device, and the mirror writes plain
+                // text (#155). Removing the lock re-includes it on the next save.
+                if (!updatedNote.locked) {
+                    val ok = withContext(Dispatchers.IO) {
+                        val wrote = NoteFolderMirror.writeNote(
+                            context,
+                            uri,
+                            updatedNote,
+                            appSettings.syncFileExtension,
+                            appSettings.mirrorMetadata()
+                        )
+                        if (wrote) {
+                            val attachments = AttachmentManager.filesForNote(context, id)
+                            if (attachments.isNotEmpty()) {
+                                NoteFolderMirror.mirrorAttachments(context, uri, id, attachments)
+                            }
+                        }
+                        wrote
+                    }
+                    if (ok) {
+                        // Stamp the synced snapshot so the next reconcile
+                        // can distinguish "remote echo" from "remote edit
+                        // by another device since this snapshot."
+                        repo.updateNote(updatedNote.copy(lastImportedAt = updatedNote.updatedAt))
+                    }
+                }
+            }
+        }
+    }
+    // Debounced autosave gate: every edit and formatting action bumps it, and
+    // it coalesces a burst into one save of the latest text (#262). The save
+    // body lives in [autosave] so the timing/ordering contract is testable.
+    val saver = remember(noteId) {
+        DebouncedSaver(
+            debounceMillis = SAVE_DEBOUNCE_MS,
+            readContent = { editorState.text },
+            save = { content -> autosave(content) }
+        )
+    }
     var isLoaded by remember(noteId) { mutableStateOf(noteId == null) }
     var shouldRequestEditorFocus by remember(noteId) { mutableStateOf(noteId == null) }
     val editorFocusRequester = remember(noteId) { FocusRequester() }
@@ -164,7 +221,6 @@ fun EditorScreen(
     val tocHeadings = remember(previewLines) { extractHeadings(previewLines) }
     // Which line becomes the title is a user setting (#280); it keys every
     // derivation below so flipping it re-titles the open note straight away.
-    val titleSource = appSettings.noteTitleSource
     val currentTitle = remember(editorState.text, noteId, titleSource) {
         if (noteId == null) "" else TitleExtractor.extractTitle(editorState.text, titleSource)
     }
@@ -262,7 +318,7 @@ fun EditorScreen(
                         text = updatedText,
                         selection = TextRange(cursor + insertion.length)
                     )
-                    saveTrigger++
+                    saver.requestSave()
                 } else {
                     Toast.makeText(context, R.string.attachment_failed, Toast.LENGTH_SHORT).show()
                 }
@@ -279,7 +335,7 @@ fun EditorScreen(
             is EditorFormattingResult.Edited -> {
                 editorState = result.value
                 shouldRequestEditorFocus = true
-                if (isLoaded) saveTrigger++
+                if (isLoaded) saver.requestSave()
             }
             EditorFormattingResult.PickImage -> {
                 imagePickerLauncher.launch(arrayOf("image/*"))
@@ -385,52 +441,8 @@ fun EditorScreen(
         }
     }
 
-    LaunchedEffect(noteId, saveTrigger, isLoaded) {
-        if (noteId != null && isLoaded && saveTrigger > 0) {
-            delay(1000)
-            val currentNote = repo.getNote(noteId)
-            if (currentNote != null) {
-                val content = editorState.text
-                val updatedNote = currentNote.copy(
-                    title = TitleExtractor.extractTitle(content, titleSource),
-                    contentMarkdown = content,
-                    excerpt = TitleExtractor.generateExcerpt(content, titleSource),
-                    updatedAt = java.time.Instant.now()
-                )
-                repo.updateNote(updatedNote)
-                tagRepo.reindexTagsForNote(noteId, content)
-                linkRepo.reindexLinksForNote(noteId, content)
-                appSettings.syncFolderUriOrNull()?.let { uri ->
-                    // Never mirror a locked note to the sync folder — the Locked
-                    // space is meant to stay on-device, and the mirror writes plain
-                    // text (#155). Removing the lock re-includes it on the next save.
-                    if (!updatedNote.locked) {
-                        val ok = withContext(Dispatchers.IO) {
-                            val wrote = NoteFolderMirror.writeNote(
-                                context,
-                                uri,
-                                updatedNote,
-                                appSettings.syncFileExtension,
-                                appSettings.mirrorMetadata()
-                            )
-                            if (wrote) {
-                                val attachments = AttachmentManager.filesForNote(context, noteId)
-                                if (attachments.isNotEmpty()) {
-                                    NoteFolderMirror.mirrorAttachments(context, uri, noteId, attachments)
-                                }
-                            }
-                            wrote
-                        }
-                        if (ok) {
-                            // Stamp the synced snapshot so the next reconcile
-                            // can distinguish "remote echo" from "remote edit
-                            // by another device since this snapshot."
-                            repo.updateNote(updatedNote.copy(lastImportedAt = updatedNote.updatedAt))
-                        }
-                    }
-                }
-            }
-        }
+    LaunchedEffect(noteId, isLoaded) {
+        if (noteId != null && isLoaded) saver.run()
     }
 
     LaunchedEffect(shouldRequestEditorFocus, isLoaded, isPreviewMode) {
@@ -721,7 +733,7 @@ fun EditorScreen(
                             MarkdownEditActions.toggleTaskAtLine(editorState.text, sourceLine)
                                 ?.let { updated ->
                                     editorState = editorState.copy(text = updated)
-                                    if (isLoaded) saveTrigger++
+                                    if (isLoaded) saver.requestSave()
                                 }
                         },
                         onWikilinkClick = { title ->
@@ -827,7 +839,7 @@ fun EditorScreen(
                                     val target = findMatches[safeIndex]
                                     editorState = replaceRange(editorState, target, replaceQuery)
                                     shouldRequestEditorFocus = true
-                                    if (isLoaded) saveTrigger++
+                                    if (isLoaded) saver.requestSave()
                                 }
                             },
                             onReplaceAll = {
@@ -835,7 +847,7 @@ fun EditorScreen(
                                     val count = findMatches.size
                                     editorState = replaceAllRanges(editorState, findMatches, replaceQuery)
                                     shouldRequestEditorFocus = true
-                                    if (isLoaded) saveTrigger++
+                                    if (isLoaded) saver.requestSave()
                                     Toast.makeText(
                                         context,
                                         context.resources.getQuantityString(R.plurals.replace_all_done_format, count, count),
@@ -867,7 +879,7 @@ fun EditorScreen(
                         editorState = applyQuickInsertCommand(editorState, query, command)
                         quickInsertSelectedIndex = 0
                         shouldRequestEditorFocus = true
-                        if (isLoaded) saveTrigger++
+                        if (isLoaded) saver.requestSave()
                         if (command == QuickInsertCommand.IMAGE) {
                             imagePickerLauncher.launch(arrayOf("image/*"))
                         }
@@ -890,7 +902,7 @@ fun EditorScreen(
                             onValueChange = { incoming ->
                                 isFormattingExpanded = false
                                 editorState = MarkdownEditActions.applyAutoContinuation(editorState, incoming)
-                                if (isLoaded) saveTrigger++
+                                if (isLoaded) saver.requestSave()
                             },
                             modifier = Modifier
                                 .fillMaxWidth()
@@ -933,7 +945,7 @@ fun EditorScreen(
                                             } else {
                                                 MarkdownEditActions.indent(editorState)
                                             }
-                                            if (isLoaded) saveTrigger++
+                                            if (isLoaded) saver.requestSave()
                                             true
                                         } else {
                                             // Hardware-keyboard formatting shortcuts resolve through
@@ -1034,7 +1046,7 @@ fun EditorScreen(
                             onPick = { title ->
                                 editorState = completeWikilink(editorState, title)
                                 shouldRequestEditorFocus = true
-                                if (isLoaded) saveTrigger++
+                                if (isLoaded) saver.requestSave()
                             }
                         )
                     } else if (tagQuery != null && tagSuggestions.isNotEmpty() && !isFocusMode) {
@@ -1043,7 +1055,7 @@ fun EditorScreen(
                             onPick = { tag ->
                                 editorState = completeTag(editorState, tag)
                                 shouldRequestEditorFocus = true
-                                if (isLoaded) saveTrigger++
+                                if (isLoaded) saver.requestSave()
                             }
                         )
                     }
@@ -1093,7 +1105,7 @@ fun EditorScreen(
             confirmButton = {
                 Button(onClick = {
                     editorState = replaceImageAlt(editorState, path, draft)
-                    if (isLoaded) saveTrigger++
+                    if (isLoaded) saver.requestSave()
                     imageAltEditing = null
                 }) {
                     Text(stringResource(R.string.image_alt_dialog_save))
@@ -1154,6 +1166,7 @@ private const val MAX_TAG_SUGGESTIONS = 8
  * short enough that putting the phone down mid-note records where you were.
  */
 private const val POSITION_WRITE_DEBOUNCE_MS = 1_000L
+private const val SAVE_DEBOUNCE_MS = 1_000L
 
 /**
  * How long the note-open path waits for DataStore before opening on defaults.

--- a/app/src/test/java/com/markleaf/notes/feature/editor/DebouncedSaverTest.kt
+++ b/app/src/test/java/com/markleaf/notes/feature/editor/DebouncedSaverTest.kt
@@ -1,0 +1,145 @@
+package com.markleaf.notes.feature.editor
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * The debounce contract behind the editor's autosave (#262).
+ *
+ * The screen bumps [DebouncedSaver.requestSave] on every edit and formatting
+ * action, including rapid taps on a preview checkbox. Two properties must hold
+ * or a user-visible change could be reverted by a stale save:
+ *
+ * 1. **A burst coalesces into one save.** A second request inside the debounce
+ *    window cancels the pending save instead of queueing it, so an older text
+ *    can never land after a newer one.
+ * 2. **The saved text is the text at fire time, not at request time.** The
+ *    content is read after the delay, so typing during the quiet second is
+ *    included in the single save.
+ *
+ * These are timing/ordering properties, so the tests drive the virtual clock
+ * of `runTest` rather than a device: the collector runs in `backgroundScope`
+ * and the test advances time explicitly.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class DebouncedSaverTest {
+
+    @Test
+    fun rapidRequests_coalesceIntoSingleSaveOfTheLatestText() = runTest {
+        val saved = mutableListOf<String>()
+        val content = mutableListOf("")
+        val saver = DebouncedSaver(
+            debounceMillis = 1_000,
+            readContent = { content.last() },
+            save = { saved += it }
+        )
+        backgroundScope.launch { saver.run() }
+
+        // A burst of preview checkbox taps inside the one-second window: the
+        // user flips a task on, off, and on again faster than the debounce.
+        content[0] = "- [x] a"
+        saver.requestSave()
+        advanceTimeBy(200)
+        content[0] = "- [ ] a"
+        saver.requestSave()
+        advanceTimeBy(200)
+        content[0] = "- [x] a"
+        saver.requestSave()
+        advanceTimeBy(1_100)
+        runCurrent()
+
+        // Exactly one save, and it is the text as of the last tap — the
+        // intermediate states were never persisted, so nothing can "revert".
+        assertEquals(listOf("- [x] a"), saved)
+    }
+
+    @Test
+    fun contentIsReadWhenTheTimerFires_notWhenTheRequestArrived() = runTest {
+        val saved = mutableListOf<String>()
+        val content = mutableListOf("")
+        val saver = DebouncedSaver(
+            debounceMillis = 1_000,
+            readContent = { content.last() },
+            save = { saved += it }
+        )
+        backgroundScope.launch { saver.run() }
+
+        content[0] = "first"
+        saver.requestSave()
+        // The user keeps typing during the quiet second; the save must pick up
+        // the final text, not the text that was current when the edit landed.
+        advanceTimeBy(500)
+        content[0] = "first second"
+        advanceTimeBy(600)
+        runCurrent()
+
+        assertEquals(listOf("first second"), saved)
+    }
+
+    @Test
+    fun noRequests_noSave() = runTest {
+        var saves = 0
+        val saver = DebouncedSaver(
+            debounceMillis = 1_000,
+            readContent = { "content" },
+            save = { saves++ }
+        )
+        backgroundScope.launch { saver.run() }
+
+        advanceTimeBy(5_000)
+        runCurrent()
+
+        assertEquals(0, saves)
+    }
+
+    @Test
+    fun aRequestAfterASaveFiresAnotherSave() = runTest {
+        val saved = mutableListOf<String>()
+        val content = mutableListOf("")
+        val saver = DebouncedSaver(
+            debounceMillis = 1_000,
+            readContent = { content.last() },
+            save = { saved += it }
+        )
+        backgroundScope.launch { saver.run() }
+
+        content[0] = "one"
+        saver.requestSave()
+        advanceTimeBy(1_100)
+        runCurrent()
+        assertEquals(listOf("one"), saved)
+
+        // A later, separate edit is its own save — coalescing only applies
+        // within a burst, not across quiet periods.
+        content[0] = "two"
+        saver.requestSave()
+        advanceTimeBy(1_100)
+        runCurrent()
+        assertEquals(listOf("one", "two"), saved)
+    }
+
+    @Test
+    fun aRequestBeforeRunStarts_isStillSaved() = runTest {
+        val saved = mutableListOf<String>()
+        val saver = DebouncedSaver(
+            debounceMillis = 1_000,
+            readContent = { "content" },
+            save = { saved += it }
+        )
+        // The screen only starts the collector once the note is loaded, but an
+        // edit can land before that (e.g. an image picker result). The pending
+        // trigger must not be lost when the collector starts.
+        saver.requestSave()
+        backgroundScope.launch { saver.run() }
+
+        advanceTimeBy(1_100)
+        runCurrent()
+
+        assertEquals(listOf("content"), saved)
+    }
+}


### PR DESCRIPTION
## What

Closes the #262 item "Rapid taps inside the one-second save debounce" by making the debounce timing/ordering contract a testable unit instead of living only inside a load effect that needs a device to exercise.

The editor's autosave gate is extracted from `EditorScreen` into `DebouncedSaver`, which owns two load-bearing properties:

1. **A burst coalesces into one save.** Each `requestSave()` restarts the timer, so a second preview-checkbox tap inside the debounce window cancels the pending save instead of queueing it — an older text can never land after a newer one and "revert" a change the user already saw take.
2. **The saved text is read when the timer fires, not when the edit landed.** The content is fetched after the delay, so typing during the quiet second is included in the single save.

The persistence body moved verbatim into a local `autosave(content)` function in `EditorScreen`; all 11 `saveTrigger++` call sites (formatting actions, find/replace, quick insert, auto-continuation, indent, wikilink/tag completion, alt-text dialog, preview checkbox) now call `saver.requestSave()`.

## Tests

`DebouncedSaverTest` pins both properties with a virtual clock (`runTest` + `backgroundScope`, no wall-clock dependency):

- rapid requests coalesce into exactly one save of the latest text (the preview-checkbox burst scenario)
- content is read at fire time, not at request time
- no requests → no save
- a request after a save fires another save (coalescing only applies within a burst)
- a request before the collector starts is still saved (image-picker result landing before load completes)

## Verification

- `:app:testDebugUnitTest` — full suite green
- `:app:lintRelease` — green
- Reviewer (pre-PR): no blocking issues; three non-blocking findings addressed (live `titleSource` read in autosave, atomic trigger increment, redundant assertion removed)
