### PR TITLE
fix: proper icon sizing in drawables

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -88,10 +88,6 @@ android {
     }
 
     buildTypes {
-        getByName("debug") {
-            applicationIdSuffix = ".debug"
-            isDebuggable = true
-        }
         getByName("release") {
             // R8 + resource shrinking are required for the Play / production
             // gate. ProGuard rules live in `proguard-rules.pro`; keep that

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -88,6 +88,10 @@ android {
     }
 
     buildTypes {
+        getByName("debug") {
+            applicationIdSuffix = ".debug"
+            isDebuggable = true
+        }
         getByName("release") {
             // R8 + resource shrinking are required for the Play / production
             // gate. ProGuard rules live in `proguard-rules.pro`; keep that

--- a/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -1,17 +1,28 @@
-<?xml version="1.0" encoding="utf-8"?>
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="108dp"
-    android:height="108dp"
-    android:viewportWidth="108"
-    android:viewportHeight="108">
-    <!-- 나뭇잎 형태 (Markleaf 정체성) -->
-    <path
-        android:fillColor="#2E7D32"
-        android:pathData="M54,20 C54,20 30,35 30,60 C30,85 54,88 54,88 C54,88 78,85 78,60 C78,35 54,20 54,20 Z" />
-    <!-- 마크다운 '#' 기호를 형상화한 나뭇잎 맥 -->
-    <path
-        android:strokeColor="#FFFFFF"
-        android:strokeWidth="2.5"
-        android:strokeLineCap="round"
-        android:pathData="M54,35 L54,75 M45,45 L63,45 M45,55 L63,55" />
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:name="vector"
+    android:width="512dp"
+    android:height="512dp"
+    android:viewportWidth="512"
+    android:viewportHeight="512">
+    <group
+        android:name="group_2"
+        android:translateX="64"
+        android:translateY="64"
+        android:scaleX="0.75"
+        android:scaleY="0.75">
+        <!-- 나뭇잎 형태 (Markleaf 정체성) -->
+        <path
+            android:name="path_5"
+            android:pathData="M 256 94.815 C 256 94.815 142.222 165.926 142.222 284.444 C 142.222 402.963 256 417.185 256 417.185 C 256 417.185 369.778 402.963 369.778 284.444 C 369.778 165.926 256 94.815 256 94.815 Z"
+            android:fillColor="#2E7D32"
+            android:strokeAlpha="0.8"/>
+        <!-- 마크다운 '#' 기호를 형상화한 나뭇잎 맥 -->
+        <path
+            android:name="path_6"
+            android:pathData="M 256 165.926 L 256 355.556 M 213.333 213.333 L 298.667 213.333 M 213.333 260.741 L 298.667 260.741"
+            android:strokeColor="#FFFFFF"
+            android:strokeWidth="8"
+            android:strokeLineCap="round"/>
+    </group>
 </vector>

--- a/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -1,28 +1,35 @@
-<vector
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    android:name="vector"
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Adaptive-icon foreground. The 512 viewport is the source artwork; the group
+  scales it to 0.85 and re-centres it (translate = 256 * (1 - 0.85)) so the leaf
+  stays inside the 66dp safe circle instead of being clipped by the launcher
+  mask (#318). It used to reach 34dp from centre against a 33dp safe radius;
+  it now reaches 28.9dp.
+
+  Stroke width is the original 2.5dp scaled by the same 512/108 factor as the
+  geometry (2.5 x 4.7407), so the '#' veins keep the weight they have in
+  `ic_launcher_monochrome.xml`. Scaling the geometry without it leaves the two
+  layers drawing the same mark at different weights.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="512dp"
     android:height="512dp"
     android:viewportWidth="512"
     android:viewportHeight="512">
     <group
-        android:name="group_2"
-        android:translateX="64"
-        android:translateY="64"
-        android:scaleX="0.75"
-        android:scaleY="0.75">
+        android:translateX="38.4"
+        android:translateY="38.4"
+        android:scaleX="0.85"
+        android:scaleY="0.85">
         <!-- 나뭇잎 형태 (Markleaf 정체성) -->
         <path
-            android:name="path_5"
-            android:pathData="M 256 94.815 C 256 94.815 142.222 165.926 142.222 284.444 C 142.222 402.963 256 417.185 256 417.185 C 256 417.185 369.778 402.963 369.778 284.444 C 369.778 165.926 256 94.815 256 94.815 Z"
             android:fillColor="#2E7D32"
-            android:strokeAlpha="0.8"/>
+            android:pathData="M 256 94.815 C 256 94.815 142.222 165.926 142.222 284.444 C 142.222 402.963 256 417.185 256 417.185 C 256 417.185 369.778 402.963 369.778 284.444 C 369.778 165.926 256 94.815 256 94.815 Z" />
         <!-- 마크다운 '#' 기호를 형상화한 나뭇잎 맥 -->
         <path
-            android:name="path_6"
-            android:pathData="M 256 165.926 L 256 355.556 M 213.333 213.333 L 298.667 213.333 M 213.333 260.741 L 298.667 260.741"
             android:strokeColor="#FFFFFF"
-            android:strokeWidth="8"
-            android:strokeLineCap="round"/>
+            android:strokeWidth="11.852"
+            android:strokeLineCap="round"
+            android:pathData="M 256 165.926 L 256 355.556 M 213.333 213.333 L 298.667 213.333 M 213.333 260.741 L 298.667 260.741" />
     </group>
 </vector>

--- a/app/src/main/res/drawable/ic_launcher_monochrome.xml
+++ b/app/src/main/res/drawable/ic_launcher_monochrome.xml
@@ -5,24 +5,29 @@
   single-color silhouette. We keep the Markleaf leaf and cut the markdown '#'
   veins out as negative space (fillType=evenOdd) so the identity survives tinting
   instead of collapsing into a featureless blob.
+
+  Geometry mirrors `ic_launcher_foreground.xml`: same 512 viewport, same 0.85
+  group scale that keeps the leaf inside the 66dp safe circle (#318). Keep the
+  two files in step. The launcher draws whichever layer the user's theme asks
+  for, so a divergence shows up as the icon changing shape when themed icons
+  are turned on.
 -->
-<vector
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    android:name="vector"
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="512dp"
     android:height="512dp"
     android:viewportWidth="512"
     android:viewportHeight="512">
     <group
-        android:name="group"
-        android:translateX="64"
-        android:translateY="64"
-        android:scaleX="0.75"
-        android:scaleY="0.75">
+        android:translateX="38.4"
+        android:translateY="38.4"
+        android:scaleX="0.85"
+        android:scaleY="0.85">
         <path
-            android:name="path"
-            android:pathData="M 256 94.815 C 256 94.815 142.222 165.926 142.222 284.444 C 142.222 402.963 256 417.185 256 417.185 C 256 417.185 369.778 402.963 369.778 284.444 C 369.778 165.926 256 94.815 256 94.815 Z M 250.074 165.926 L 261.926 165.926 L 261.926 355.556 L 250.074 355.556 Z M 213.333 207.407 L 298.667 207.407 L 298.667 219.259 L 213.333 219.259 Z M 213.333 254.815 L 298.667 254.815 L 298.667 266.667 L 213.333 266.667 Z"
             android:fillColor="#000000"
-            android:fillType="evenOdd"/>
+            android:fillType="evenOdd"
+            android:pathData="M 256 94.815 C 256 94.815 142.222 165.926 142.222 284.444 C 142.222 402.963 256 417.185 256 417.185 C 256 417.185 369.778 402.963 369.778 284.444 C 369.778 165.926 256 94.815 256 94.815 Z
+            M 250.074 165.926 L 261.926 165.926 L 261.926 355.556 L 250.074 355.556 Z
+            M 213.333 207.407 L 298.667 207.407 L 298.667 219.259 L 213.333 219.259 Z
+            M 213.333 254.815 L 298.667 254.815 L 298.667 266.667 L 213.333 266.667 Z" />
     </group>
 </vector>

--- a/app/src/main/res/drawable/ic_launcher_monochrome.xml
+++ b/app/src/main/res/drawable/ic_launcher_monochrome.xml
@@ -6,16 +6,23 @@
   veins out as negative space (fillType=evenOdd) so the identity survives tinting
   instead of collapsing into a featureless blob.
 -->
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="108dp"
-    android:height="108dp"
-    android:viewportWidth="108"
-    android:viewportHeight="108">
-    <path
-        android:fillColor="#000000"
-        android:fillType="evenOdd"
-        android:pathData="M54,20 C54,20 30,35 30,60 C30,85 54,88 54,88 C54,88 78,85 78,60 C78,35 54,20 54,20 Z
-        M52.75,35 L55.25,35 L55.25,75 L52.75,75 Z
-        M45,43.75 L63,43.75 L63,46.25 L45,46.25 Z
-        M45,53.75 L63,53.75 L63,56.25 L45,56.25 Z" />
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:name="vector"
+    android:width="512dp"
+    android:height="512dp"
+    android:viewportWidth="512"
+    android:viewportHeight="512">
+    <group
+        android:name="group"
+        android:translateX="64"
+        android:translateY="64"
+        android:scaleX="0.75"
+        android:scaleY="0.75">
+        <path
+            android:name="path"
+            android:pathData="M 256 94.815 C 256 94.815 142.222 165.926 142.222 284.444 C 142.222 402.963 256 417.185 256 417.185 C 256 417.185 369.778 402.963 369.778 284.444 C 369.778 165.926 256 94.815 256 94.815 Z M 250.074 165.926 L 261.926 165.926 L 261.926 355.556 L 250.074 355.556 Z M 213.333 207.407 L 298.667 207.407 L 298.667 219.259 L 213.333 219.259 Z M 213.333 254.815 L 298.667 254.815 L 298.667 266.667 L 213.333 266.667 Z"
+            android:fillColor="#000000"
+            android:fillType="evenOdd"/>
+    </group>
 </vector>


### PR DESCRIPTION
Left is before, right is after. Also adds `.debug` suffix to debug builds.

<img width="601" height="364" alt="image" src="https://github.com/user-attachments/assets/4d3c9d0f-39a0-4695-b4b4-1ab588ae127e" />
<img width="601" height="364" alt="image" src="https://github.com/user-attachments/assets/1179d464-0d91-4a53-b330-fa52c1a006ba" />
