### PR TITLE
chore: ignore JVM fatal-error dumps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,13 @@
 # Nightly issue-bot: local secrets (SMTP app password) and runtime scratch.
 /scripts/nightly/config.local.psd1
 /scripts/nightly/.runtime/
+
+# JVM fatal-error dumps. A crashed Gradle daemon or test JVM writes these into
+# whatever its working directory was, so they turn up at the repo root *and*
+# under `app/` — hence no leading slash. They are large (a `replay_pid*.log`
+# measured 520 KB) and mean nothing outside the machine that crashed. Four of
+# them sat untracked through a whole session on 2026-08-14 after the machine
+# ran out of memory; nothing committed them only because release commits stage
+# files explicitly rather than with `git add -A`.
+hs_err_pid*.log
+replay_pid*.log


### PR DESCRIPTION
A crashed Gradle daemon or test JVM writes `hs_err_pid*.log` — and a `replay_pid*.log` beside it — into whatever its working directory was. On 2026-08-14 this machine ran out of memory mid-session and left four of them untracked:

```
app/hs_err_pid14380.log      77 KB
app/replay_pid14380.log     520 KB
hs_err_pid52060.log          14 KB
hs_err_pid56564.log          96 KB
```

They landed both at the repo root **and** under `app/`, so the patterns carry no leading slash.

Nothing committed them, but only because release commits stage files explicitly rather than with `git add -A` — which is the same near-miss the `/.kotlin/` entry just above already records ("caught only when a `git add -A` swept one into a commit"). This entry follows that one's shape and reasoning.

### Verified

Created dumps at both depths and checked what git says:

```
.gitignore:47:hs_err_pid*.log      hs_err_pid99999.log
.gitignore:47:hs_err_pid*.log      app/hs_err_pid99999.log
.gitignore:48:replay_pid*.log      app/replay_pid99999.log
```

`git status` reports 0 of them, and `app/build.gradle.kts` stays tracked — the pattern catches dumps, not sources.

One line of `.gitignore` reasoning and two patterns. No code, no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
