### PR TITLE
test: quantify preview parse cost and gate Roborazzi on Windows (#262)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -407,3 +407,28 @@ dependencies {
     debugImplementation("androidx.compose.ui:ui-tooling")
     debugImplementation("androidx.compose.ui:ui-test-manifest")
 }
+
+// Roborazzi goldens are rendered by the Linux CI runner. Windows font
+// hinting differs enough that a local verify fails roughly half the
+// snapshots on noise alone, so it cannot separate a real change from
+// platform noise (#262). The canonical visual gate is CI's
+// `verifyRoborazziDebug`; golden updates go through the `record_roborazzi`
+// workflow dispatch (local re-recording would commit Windows-rendered
+// goldens that CI then rejects). The verify/record/compare tasks are
+// therefore not offered on Windows: requesting one fails the build at
+// configuration time with this explanation, before any test runs and before
+// the plugin can inject `roborazzi.test.verify` into the test JVM. The
+// `finalizeTestRoborazzi*` bookkeeping tasks stay enabled — they only
+// assemble the report after the snapshot tests run, which is harmless and
+// useful locally.
+if (System.getProperty("os.name").startsWith("Windows")) {
+    if (gradle.startParameter.taskNames.any { it.contains("Roborazzi", ignoreCase = true) }) {
+        throw GradleException(
+            "Roborazzi verify/record/compare is not offered on Windows: local " +
+                "rendering differs from the Linux CI goldens (font hinting), so a local " +
+                "verify cannot separate a real change from platform noise (#262). " +
+                "Run the visual gate on CI (verifyRoborazziDebug) and update goldens via " +
+                "the record_roborazzi workflow dispatch."
+        )
+    }
+}

--- a/app/src/test/java/com/markleaf/notes/core/markdown/PreviewParseCostTest.kt
+++ b/app/src/test/java/com/markleaf/notes/core/markdown/PreviewParseCostTest.kt
@@ -1,0 +1,85 @@
+package com.markleaf.notes.core.markdown
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Quantifies the preview parse cost on very long notes (#262).
+ *
+ * The preview re-parses the whole note on every text change while the preview
+ * or outline is open (`EditorScreen` derives `previewLines` from
+ * `editorState.text`), and the parser accumulates block source spans
+ * (`IncludeSourceSpans.BLOCKS`) so a checkbox tap can find its source line.
+ * That bookkeeping is fine for ordinary notes but was never quantified for
+ * very long ones.
+ *
+ * This test measures the production parser on a 10,000-line note — far beyond
+ * ordinary (most notes are well under 1,000 lines) — and pins a deliberately
+ * generous upper bound. The bound exists to catch a quadratic blow-up (a
+ * per-line scan over the whole document, say), not to benchmark the machine:
+ * best-of-5 timing keeps CI noise from tripping it. The measured numbers are
+ * printed so the cost stays visible in the test report.
+ *
+ * A macrobenchmark cannot isolate this: `MacrobenchmarkRule` measures whole-app
+ * frames on a device, and seeding a 10k-line note into the app for it is
+ * impractical. The parser is pure JVM, so a JVM test measures exactly the
+ * production path and runs in CI.
+ */
+class PreviewParseCostTest {
+
+    @Test
+    fun veryLongNote_parsesWithinBudget() {
+        val note = generateVeryLongNote(LINE_COUNT)
+
+        // Warm up: class loading, extension init, JIT.
+        SimpleMarkdownPreview.parse(note)
+
+        val bestMs = (1..5).minOf {
+            val start = System.nanoTime()
+            val lines = SimpleMarkdownPreview.parse(note)
+            val elapsedMs = (System.nanoTime() - start) / 1_000_000.0
+            // Keep the result alive so the parse cannot be elided.
+            check(lines.isNotEmpty())
+            elapsedMs
+        }
+
+        println(
+            "PreviewParseCost: $LINE_COUNT-line note parsed in " +
+                "%.1f ms (best of 5)".format(bestMs)
+        )
+
+        assertTrue(
+            "$LINE_COUNT-line preview parse took %.1f ms".format(bestMs),
+            bestMs < BUDGET_MS
+        )
+    }
+
+    private fun generateVeryLongNote(lineCount: Int): String {
+        val sb = StringBuilder(lineCount * 48)
+        var line = 0
+        while (line < lineCount) {
+            when (line % 25) {
+                0 -> sb.append("# Heading ").append(line).append('\n')
+                1 -> sb.append("## Subheading ").append(line).append('\n')
+                2 -> sb.append("- [ ] task item ").append(line).append('\n')
+                3 -> sb.append("- [x] done task ").append(line).append('\n')
+                4 -> sb.append("- plain bullet ").append(line).append('\n')
+                5 -> sb.append("1. ordered item ").append(line).append('\n')
+                6 -> sb.append("> blockquote line ").append(line).append('\n')
+                7 -> sb.append("```kotlin\nval x = ").append(line).append("\n```\n")
+                8 -> sb.append("| a | b |\n|---|---|\n| ").append(line).append(" | x |\n")
+                else -> sb.append("A paragraph line with some **bold** and *italic* text ")
+                    .append(line).append('\n')
+            }
+            line++
+        }
+        return sb.toString()
+    }
+
+    private companion object {
+        const val LINE_COUNT = 10_000
+        // Generous: catches quadratic blow-up, not machine speed. A 10k-line
+        // note is an extreme; ordinary notes are < 1k lines.
+        const val BUDGET_MS = 500.0
+    }
+}


### PR DESCRIPTION
## What

Closes two remaining #262 items in one batch:

### 1. `IncludeSourceSpans.BLOCKS` cost is unmeasured

`CommonMarkPreviewAdapter` parses every preview with `IncludeSourceSpans.BLOCKS` so a checkbox tap can find its source line. That bookkeeping is fine for ordinary notes but was never quantified for very long ones — and `EditorScreen` re-parses on every text change while the preview is open (`previewLines = remember(editorState.text, shouldPreparePreview) { SimpleMarkdownPreview.parse(...) }`).

New `PreviewParseCostTest` measures the **production** parser on a 10,000-line note (headings, task lists, bullets, ordered lists, blockquotes, fenced code, tables, paragraphs) via the real `SimpleMarkdownPreview.parse` path, best-of-5 timing, and asserts a generous 500 ms budget that catches a quadratic blow-up without tripping on CI noise. Measured locally: **66.3 ms** for 10k lines.

A Macrobenchmark can't isolate this: it measures whole-app frames on a device and would need a 10k-line note seeded into the app. The parser is pure JVM, so a JVM test measures the exact production path and runs in CI.

### 2. The local Roborazzi verify cannot separate a real change from platform noise

On Windows, `verifyRoborazziDebug` fails ~34 of 62 snapshots on font-hinting noise alone, so it can't tell a real golden change from platform noise. The pinned-expected-failure-count option was rejected: the count has varied 15/20/34 across reports and machines and would rot.

Instead, the verify/record/compare tasks are **not offered on Windows**: requesting one fails the build at configuration time with an explanation pointing to CI's `verifyRoborazziDebug` (Linux, byte-identical on 61/62 goldens) and the `record_roborazzi` workflow dispatch. This fires before any test runs and before the Roborazzi plugin injects `roborazzi.test.verify` into the test JVM (disabling the task alone did not prevent the plugin's configuration-time property injection — verified empirically). Normal builds (`testDebugUnitTest`, `lintRelease`, `assembleDebug`) are unaffected.

## Verification

- `:app:testDebugUnitTest` — full suite green (includes `PreviewParseCostTest`)
- `:app:lintRelease` — green
- `:app:verifyRoborazziDebug` on Windows — fails fast at configuration with the guidance message (no tests run, ~23s vs the previous ~2.5 min of noisy failures)
- Reviewer (pre-PR): self-reviewed (reviewer agent unavailable); see PR body for the self-review notes
