### PR TITLE
chore(i18n): make config/locales.tsv the one language list (#262)

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -33,6 +33,12 @@ jobs:
 
       # 버전 표기·릴리스 노트 검사는 Gradle 앞에 둔다. 초 단위로 끝나고, 릴리스
       # 준비 커밋에서 빠뜨리기 가장 쉬운 것들이라 먼저 실패하는 편이 낫다.
+      # 언어 목록(config/locales.tsv)과 실제 표면이 맞는지 먼저 본다. 목록이
+      # 일곱 군데에 복사돼 있었을 때는 새 언어가 절반만 들어가도 통과했고,
+      # 그 절반은 아무 게이트도 보지 않는 표면이었다 (#294, #329).
+      - name: Verify locale manifest (declared languages vs files)
+        run: pwsh -File scripts/verify-locales.ps1
+
       - name: Verify public version strings (landing + README)
         run: pwsh -File scripts/verify-landing-versions.ps1
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -44,6 +44,7 @@ verify_release_docs:
   before_script: []
   cache: []
   script:
+    - pwsh -File scripts/verify-locales.ps1
     - pwsh -File scripts/verify-landing-versions.ps1
     - pwsh -File scripts/verify-release-notes.ps1
   rules:
@@ -98,12 +99,14 @@ package_signed_release:
     - ACTUAL_CERT_SHA256="$("$APKSIGNER" verify --print-certs "$APK" | sed -n 's/^Signer .*certificate SHA-256 digest:[[:space:]]*//p' | tr '[:upper:]' '[:lower:]')"
     - test "$ACTUAL_CERT_SHA256" = "$MARKLEAF_RELEASE_CERT_SHA256"
     - NOTES="$(find dist -maxdepth 1 -name '*-release-notes.txt' -print -quit)"
-    - grep -q '^<ko-KR>$' "$NOTES"
-    - grep -q '^<en-US>$' "$NOTES"
-    - grep -q '^<ja-JP>$' "$NOTES"
-    - grep -q '^<de-DE>$' "$NOTES"
-    - grep -q '^<fr-FR>$' "$NOTES"
-    - grep -q '^<es-ES>$' "$NOTES"
+    # 로케일 목록은 config/locales.tsv 에서 읽는다. 여기 여섯 개를 적어 두었더니
+    # zh-CN(#294)·hr-HR(#329) 두 번의 언어 추가를 지나도록 그대로였고, 이 job 이
+    # GITLAB_RELEASE_FROM_CI 뒤에 가려 아무도 돌리지 않아서 드러나지도 않았다 —
+    # 스위치를 켜는 순간 통과하는 잘못된 게이트가 된다(#262).
+    - |
+      for LOCALE in $(awk '$1 !~ /^#/ && NF { print $2 }' config/locales.tsv); do
+        grep -q "^<$LOCALE>$" "$NOTES" || { echo "release notes are missing the <$LOCALE> block"; exit 1; }
+      done
   after_script:
     - rm -rf .secrets
     - rm -f "$GRADLE_USER_HOME/gradle.properties"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -263,6 +263,12 @@ Play/F-Droid용 `fastlane/metadata/android/<locale>/changelogs/<versionCode>.txt
 
 README와 GitHub Pages 랜딩도 영어가 기본이며 앱이 지원하는 8개 언어(en · ko · ja · zh · de · es · fr · hr)로 병기한다. 영어판이 canonical이고 `x-default`다. 공개 표면의 버전 표기를 갱신할 때는 8개 언어를 함께 갱신하고 `scripts/verify-landing-versions.ps1`로 검증한다.
 
+#### 언어 목록은 `config/locales.tsv` 한 곳에 있다
+
+언어 목록이 테스트 2개·`app/build.gradle.kts`·검사 스크립트 3개에 복사돼 있었고, 새 언어가 그 중 일부에만 들어가면 **나머지 표면은 아무 게이트도 보지 않은 채 초록으로 출시됐다** — 중국어(#294)와 크로아티아어(#329) 모두 손으로 세어서야 발견했다(#262). 지금은 `config/locales.tsv` 가 목록이고, 위의 여섯 곳이 전부 그 파일을 읽는다.
+
+언어를 추가할 때는 그 파일에 행을 하나 넣고, 헤더에 적힌 표면들(`values-<code>/strings.xml`, `fastlane/metadata/android/<store>/`, `docs/index.<code>.html`, `docs/privacy.<code>.html`, `README.<code>.md`, `docs/assets/markleaf-tablet-<code>.{gif,mp4}` + `-still.webp`)을 채운다. `pwsh scripts/verify-locales.ps1` 이 양방향으로 검사하므로 — 선언했는데 없는 파일, 있는데 선언되지 않은 파일 — 빠뜨린 것이 CI에서 이름으로 나온다. 이 문서·`docs/RELEASE.md`·`docs/assets/README.md` 에 적힌 언어 **개수** 표기도 같은 스크립트가 목록과 대조한다.
+
 ### GitHub 공개 표면 콘텐츠 — 영어 기본
 
 Markleaf는 글로벌 유저를 대상으로 하므로, 위 공개 문서와 같은 원칙으로 **GitHub에 공개로 남는 사용자·커뮤니티 대상 콘텐츠는 영어를 기본**으로 작성한다. 대상: Issue·PR 제목/본문, Discussions 글·댓글, 릴리즈 노트, 커밋 메시지. 한국어 등 다른 언어는 필요하면 영어 아래에 번역으로 병기한다.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -153,6 +153,14 @@ android {
             isIncludeAndroidResources = true
             all {
                 it.systemProperty("robolectric.sqliteMode", "NATIVE")
+                // The locale tests read config/locales.tsv (LocaleManifest), which
+                // is outside the test task's inputs, so editing it alone left the
+                // task UP-TO-DATE and the new language unchecked until something
+                // else changed. CI checks out clean and never saw it; a person
+                // adding a language would have.
+                it.inputs.file(rootProject.file("config/locales.tsv"))
+                    .withPropertyName("localeManifest")
+                    .withPathSensitivity(PathSensitivity.RELATIVE)
             }
         }
         // Compose UI and Roborazzi tests need the ComponentActivity entry that
@@ -199,7 +207,7 @@ ksp {
 // Release artifact export
 // ---------------------------------------------------------------------------
 // Both the local Play hand-off and GitLab CI use this writer so artifact names,
-// six-locale notes, and validation cannot drift between distribution channels.
+// all-locale notes, and validation cannot drift between distribution channels.
 // Local exports omit the APK because D:\Build is the Play Console hand-off;
 // GitLab exports include it for direct sideload downloads.
 val writeReleaseArtifacts: (File, Boolean) -> Unit = { exportDir, includeApk ->
@@ -253,7 +261,21 @@ val writeReleaseArtifacts: (File, Boolean) -> Unit = { exportDir, includeApk ->
     // Every locale must have a changelog for this versionCode; fail fast so
     // a cut never ships notes that silently drop a locale.
     val fastlaneRoot = rootProject.file("fastlane/metadata/android")
-    val noteLocales = listOf("ko-KR", "en-US", "ja-JP", "zh-CN", "de-DE", "fr-FR", "es-ES", "hr-HR")
+    // The store locales come from config/locales.tsv — the one language list
+    // that the unit tests, the verify scripts and CI all read (#262). A copy
+    // here is how #294 and #329 each shipped a language that half the surfaces
+    // did not know about. Row order is the order the blocks are written in.
+    val localeManifest = rootProject.file("config/locales.tsv")
+    if (!localeManifest.isFile) {
+        throw GradleException("Locale manifest not found at ${localeManifest.absolutePath}")
+    }
+    val noteLocales = localeManifest.readLines()
+        .map { it.substringBefore('#').trim() }
+        .filter { it.isNotEmpty() }
+        .map { row ->
+            row.split(Regex("\\s+")).getOrNull(1)
+                ?: throw GradleException("Malformed row in config/locales.tsv: $row")
+        }
     val sources = noteLocales.associateWith { File(fastlaneRoot, "$it/changelogs/$versionCode.txt") }
 
     val missing = noteLocales.filter { !sources.getValue(it).isFile }

--- a/app/src/test/java/com/markleaf/notes/LocaleManifest.kt
+++ b/app/src/test/java/com/markleaf/notes/LocaleManifest.kt
@@ -1,0 +1,77 @@
+package com.markleaf.notes
+
+import java.io.File
+import org.junit.Assert.assertTrue
+
+/**
+ * The language list, read from `config/locales.tsv` rather than repeated here.
+ *
+ * The list used to live in seven places — two of them in this test source set —
+ * and a language missing from one of them was a surface no gate looked at, so
+ * it shipped untested and green. Both #294 (Chinese) and #329 (Croatian)
+ * arrived that way and were caught by hand. Tests that need the list ask for it
+ * here; `scripts/verify-locales.ps1` checks the list against the files on disk
+ * in both directions.
+ */
+object LocaleManifest {
+
+    data class Entry(
+        val code: String,
+        val store: String,
+        val isSource: Boolean,
+        val hasStarterNotes: Boolean
+    ) {
+        /** `values` for the language the app is written in, `values-<code>` for the rest. */
+        val resDir: String get() = if (isSource) "values" else "values-$code"
+
+        /** `raw` for the source language, `raw-<code>` for the rest. */
+        val rawDir: String get() = if (isSource) "raw" else "raw-$code"
+    }
+
+    /** Unit tests run with the app module as their working directory. */
+    private val manifestFile = File("../config/locales.tsv")
+
+    val entries: List<Entry> by lazy { read() }
+
+    /** The language the app is written in — its resources carry no locale code. */
+    val source: Entry get() = entries.single { it.isSource }
+
+    /** Every language the app is translated into, source excluded. */
+    val translated: List<Entry> get() = entries.filterNot { it.isSource }
+
+    /** Locale codes as they appear in `values-<code>`: `fr`, `es`, … */
+    val translatedCodes: List<String> get() = translated.map { it.code }
+
+    private fun read(): List<Entry> {
+        assertTrue(
+            "Expected the locale manifest at ${manifestFile.absolutePath}. Unit tests run " +
+                "with the app module as their working directory, so the path is relative to it.",
+            manifestFile.isFile
+        )
+        val entries = manifestFile.readLines()
+            .map { it.substringBefore('#').trim() }
+            .filter { it.isNotEmpty() }
+            .map { row ->
+                val fields = row.split(Regex("\\s+"))
+                require(fields.size == 4) {
+                    "config/locales.tsv rows are `code store source starter`, but read: $row"
+                }
+                Entry(
+                    code = fields[0],
+                    store = fields[1],
+                    isSource = fields[2].toBoolean(row),
+                    hasStarterNotes = fields[3].toBoolean(row)
+                )
+            }
+        require(entries.count { it.isSource } == 1) {
+            "config/locales.tsv must mark exactly one language as the source language."
+        }
+        return entries
+    }
+
+    private fun String.toBoolean(row: String): Boolean = when (this) {
+        "yes" -> true
+        "no" -> false
+        else -> throw IllegalArgumentException("config/locales.tsv wants yes/no, read '$this' in: $row")
+    }
+}

--- a/app/src/test/java/com/markleaf/notes/UntranslatedStringTest.kt
+++ b/app/src/test/java/com/markleaf/notes/UntranslatedStringTest.kt
@@ -29,7 +29,7 @@ class UntranslatedStringTest {
         val offenders = mutableListOf<String>()
 
         for (locale in LOCALES) {
-            val allowed = STRUCTURALLY_IDENTICAL + LANGUAGE_COINCIDENCES.getValue(locale)
+            val allowed = STRUCTURALLY_IDENTICAL + coincidencesFor(locale)
             for ((key, value) in readStrings(stringsFor(locale))) {
                 if (key !in allowed && english[key] == value) {
                     offenders += "values-$locale  $key = \"$value\""
@@ -53,9 +53,16 @@ class UntranslatedStringTest {
         val english = readStrings(resDir().resolve("values/strings.xml"))
         val stale = mutableListOf<String>()
 
+        // A coincidence list for a language the app no longer ships is the same
+        // kind of rot: it exempts nothing, and it reads as if that language were
+        // still checked here.
+        for (locale in LANGUAGE_COINCIDENCES.keys - LOCALES.toSet()) {
+            stale += "values-$locale  (not in config/locales.tsv)"
+        }
+
         for (locale in LOCALES) {
             val translated = readStrings(stringsFor(locale))
-            for (key in STRUCTURALLY_IDENTICAL + LANGUAGE_COINCIDENCES.getValue(locale)) {
+            for (key in STRUCTURALLY_IDENTICAL + coincidencesFor(locale)) {
                 val value = translated[key]
                 when {
                     value == null -> stale += "values-$locale  $key (no longer exists)"
@@ -115,7 +122,16 @@ class UntranslatedStringTest {
     }
 
     private companion object {
-        val LOCALES = listOf("fr", "es", "de", "ja", "ko", "zh", "hr")
+        /** From `config/locales.tsv`; see [LocaleManifest]. */
+        val LOCALES = LocaleManifest.translatedCodes
+
+        /**
+         * A language with no list has no exemptions — the strictest reading, so
+         * a new language's genuine coincidences fail here and get looked at
+         * rather than being waved through by a placeholder entry.
+         */
+        fun coincidencesFor(locale: String): Set<String> =
+            LANGUAGE_COINCIDENCES[locale] ?: emptySet()
 
         /**
          * Identical in every language because they are not prose: the app name,
@@ -178,9 +194,9 @@ class UntranslatedStringTest {
                 "tags",
                 "version_format"
             ),
-            "ja" to emptySet(),
-            "ko" to emptySet(),
-            "zh" to emptySet(),
+            // ja, ko and zh have no entry: nothing in them coincides with the
+            // English source, and an absent list means no exemptions.
+            //
             // Croatian borrows the typography vocabulary: "font" is the Croatian
             // word, and "Sans"/"Serif" name the typefaces rather than describe them.
             "hr" to setOf(

--- a/app/src/test/java/com/markleaf/notes/res/ResourceParityTest.kt
+++ b/app/src/test/java/com/markleaf/notes/res/ResourceParityTest.kt
@@ -1,5 +1,6 @@
 package com.markleaf.notes.res
 
+import com.markleaf.notes.LocaleManifest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -9,17 +10,9 @@ import javax.xml.parsers.DocumentBuilderFactory
 class ResourceParityTest {
     @Test
     fun localizedStringResourcesContainAllDefaultKeys() {
-        val defaultKeys = stringNames("src/main/res/values/strings.xml")
+        val defaultKeys = stringNames("src/main/res/${LocaleManifest.source.resDir}/strings.xml")
 
-        listOf(
-            "src/main/res/values-ko/strings.xml",
-            "src/main/res/values-es/strings.xml",
-            "src/main/res/values-ja/strings.xml",
-            "src/main/res/values-de/strings.xml",
-            "src/main/res/values-fr/strings.xml",
-            "src/main/res/values-zh/strings.xml",
-            "src/main/res/values-hr/strings.xml"
-        ).forEach { path ->
+        LocaleManifest.translated.map { "src/main/res/${it.resDir}/strings.xml" }.forEach { path ->
             val localizedKeys = stringNames(path)
             assertEquals(
                 "Resource count mismatch for $path",
@@ -35,30 +28,27 @@ class ResourceParityTest {
     }
 
     /**
-     * `raw-zh` is deliberately not in this list. The Chinese contribution (#294)
-     * covers `strings.xml` only, so a Chinese device falls back to the English
-     * `raw/starter_notes.md` on first launch — degraded, but working.
+     * Which languages have starter notes is the `starter` column of
+     * `config/locales.tsv`, and `zh` is deliberately `no` there: the Chinese
+     * contribution (#294) covers `strings.xml` only, so a Chinese device falls
+     * back to the English `raw/starter_notes.md` on first launch — degraded,
+     * but working.
      *
-     * Writing that down is the point. This list is the only record of which
-     * locales have starter notes, so an omission left silent reads as an
-     * oversight the next time someone counts the directories. Add `raw-zh` here
-     * when the file lands.
+     * Writing that down is the point, and the column is now the place it is
+     * written: an omission left silent reads as an oversight the next time
+     * someone counts the directories. `scripts/verify-locales.ps1` checks the
+     * other direction — a `raw-<code>` directory whose column says `no`.
      */
     @Test
     fun localizedStarterNotesExist() {
-        listOf(
-            "src/main/res/raw/starter_notes.md",
-            "src/main/res/raw-ko/starter_notes.md",
-            "src/main/res/raw-es/starter_notes.md",
-            "src/main/res/raw-de/starter_notes.md",
-            "src/main/res/raw-ja/starter_notes.md",
-            "src/main/res/raw-fr/starter_notes.md",
-            "src/main/res/raw-hr/starter_notes.md"
-        ).forEach { path ->
-            val file = File(path)
-            assertTrue("$path should exist", file.exists())
-            assertEquals(6, file.readText().split("---markleaf-note---").size)
-        }
+        LocaleManifest.entries
+            .filter { it.hasStarterNotes }
+            .map { "src/main/res/${it.rawDir}/starter_notes.md" }
+            .forEach { path ->
+                val file = File(path)
+                assertTrue("$path should exist", file.exists())
+                assertEquals(6, file.readText().split("---markleaf-note---").size)
+            }
     }
 
     private fun stringNames(path: String): Set<String> {

--- a/config/locales.tsv
+++ b/config/locales.tsv
@@ -1,0 +1,39 @@
+# The languages Markleaf ships in — the one list.
+#
+# Every gate, script and build step reads this file instead of holding a copy of
+# the list. Copies are how a language ships untested: a locale missing from one
+# of those lists is a surface no gate looks at, so nothing goes red. Both #294
+# (Chinese) and #329 (Croatian) arrived missing most of the copies, and both
+# were caught by hand rather than by CI.
+#
+# Columns are whitespace-separated; `#` starts a comment.
+#
+#   code     the language's resource and asset code, as it appears in filenames
+#   store    the BCP 47 tag Play and F-Droid use, and the block tag inside the
+#            all-locale release-notes TXT
+#   source   yes for the language the app is written in. Its files carry no code
+#            in their names (values/, docs/index.html, README.md); every other
+#            language's do (values-ko/, docs/index.ko.html, README.ko.md).
+#   starter  yes when the language has its own first-launch notes. zh is
+#            deliberately no: the Chinese contribution (#294) covers strings.xml
+#            only, so a Chinese device falls back to the English starter notes —
+#            degraded, but working.
+#
+# Row order is the order the release-notes TXT writes its locale blocks in.
+#
+# Adding a language means adding a row here and then the files the surfaces ask
+# for: app/src/main/res/values-<code>/strings.xml,
+# fastlane/metadata/android/<store>/, docs/index.<code>.html,
+# docs/privacy.<code>.html, README.<code>.md and
+# docs/assets/markleaf-tablet-<code>.{gif,mp4} plus -still.webp.
+# `pwsh scripts/verify-locales.ps1` names whichever one is missing.
+#
+# code	store	source	starter
+ko	ko-KR	no	yes
+en	en-US	yes	yes
+ja	ja-JP	no	yes
+zh	zh-CN	no	no
+de	de-DE	no	yes
+fr	fr-FR	no	yes
+es	es-ES	no	yes
+hr	hr-HR	no	yes

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -190,6 +190,7 @@ rule in `app/proguard-rules.pro` — not to disable R8.
 
 Every push to `main` and every pull request runs:
 
+- `pwsh -File scripts/verify-locales.ps1` — the languages declared in `config/locales.tsv` and the files on disk agree, in both directions
 - `pwsh -File scripts/verify-landing-versions.ps1` — public version strings match `versionName`
 - `pwsh -File scripts/verify-release-notes.ps1` — fastlane changelogs exist and fit, CHANGELOG editions agree
 - `./gradlew assembleDebug`
@@ -228,7 +229,7 @@ runner first;** one re-run usually settles it.
 GitLab CI independently runs `testDebugUnitTest`, `lintRelease`, and
 `assembleDebug` for branches and merge requests. A semantic version tag
 matching `vX.Y.Z` additionally builds the signed APK/AAB, exports the R8
-mapping and six-locale notes, and verifies the APK certificate before
+mapping and all-locale notes, and verifies the APK certificate before
 publishing. GitHub remains the canonical Roborazzi and emulator-smoke runner;
 GitLab is an independent build and binary-distribution path.
 
@@ -437,12 +438,42 @@ not the procedure.
 
 ## Release Version and Notes Checks
 
-Two PowerShell checks guard the parts of a release that are maintained by hand.
-Both run in CI on every push and pull request, and both take their expected
-version from `app/build.gradle.kts`. `versionName` and `versionCode` are the
-source of truth rather than the latest git tag, because these checks run *before*
-the tag is pushed — during release preparation the newest tag still points at the
-previous version.
+Three PowerShell checks guard the parts of a release that are maintained by
+hand. All run in CI on every push and pull request, and the two version-aware
+ones take their expected version from `app/build.gradle.kts`. `versionName` and
+`versionCode` are the source of truth rather than the latest git tag, because
+these checks run *before* the tag is pushed — during release preparation the
+newest tag still points at the previous version.
+
+### The language list
+
+```powershell
+pwsh scripts/verify-locales.ps1
+```
+
+`config/locales.tsv` is the list of languages Markleaf ships in, and everything
+that needs the list reads that file: both resource-parity unit tests, the store
+locales in `app/build.gradle.kts`, the three verify scripts, and the release
+notes check in `.gitlab-ci.yml`. The list used to be copied into seven places,
+and a language that made it into only some of them shipped with no parity check,
+no untranslated-string check and no store note — green, because the surfaces it
+was missing from are exactly the surfaces nothing looks at. Chinese (#294) and
+Croatian (#329) both arrived that way and were caught by counting by hand.
+
+This check reads the manifest and compares it against the files on disk in both
+directions: a declared language whose files are missing, and a file whose
+language is not declared. It covers app resources, starter notes, fastlane store
+directories, landing *and* privacy pages, READMEs, and the demo clips. The
+privacy pages are the reason the second direction matters — they carry no
+version string, so `verify-landing-versions.ps1` never looked at them, and a
+language added without its privacy translation gave two dead links per page.
+
+It also checks the language *counts* written into `AGENTS.md`, this file and
+`docs/assets/README.md`. Prose counts are the one place the list cannot be
+derived from, which is why they had been stale through two additions.
+
+Adding a language means adding a row to the manifest and then the files its
+header names. The check names whichever one is missing.
 
 ### Public version strings
 

--- a/scripts/locales.ps1
+++ b/scripts/locales.ps1
@@ -1,0 +1,81 @@
+<#
+.SYNOPSIS
+  config/locales.tsv 를 읽어 로케일 목록을 돌려주는 공용 헬퍼. 직접 실행하지 않고
+  다른 스크립트에서 dot-source 한다.
+.DESCRIPTION
+  릴리스·랜딩 검사 스크립트가 각자 로케일 목록을 들고 있었고, 그래서 #294 와 #329
+  가 각각 목록 절반만 갱신한 채 통과했다. 목록은 config/locales.tsv 한 곳에 있고
+  이 함수가 그것을 읽는다. 파일명 규칙(소스 언어는 코드가 안 붙고 나머지는 붙는다)
+  도 여기 한 번만 적는다 — 규칙을 쓰는 곳마다 다시 적으면 목록을 합친 의미가 없다.
+.EXAMPLE
+  . (Join-Path $PSScriptRoot 'locales.ps1')
+  $locales = Get-MarkleafLocales -RepoRoot $RepoRoot
+  $locales.Store        # ko-KR, en-US, ...  (릴리스 노트 블록 순서)
+  $locales.LandingFile  # index.html, index.ko.html, ...
+#>
+
+function Get-MarkleafLocales {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)][string]$RepoRoot,
+        [string]$ManifestPath = "config/locales.tsv"
+    )
+
+    $path = if ([System.IO.Path]::IsPathRooted($ManifestPath)) {
+        $ManifestPath
+    } else {
+        Join-Path $RepoRoot $ManifestPath
+    }
+    if (-not (Test-Path -LiteralPath $path)) {
+        throw "로케일 목록을 찾지 못했습니다: $path"
+    }
+
+    $locales = @()
+    $lineNumber = 0
+    foreach ($raw in Get-Content -Encoding utf8 -LiteralPath $path) {
+        $lineNumber++
+        $line = ($raw -split '#', 2)[0].Trim()
+        if (-not $line) { continue }
+
+        $fields = @($line -split '\s+')
+        if ($fields.Count -ne 4) {
+            throw "$path ${lineNumber}행: 열이 4개여야 합니다 (code store source starter) — '$raw'"
+        }
+        foreach ($index in 2, 3) {
+            if ($fields[$index] -notin @('yes', 'no')) {
+                throw "$path ${lineNumber}행: '$($fields[$index])' 는 yes/no 여야 합니다 — '$raw'"
+            }
+        }
+
+        $code = $fields[0]
+        $isSource = $fields[2] -eq 'yes'
+        # 소스 언어의 파일에는 코드가 붙지 않는다: values/, docs/index.html,
+        # README.md. 나머지는 전부 코드가 붙는다.
+        $suffix = if ($isSource) { "" } else { ".$code" }
+        $locales += [pscustomobject]@{
+            Code            = $code
+            Store           = $fields[1]
+            IsSource        = $isSource
+            HasStarterNotes = $fields[3] -eq 'yes'
+            ResDir          = if ($isSource) { "values" } else { "values-$code" }
+            RawDir          = if ($isSource) { "raw" } else { "raw-$code" }
+            LandingFile     = "index$suffix.html"
+            PrivacyFile     = "privacy$suffix.html"
+            ReadmeFile      = "README$suffix.md"
+        }
+    }
+
+    if ($locales.Count -eq 0) {
+        throw "$path 에 로케일 행이 없습니다."
+    }
+    $duplicates = @($locales | Group-Object Code | Where-Object { $_.Count -gt 1 })
+    if ($duplicates.Count -gt 0) {
+        throw "$path 에 중복된 code 가 있습니다: $(($duplicates | ForEach-Object { $_.Name }) -join ', ')"
+    }
+    $sources = @($locales | Where-Object { $_.IsSource })
+    if ($sources.Count -ne 1) {
+        throw "$path 의 source 열은 정확히 한 행에서만 yes 여야 합니다 (지금 $($sources.Count)개)."
+    }
+
+    return $locales
+}

--- a/scripts/locales.ps1
+++ b/scripts/locales.ps1
@@ -68,9 +68,14 @@ function Get-MarkleafLocales {
     if ($locales.Count -eq 0) {
         throw "$path 에 로케일 행이 없습니다."
     }
-    $duplicates = @($locales | Group-Object Code | Where-Object { $_.Count -gt 1 })
-    if ($duplicates.Count -gt 0) {
-        throw "$path 에 중복된 code 가 있습니다: $(($duplicates | ForEach-Object { $_.Name }) -join ', ')"
+    # code 와 store 둘 다 유일해야 한다. store 가 겹치면 두 언어가 같은 fastlane
+    # 디렉터리로 검사를 통과하고, 릴리스 노트 TXT 는 같은 블록을 두 번 쓴다 —
+    # 새 언어가 자기 스토어 메타데이터 없이 초록으로 나가는 경로다.
+    foreach ($field in 'Code', 'Store') {
+        $duplicates = @($locales | Group-Object $field | Where-Object { $_.Count -gt 1 })
+        if ($duplicates.Count -gt 0) {
+            throw "$path 에 중복된 $field 가 있습니다: $(($duplicates | ForEach-Object { $_.Name }) -join ', ')"
+        }
     }
     $sources = @($locales | Where-Object { $_.IsSource })
     if ($sources.Count -ne 1) {

--- a/scripts/verify-landing-versions.ps1
+++ b/scripts/verify-landing-versions.ps1
@@ -39,6 +39,11 @@ param(
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
 
+# 언어 목록과 파일명 규칙은 config/locales.tsv 에서 온다. 이 스크립트만 네 벌을
+# 들고 있었고, 그 중 하나라도 빠뜨린 언어는 아무 검사도 받지 않았다(#262).
+# 어떤 언어가 어떤 파일을 가져야 하는지는 verify-locales.ps1 이 본다.
+. (Join-Path $PSScriptRoot 'locales.ps1')
+
 function Resolve-UnderRoot([string]$Path) {
     if ([System.IO.Path]::IsPathRooted($Path)) { return $Path }
     return (Join-Path $RepoRoot $Path)
@@ -71,7 +76,8 @@ Write-Host "기대 버전: v$ExpectedVersion (app/build.gradle.kts versionName)"
 
 # ---- 랜딩 페이지 ----
 $docsPath = Resolve-UnderRoot $DocsDir
-$landingFiles = @("index.html", "index.ko.html", "index.ja.html", "index.zh.html", "index.de.html", "index.es.html", "index.fr.html", "index.hr.html")
+$locales = Get-MarkleafLocales -RepoRoot $RepoRoot
+$landingFiles = @($locales | ForEach-Object { $_.LandingFile })
 $releasePatterns = [ordered]@{
     'softwareVersion' = '"softwareVersion":\s*"([0-9]+\.[0-9]+\.[0-9]+)"'
     'release-line'    = 'class="release-line">[^<]*?v([0-9]+\.[0-9]+\.[0-9]+)'
@@ -114,7 +120,7 @@ foreach ($file in $landingFiles) {
 }
 
 # ---- README ----
-$readmeFiles = @("README.md", "README.ko.md", "README.ja.md", "README.zh.md", "README.de.md", "README.es.md", "README.fr.md", "README.hr.md")
+$readmeFiles = @($locales | ForEach-Object { $_.ReadmeFile })
 $releaseLinkPattern = '(?:releases/tag/|-/releases/)v[0-9]+\.[0-9]+\.[0-9]+'
 
 Write-Host "`nREADME ($($readmeFiles.Count)개)"
@@ -197,24 +203,9 @@ if ($expectedDate) {
 # webp)로 바뀌었고 — 자동재생 GIF 는 `prefers-reduced-motion` 을 존중할 방법이
 # 없고 방문당 ~930KB 였다 — README 는 GitHub 가 마크다운을 그대로 렌더하므로
 # `<video>` 를 쓸 수 없어 GIF 그대로다. 그래서 기대 확장자가 표면마다 다르다.
-$assetPairs = @(
-    @{ File = "docs/index.html";    Lang = "en"; Kind = "video" }
-    @{ File = "docs/index.ko.html"; Lang = "ko"; Kind = "video" }
-    @{ File = "docs/index.ja.html"; Lang = "ja"; Kind = "video" }
-    @{ File = "docs/index.zh.html"; Lang = "zh"; Kind = "video" }
-    @{ File = "docs/index.de.html"; Lang = "de"; Kind = "video" }
-    @{ File = "docs/index.es.html"; Lang = "es"; Kind = "video" }
-    @{ File = "docs/index.fr.html"; Lang = "fr"; Kind = "video" }
-    @{ File = "docs/index.hr.html"; Lang = "hr"; Kind = "video" }
-    @{ File = "README.md";    Lang = "en"; Kind = "gif" }
-    @{ File = "README.ko.md"; Lang = "ko"; Kind = "gif" }
-    @{ File = "README.ja.md"; Lang = "ja"; Kind = "gif" }
-    @{ File = "README.zh.md"; Lang = "zh"; Kind = "gif" }
-    @{ File = "README.de.md"; Lang = "de"; Kind = "gif" }
-    @{ File = "README.es.md"; Lang = "es"; Kind = "gif" }
-    @{ File = "README.fr.md"; Lang = "fr"; Kind = "gif" }
-    @{ File = "README.hr.md"; Lang = "hr"; Kind = "gif" }
-)
+$assetPairs = @()
+$assetPairs += @($locales | ForEach-Object { @{ File = "$DocsDir/$($_.LandingFile)"; Lang = $_.Code; Kind = "video" } })
+$assetPairs += @($locales | ForEach-Object { @{ File = $_.ReadmeFile; Lang = $_.Code; Kind = "gif" } })
 
 Write-Host "`n데모 클립 ($($assetPairs.Count)개 표면)"
 foreach ($pair in $assetPairs) {

--- a/scripts/verify-locales.ps1
+++ b/scripts/verify-locales.ps1
@@ -1,0 +1,207 @@
+<#
+.SYNOPSIS
+  config/locales.tsv 의 언어 목록과 실제 표면(리소스·스토어·랜딩·README·문서)이
+  양방향으로 일치하는지 검증한다.
+.DESCRIPTION
+  언어 목록이 일곱 군데에 복사돼 있었고, 그래서 새 언어가 절반만 들어간 채로
+  통과했다 — 중국어(#294)와 크로아티아어(#329) 모두 손으로 세어서야 발견했다.
+  목록은 이제 config/locales.tsv 한 곳에 있고, 테스트·Gradle·검사 스크립트가
+  그것을 읽는다.
+
+  목록 하나만으로는 절반만 막힌다. 목록에 있는데 파일이 없으면(선언만 하고 번역을
+  안 붙였다) 그 언어는 여전히 조용히 나가고, 파일이 있는데 목록에 없으면(#294 의
+  raw-zh 처럼) 아무 게이트도 그 파일을 보지 않는다. 그래서 표면마다 양방향으로
+  본다: 선언된 언어의 파일이 있는가, 그리고 그 자리에 있는 파일이 전부 선언된
+  언어의 것인가.
+
+  검사하는 표면은 여섯 가지다.
+
+  1. 앱 리소스 — app/src/main/res/values[-code]/strings.xml
+  2. 첫 실행 노트 — res/raw[-code]/starter_notes.md (starter=yes 인 언어만)
+  3. 스토어 메타데이터 — fastlane/metadata/android/<store>/
+  4. 랜딩·개인정보 페이지 — docs/index[.code].html, docs/privacy[.code].html
+     (개인정보 페이지는 버전 표기가 없어 verify-landing-versions.ps1 의 대상이
+     아니었고, 그래서 어떤 검사도 존재 여부를 보지 않았다 — 링크 두 개가 죽는다.)
+  5. README — README[.code].md
+  6. 데모 클립 — docs/assets/markleaf-tablet-<code>.{gif,mp4} + -still.webp
+
+  마지막으로 문서에 적힌 언어 "개수"도 본다. AGENTS.md·docs/RELEASE.md·
+  docs/assets/README.md 는 개수를 산문으로 적어 두는데, 그건 목록에서 파생되지
+  않으므로 언어가 늘어도 그대로 남는다.
+.EXAMPLE
+  pwsh scripts/verify-locales.ps1
+#>
+[CmdletBinding()]
+param(
+    [string]$RepoRoot = (Split-Path -Parent $PSScriptRoot)
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+. (Join-Path $PSScriptRoot 'locales.ps1')
+
+function Resolve-UnderRoot([string]$Path) {
+    if ([System.IO.Path]::IsPathRooted($Path)) { return $Path }
+    return (Join-Path $RepoRoot $Path)
+}
+
+$fail = 0
+function Add-Failure([string]$Message) {
+    Write-Host $Message -ForegroundColor Red
+    $script:fail++
+}
+
+# 선언된 경로가 실제로 있는지. $Expected 는 저장소 기준 상대 경로다.
+function Test-Declared([string]$Label, [string[]]$Expected) {
+    $missing = @($Expected | Where-Object { -not (Test-Path -LiteralPath (Resolve-UnderRoot $_)) })
+    if ($missing.Count -gt 0) {
+        Add-Failure ("  FAIL  {0,-14} 선언된 언어인데 없는 경로: {1}" -f $Label, ($missing -join ', '))
+    } else {
+        Write-Host ("  OK    {0,-14} {1}개" -f $Label, $Expected.Count) -ForegroundColor Green
+    }
+}
+
+# 그 자리에 있는 것 중 선언되지 않은 것. $Pattern 은 언어별 항목만 골라내는
+# 정규식이고, 첫 그룹이 언어 코드여야 한다.
+function Test-Strays([string]$Label, [string]$ScanRoot, [string]$Pattern, [string[]]$DeclaredCodes, [switch]$Directory) {
+    $root = Resolve-UnderRoot $ScanRoot
+    if (-not (Test-Path -LiteralPath $root)) {
+        Add-Failure ("  FAIL  {0,-14} 검사할 디렉터리가 없습니다: {1}" -f $Label, $ScanRoot)
+        return
+    }
+    $entries = if ($Directory) {
+        Get-ChildItem -LiteralPath $root -Directory
+    } else {
+        Get-ChildItem -LiteralPath $root -File
+    }
+    $strays = @()
+    foreach ($entry in $entries) {
+        $match = [regex]::Match($entry.Name, $Pattern)
+        if (-not $match.Success) { continue }
+        $code = $match.Groups[1].Value
+        if ($DeclaredCodes -notcontains $code) {
+            $strays += "$($entry.Name) ($code)"
+        }
+    }
+    if ($strays.Count -gt 0) {
+        Add-Failure ("  FAIL  {0,-14} config/locales.tsv 에 없는 언어의 파일: {1}" -f $Label, ($strays -join ', '))
+    }
+}
+
+$locales = Get-MarkleafLocales -RepoRoot $RepoRoot
+$codes = @($locales | ForEach-Object { $_.Code })
+$stores = @($locales | ForEach-Object { $_.Store })
+Write-Host "로케일 목록: $($locales.Count)개 (config/locales.tsv) — $($codes -join ', ')"
+
+# ---- 1. 앱 리소스 ----
+Write-Host "`n앱 리소스 (app/src/main/res)"
+Test-Declared "strings.xml" @($locales | ForEach-Object { "app/src/main/res/$($_.ResDir)/strings.xml" })
+# values-night 처럼 언어가 아닌 한정자는 두 글자 코드 모양이 아니라 저절로 빠진다.
+Test-Strays "values-*" "app/src/main/res" '^values-([a-z]{2})(?:-r[A-Z]{2})?$' $codes -Directory
+
+# ---- 2. 첫 실행 노트 ----
+Write-Host "`n첫 실행 노트 (res/raw)"
+$withStarter = @($locales | Where-Object { $_.HasStarterNotes })
+Test-Declared "starter_notes" @($withStarter | ForEach-Object { "app/src/main/res/$($_.RawDir)/starter_notes.md" })
+# raw-zh 는 일부러 없다(#294). 반대로 raw-<code> 가 있는데 목록에서 starter=no
+# 라면 목록이 낡은 것이므로 그것도 잡는다.
+Test-Strays "raw-*" "app/src/main/res" '^raw-([a-z]{2})$' @($withStarter | ForEach-Object { $_.Code }) -Directory
+
+# ---- 3. 스토어 메타데이터 ----
+Write-Host "`n스토어 메타데이터 (fastlane/metadata/android)"
+Test-Declared "store locale" @($stores | ForEach-Object { "fastlane/metadata/android/$_" })
+Test-Strays "store locale" "fastlane/metadata/android" '^([a-z]{2}-[A-Z]{2})$' $stores -Directory
+
+# ---- 4. 랜딩·개인정보 페이지 ----
+Write-Host "`n랜딩·개인정보 페이지 (docs)"
+Test-Declared "index.html" @($locales | ForEach-Object { "docs/$($_.LandingFile)" })
+Test-Declared "privacy.html" @($locales | ForEach-Object { "docs/$($_.PrivacyFile)" })
+# 소스 언어(index.html)는 코드가 없으므로 이 정규식에 걸리지 않는다.
+Test-Strays "index.*.html" "docs" '^index\.([a-z]{2})\.html$' $codes
+Test-Strays "privacy.*.html" "docs" '^privacy\.([a-z]{2})\.html$' $codes
+
+# ---- 5. README ----
+Write-Host "`nREADME"
+Test-Declared "README" @($locales | ForEach-Object { $_.ReadmeFile })
+Test-Strays "README.*.md" "." '^README\.([a-z]{2})\.md$' $codes
+
+# ---- 6. 데모 클립 ----
+Write-Host "`n데모 클립 (docs/assets)"
+$clips = @()
+foreach ($locale in $locales) {
+    $clips += "docs/assets/markleaf-tablet-$($locale.Code).mp4"
+    $clips += "docs/assets/markleaf-tablet-$($locale.Code).gif"
+    $clips += "docs/assets/markleaf-tablet-$($locale.Code)-still.webp"
+}
+Test-Declared "tablet clip" $clips
+Test-Strays "tablet clip" "docs/assets" '^markleaf-tablet-([a-z]{2})(?:-still)?\.(?:gif|mp4|webp)$' $codes
+
+# ---- 7. 문서에 적힌 개수 ----
+#
+# 개수는 목록에서 파생되지 않는 유일한 표기라 언어가 늘어도 그대로 남는다.
+# verify-release-export.ps1 의 "여섯 로케일" OK 줄이 두 번의 언어 추가를 지나
+# 그대로 있었던 것과 같은 종류다.
+Write-Host "`n문서에 적힌 언어 개수 ($($locales.Count)개여야 함)"
+$numberWords = @{
+    1 = 'one'; 2 = 'two'; 3 = 'three'; 4 = 'four'; 5 = 'five'; 6 = 'six'
+    7 = 'seven'; 8 = 'eight'; 9 = 'nine'; 10 = 'ten'; 11 = 'eleven'; 12 = 'twelve'
+}
+$expectedWord = $numberWords[$locales.Count]
+# "the languages" 같은 산문까지 후보로 잡지 않도록 수사(數詞)만 본다.
+$numberWordAlternation = (($numberWords.Values | Sort-Object) -join '|')
+
+# 파일 -> (라벨, 정규식, 기댓값) 목록. 정규식의 첫 그룹이 개수다.
+$countChecks = @(
+    @{ File = "AGENTS.md"; Label = "N개 로케일"; Pattern = '(\d+)개\s*(?:스토어\s+)?로케일'; Expected = "$($locales.Count)" }
+    @{ File = "AGENTS.md"; Label = "N개 언어"; Pattern = '(\d+)개\s*언어'; Expected = "$($locales.Count)" }
+    @{ File = "docs/RELEASE.md"; Label = "N languages"; Pattern = "\b($numberWordAlternation)\s+(?:languages|READMEs)\b"; Expected = $expectedWord }
+    @{ File = "docs/assets/README.md"; Label = "클립 개수"; Pattern = 'markleaf-tablet-<lang>[^|]*\((\d+)\)'; Expected = "$($locales.Count)" }
+)
+foreach ($check in $countChecks) {
+    $path = Resolve-UnderRoot $check.File
+    if (-not (Test-Path -LiteralPath $path)) {
+        Add-Failure ("  FAIL  {0,-22} 파일이 없습니다." -f $check.File)
+        continue
+    }
+    $text = Get-Content -Raw -Encoding utf8 -LiteralPath $path
+    $found = @([regex]::Matches($text, $check.Pattern) | ForEach-Object { $_.Groups[1].Value } | Sort-Object -Unique)
+    if ($found.Count -eq 0) {
+        Add-Failure ("  FAIL  {0,-22} {1} 표기를 찾지 못했습니다 — 표현이 바뀌었다면 이 검사의 정규식도 함께 고치세요." -f $check.File, $check.Label)
+        continue
+    }
+    $wrong = @($found | Where-Object { $_ -ne $check.Expected })
+    if ($wrong.Count -gt 0) {
+        Add-Failure ("  FAIL  {0,-22} {1} 이(가) '{2}' 여야 하는데 '{3}' 로 적혀 있습니다." -f $check.File, $check.Label, $check.Expected, ($wrong -join ', '))
+    } else {
+        Write-Host ("  OK    {0,-22} {1} = {2}" -f $check.File, $check.Label, $check.Expected) -ForegroundColor Green
+    }
+}
+
+# AGENTS.md 는 개수와 함께 코드 목록도 적는다: "8개 언어(en · ko · ...)".
+# 개수만 맞고 목록이 낡는 경우가 있어 집합으로 비교한다.
+$agentsPath = Resolve-UnderRoot "AGENTS.md"
+if (Test-Path -LiteralPath $agentsPath) {
+    $agentsText = Get-Content -Raw -Encoding utf8 -LiteralPath $agentsPath
+    $listMatches = @([regex]::Matches($agentsText, '\(([a-z]{2}(?:\s*·\s*[a-z]{2})+)\)'))
+    if ($listMatches.Count -eq 0) {
+        Add-Failure "  FAIL  AGENTS.md            '(en · ko · …)' 언어 목록을 찾지 못했습니다."
+    } else {
+        $expectedList = ($codes | Sort-Object) -join ' '
+        foreach ($match in $listMatches) {
+            $listed = (($match.Groups[1].Value -split '·' | ForEach-Object { $_.Trim() }) | Sort-Object) -join ' '
+            if ($listed -ne $expectedList) {
+                Add-Failure ("  FAIL  AGENTS.md            언어 목록이 다릅니다: '{0}' (기대: {1})" -f $match.Groups[1].Value, ($codes -join ' · '))
+            } else {
+                Write-Host ("  OK    AGENTS.md            언어 목록 ({0})" -f $match.Groups[1].Value) -ForegroundColor Green
+            }
+        }
+    }
+}
+
+if ($fail -ne 0) {
+    Write-Host "`n실패 $fail 건. config/locales.tsv 와 표면을 맞추세요 — 검사를 고치지 마세요." -ForegroundColor Red
+    Write-Host "언어를 추가하는 중이라면 config/locales.tsv 헤더에 어떤 파일이 필요한지 적혀 있습니다." -ForegroundColor Red
+    exit 2
+}
+Write-Host "`n모든 로케일 표면 검사를 통과했습니다 ($($locales.Count)개 언어)." -ForegroundColor Green

--- a/scripts/verify-locales.ps1
+++ b/scripts/verify-locales.ps1
@@ -63,8 +63,10 @@ function Test-Declared([string]$Label, [string[]]$Expected) {
 }
 
 # 그 자리에 있는 것 중 선언되지 않은 것. $Pattern 은 언어별 항목만 골라내는
-# 정규식이고, 첫 그룹이 언어 코드여야 한다.
-function Test-Strays([string]$Label, [string]$ScanRoot, [string]$Pattern, [string[]]$DeclaredCodes, [switch]$Directory) {
+# 정규식이고, 첫 그룹이 언어 코드여야 한다. $DeclaredCodes 는 "이 자리에 있어도
+# 되는" 코드다 — 코드가 붙는 자리(values-xx, index.xx.html …)에는 소스 언어가
+# 오면 안 되므로 그 목록에서 빠진다.
+function Test-Strays([string]$Label, [string]$ScanRoot, [string]$Pattern, [string[]]$DeclaredCodes, [string]$SourceCode = "", [switch]$Directory) {
     $root = Resolve-UnderRoot $ScanRoot
     if (-not (Test-Path -LiteralPath $root)) {
         Add-Failure ("  FAIL  {0,-14} 검사할 디렉터리가 없습니다: {1}" -f $Label, $ScanRoot)
@@ -76,21 +78,35 @@ function Test-Strays([string]$Label, [string]$ScanRoot, [string]$Pattern, [strin
         Get-ChildItem -LiteralPath $root -File
     }
     $strays = @()
+    $sourceStrays = @()
     foreach ($entry in $entries) {
         $match = [regex]::Match($entry.Name, $Pattern)
         if (-not $match.Success) { continue }
         $code = $match.Groups[1].Value
-        if ($DeclaredCodes -notcontains $code) {
+        if ($DeclaredCodes -contains $code) { continue }
+        if ($SourceCode -and $code -eq $SourceCode) {
+            $sourceStrays += $entry.Name
+        } else {
             $strays += "$($entry.Name) ($code)"
         }
     }
     if ($strays.Count -gt 0) {
         Add-Failure ("  FAIL  {0,-14} config/locales.tsv 에 없는 언어의 파일: {1}" -f $Label, ($strays -join ', '))
     }
+    if ($sourceStrays.Count -gt 0) {
+        # 소스 언어는 코드가 붙지 않는 자리(values/, index.html, README.md)에만
+        # 있어야 한다. values-en 은 영어 기기에서 values/ 를 밀어내는데, 파리티
+        # 테스트는 values/ 만 읽으므로 낡은 영어 리소스가 검사 밖으로 나간다.
+        Add-Failure ("  FAIL  {0,-14} 소스 언어({1})는 코드 없는 자리에만 둡니다: {2}" -f $Label, $SourceCode, ($sourceStrays -join ', '))
+    }
 }
 
 $locales = Get-MarkleafLocales -RepoRoot $RepoRoot
 $codes = @($locales | ForEach-Object { $_.Code })
+$sourceCode = ($locales | Where-Object { $_.IsSource }).Code
+# 코드가 붙는 자리에 올 수 있는 언어. 소스 언어는 values/ · index.html · README.md
+# 쪽이므로 여기서 빠진다 (values-en 은 파리티 테스트가 읽지 않는 자리다).
+$suffixedCodes = @($locales | Where-Object { -not $_.IsSource } | ForEach-Object { $_.Code })
 $stores = @($locales | ForEach-Object { $_.Store })
 Write-Host "로케일 목록: $($locales.Count)개 (config/locales.tsv) — $($codes -join ', ')"
 
@@ -98,7 +114,7 @@ Write-Host "로케일 목록: $($locales.Count)개 (config/locales.tsv) — $($c
 Write-Host "`n앱 리소스 (app/src/main/res)"
 Test-Declared "strings.xml" @($locales | ForEach-Object { "app/src/main/res/$($_.ResDir)/strings.xml" })
 # values-night 처럼 언어가 아닌 한정자는 두 글자 코드 모양이 아니라 저절로 빠진다.
-Test-Strays "values-*" "app/src/main/res" '^values-([a-z]{2})(?:-r[A-Z]{2})?$' $codes -Directory
+Test-Strays "values-*" "app/src/main/res" '^values-([a-z]{2})(?:-r[A-Z]{2})?$' $suffixedCodes $sourceCode -Directory
 
 # ---- 2. 첫 실행 노트 ----
 Write-Host "`n첫 실행 노트 (res/raw)"
@@ -106,7 +122,7 @@ $withStarter = @($locales | Where-Object { $_.HasStarterNotes })
 Test-Declared "starter_notes" @($withStarter | ForEach-Object { "app/src/main/res/$($_.RawDir)/starter_notes.md" })
 # raw-zh 는 일부러 없다(#294). 반대로 raw-<code> 가 있는데 목록에서 starter=no
 # 라면 목록이 낡은 것이므로 그것도 잡는다.
-Test-Strays "raw-*" "app/src/main/res" '^raw-([a-z]{2})$' @($withStarter | ForEach-Object { $_.Code }) -Directory
+Test-Strays "raw-*" "app/src/main/res" '^raw-([a-z]{2})$' @($withStarter | Where-Object { -not $_.IsSource } | ForEach-Object { $_.Code }) $sourceCode -Directory
 
 # ---- 3. 스토어 메타데이터 ----
 Write-Host "`n스토어 메타데이터 (fastlane/metadata/android)"
@@ -117,14 +133,15 @@ Test-Strays "store locale" "fastlane/metadata/android" '^([a-z]{2}-[A-Z]{2})$' $
 Write-Host "`n랜딩·개인정보 페이지 (docs)"
 Test-Declared "index.html" @($locales | ForEach-Object { "docs/$($_.LandingFile)" })
 Test-Declared "privacy.html" @($locales | ForEach-Object { "docs/$($_.PrivacyFile)" })
-# 소스 언어(index.html)는 코드가 없으므로 이 정규식에 걸리지 않는다.
-Test-Strays "index.*.html" "docs" '^index\.([a-z]{2})\.html$' $codes
-Test-Strays "privacy.*.html" "docs" '^privacy\.([a-z]{2})\.html$' $codes
+# 소스 언어의 페이지는 index.html 이므로, index.en.html 은 아무도 링크하지 않는
+# 사본이 된다 — 코드가 붙은 자리에서는 소스 언어도 이물이다.
+Test-Strays "index.*.html" "docs" '^index\.([a-z]{2})\.html$' $suffixedCodes $sourceCode
+Test-Strays "privacy.*.html" "docs" '^privacy\.([a-z]{2})\.html$' $suffixedCodes $sourceCode
 
 # ---- 5. README ----
 Write-Host "`nREADME"
 Test-Declared "README" @($locales | ForEach-Object { $_.ReadmeFile })
-Test-Strays "README.*.md" "." '^README\.([a-z]{2})\.md$' $codes
+Test-Strays "README.*.md" "." '^README\.([a-z]{2})\.md$' $suffixedCodes $sourceCode
 
 # ---- 6. 데모 클립 ----
 Write-Host "`n데모 클립 (docs/assets)"

--- a/scripts/verify-release-export.ps1
+++ b/scripts/verify-release-export.ps1
@@ -35,9 +35,11 @@ param(
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
 
-# app/build.gradle.kts 의 noteLocales 와 같은 목록이어야 한다. 릴리스 노트 TXT 는
-# 로케일마다 <tag> ... </tag> 블록을 연달아 담는다(writeReleaseArtifacts).
-$StoreLocales = @("ko-KR", "en-US", "ja-JP", "zh-CN", "de-DE", "fr-FR", "es-ES", "hr-HR")
+# 목록은 config/locales.tsv 한 곳에 있고, app/build.gradle.kts 의 noteLocales 도
+# 같은 파일을 읽는다(#262). 릴리스 노트 TXT 는 로케일마다 <tag> ... </tag> 블록을
+# 연달아 담는다(writeReleaseArtifacts).
+. (Join-Path $PSScriptRoot 'locales.ps1')
+$StoreLocales = @((Get-MarkleafLocales -RepoRoot $RepoRoot) | ForEach-Object { $_.Store })
 
 function Resolve-UnderRoot([string]$Path) {
     if ([System.IO.Path]::IsPathRooted($Path)) { return $Path }
@@ -115,7 +117,7 @@ foreach ($label in $expected.Keys) {
     Write-Host ("  OK    {0,-12} {1} ({2})" -f $label, $name, $human) -ForegroundColor Green
 }
 
-# ---- 2. 릴리스 노트 TXT 가 여섯 로케일 블록을 모두 담고 있는지 ----
+# ---- 2. 릴리스 노트 TXT 가 모든 로케일 블록을 담고 있는지 ----
 # 노트 파일은 있는데 로케일이 빠진 채 만들어지는 경우는 Gradle task 가 막지만,
 # 손으로 편집하거나 오래된 버전의 파일이 남아 있는 경우까지 막지는 못한다.
 if ($notesPath) {
@@ -130,7 +132,9 @@ if ($notesPath) {
     if ($missingLocales.Count -gt 0) {
         Add-Failure ("  FAIL  블록이 없는 로케일: {0}" -f ($missingLocales -join ', '))
     } else {
-        Write-Host ("  OK    여섯 로케일 블록이 모두 있습니다.") -ForegroundColor Green
+        # 개수를 문장에 박아 두었더니 언어가 두 번 늘도록 "여섯"으로 남아 있었다.
+        # 헤더가 스크롤을 벗어난 뒤 읽는 줄이 이것이라 값에서 뽑아 쓴다(#262).
+        Write-Host ("  OK    $($StoreLocales.Count)개 로케일 블록이 모두 있습니다: {0}" -f ($StoreLocales -join ', ')) -ForegroundColor Green
     }
 }
 

--- a/scripts/verify-release-notes.ps1
+++ b/scripts/verify-release-notes.ps1
@@ -51,8 +51,11 @@ $StoreDescriptionLimits = [ordered]@{
     'full_description.txt'  = 4000
 }
 
-# app/build.gradle.kts 의 noteLocales 와 같은 목록이어야 한다.
-$StoreLocales = @("ko-KR", "en-US", "ja-JP", "zh-CN", "de-DE", "fr-FR", "es-ES", "hr-HR")
+# 목록은 config/locales.tsv 한 곳에 있고, app/build.gradle.kts 의 noteLocales 도
+# 같은 파일을 읽는다. 목록을 복사해 두었더니 #294·#329 가 각각 절반만 갱신한 채
+# 통과했다(#262).
+. (Join-Path $PSScriptRoot 'locales.ps1')
+$StoreLocales = @((Get-MarkleafLocales -RepoRoot $RepoRoot) | ForEach-Object { $_.Store })
 
 function Resolve-UnderRoot([string]$Path) {
     if ([System.IO.Path]::IsPathRooted($Path)) { return $Path }


### PR DESCRIPTION
Four items from the v2.33.0 section of the hardening tracker (#262), all one shape: the language list was copied into seven places, so a new language could ship with most of its surfaces ungated.

## The list

`config/locales.tsv` is now the one list. Four whitespace-separated columns — `code`, `store`, `source`, `starter` — with the filename rules written in its header. It is a plain table rather than JSON because the consumers are Kotlin, Gradle, PowerShell and a shell one-liner, and none of them should need a parser dependency to read eight rows.

Consumers updated to read it:

| Was | Now |
|---|---|
| `ResourceParityTest` — two hardcoded lists | `LocaleManifest.translated` / `.hasStarterNotes` |
| `UntranslatedStringTest` — `LOCALES` and a `LANGUAGE_COINCIDENCES` row per locale | `LocaleManifest.translatedCodes`; an absent coincidence list now means *no exemptions* |
| `noteLocales` in `app/build.gradle.kts` | reads the manifest |
| `$StoreLocales` ×2, four lists in `verify-landing-versions.ps1` | `scripts/locales.ps1` |
| six `grep -q '^<xx-XX>$'` lines in `.gitlab-ci.yml` | one `awk` loop over the manifest |

## The gate

A list alone closes half of it — a declared language whose files are missing is still silent. `scripts/verify-locales.ps1` compares the manifest against the files on disk **in both directions**, across app resources, starter notes, fastlane store directories, landing pages, privacy pages, READMEs and demo clips. It runs in `build` on every push and PR, and in GitLab's `verify_release_docs`.

It also checks the language counts written into `AGENTS.md`, `docs/RELEASE.md` and `docs/assets/README.md`, and compares `AGENTS.md`'s `(en · ko · …)` list as a set. Prose counts are the one thing that cannot be derived from the list, which is why they had been stale through two additions.

## The three items that fall out of it

- **Nothing checked that a landing language has a privacy page.** They carry no version string, so `verify-landing-versions.ps1` never walked them; a language added without its privacy translation gave two dead links per page. Removing `docs/privacy.hr.html` now fails the gate by name.
- **`.gitlab-ci.yml` still grepped for six locale blocks** — missing `zh-CN` since #294 and `hr-HR` since #329. The job is gated behind `GITLAB_RELEASE_FROM_CI` and nothing runs it, which is why the drift went unnoticed; it would have passed the wrong thing the moment anyone turned it on. The path is the documented fallback for GitHub being unavailable, so the list is derived rather than the job deleted.
- **`verify-release-export.ps1` reported "여섯 로케일 블록" whatever the count was.** The assertion iterated the real list and was correct; the OK line beneath it said "six" through two additions. It now prints the count and the locales it checked.

## One thing the change turned up

The manifest is declared as an input of the unit test tasks. Without it, editing `config/locales.tsv` alone left `testDebugUnitTest` UP-TO-DATE, so the tests kept their previous verdict. CI checks out clean and would never have seen it; the person adding a language would have.

## Verification

- Dropped the `hr` row → 12 failures naming every `hr` file across every surface, plus all four count checks.
- Declared a language with no files → every surface fails with the path it wanted.
- Deleted `docs/privacy.hr.html` → the exact item-C case fails by name.
- Both resource tests fail on the same drift (4/4) once the manifest is a task input, and pass again when it is restored.
- `./gradlew test` (all variants) green; `verify-locales.ps1`, `verify-landing-versions.ps1`, `verify-release-notes.ps1` green; `verify-release-export.ps1` green against the real v2.33.0 artifacts in `D:\Build`, now printing `8개 로케일 블록이 모두 있습니다: ko-KR, en-US, …`.
- The Gradle snippet was executed against the manifest to confirm it yields the same eight store tags in the same order as the list it replaces.

Tracker: #262 (v2.33.0 section, four of five items).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
