### PR TITLE
docs: credit the launcher-icon fix in THANKS

### DIFF
--- a/THANKS.md
+++ b/THANKS.md
@@ -38,7 +38,7 @@ Listed by first report.
 | [@Cwpute](https://github.com/Cwpute) | [#188](https://github.com/jeiel85/markleaf-android/issues/188), [#189](https://github.com/jeiel85/markleaf-android/issues/189), [#190](https://github.com/jeiel85/markleaf-android/issues/190), [#191](https://github.com/jeiel85/markleaf-android/issues/191), [#192](https://github.com/jeiel85/markleaf-android/issues/192), [#193](https://github.com/jeiel85/markleaf-android/issues/193), [#213](https://github.com/jeiel85/markleaf-android/issues/213), [#214](https://github.com/jeiel85/markleaf-android/issues/214), [#215](https://github.com/jeiel85/markleaf-android/issues/215), [#216](https://github.com/jeiel85/markleaf-android/issues/216) |
 | [@xentenza](https://github.com/xentenza) | [#197](https://github.com/jeiel85/markleaf-android/issues/197) |
 | [@Me-2u](https://github.com/Me-2u) | [#200](https://github.com/jeiel85/markleaf-android/issues/200) |
-| [@ElizabethWega](https://github.com/ElizabethWega) | [#283](https://github.com/jeiel85/markleaf-android/issues/283) |
+| [@ElizabethWega](https://github.com/ElizabethWega) | [#283](https://github.com/jeiel85/markleaf-android/issues/283), [#298](https://github.com/jeiel85/markleaf-android/issues/298) |
 
 Not every request here was accepted — a couple were declined, and saying no to a
 thoughtful suggestion is its own kind of debt. Being told what you want from the

--- a/THANKS.md
+++ b/THANKS.md
@@ -52,9 +52,17 @@ cannot actually check. I can diff the file, count the keys, and match the format
 specifiers — I cannot tell you whether the words sound like something a person
 would write. Those languages are in the app on someone else's judgement.
 
+The other thing an outside patch catches is what the maintainer has stopped
+seeing. The launcher icon had been overflowing the adaptive-icon safe zone since
+the day it was drawn — the leaf ran a millimetre past the mask, so every launcher
+quietly cut its tip off — and I had looked at it on my own home screen for months
+without registering it. It took somebody else opening their app drawer and
+deciding the clipped leaf was worth a pull request.
+
 | | Contributed |
 |---|---|
 | [@ALILEX-1](https://github.com/ALILEX-1) | [#294](https://github.com/jeiel85/markleaf-android/pull/294) — Simplified Chinese |
+| [@ThatOneCalculator](https://github.com/ThatOneCalculator) | [#318](https://github.com/jeiel85/markleaf-android/pull/318) — launcher icon clipped by the adaptive-icon mask |
 
 Reporting something new? [Issues](https://github.com/jeiel85/markleaf-android/issues)
 for bugs, [Discussions](https://github.com/jeiel85/markleaf-android/discussions)


### PR DESCRIPTION
Adds [@ThatOneCalculator](https://github.com/ThatOneCalculator) to the Contributed table for #318, and fixes one gap found while auditing the file.

The section's opening was written around translations, which are the contribution
I cannot verify myself. #318 is the first outside patch that isn't one, and it
belongs to a different category worth naming: the bug the maintainer has stopped
seeing. The leaf had been running past the adaptive-icon safe zone since the icon
was drawn, so every launcher clipped its tip, and it sat on my own home screen for
months without registering.

While in there I checked the Reported table against every externally-filed issue.
One was missing: [@ElizabethWega](https://github.com/ElizabethWega) reported #298,
which was fixed in #299 and #300, and only their earlier #283 was listed. Added.
The other 17 reporters were all accounted for, and no Discussions thread has an
outside author yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)