### PR TITLE
fix(widget): stop the recent-notes widget crashing on Android 12+

### DIFF
--- a/app/src/main/java/com/markleaf/notes/widget/QuickNoteWidget.kt
+++ b/app/src/main/java/com/markleaf/notes/widget/QuickNoteWidget.kt
@@ -77,7 +77,11 @@ class QuickNoteWidget : AppWidgetProvider() {
             views.setRemoteAdapter(R.id.widget_list, serviceIntent)
             views.setEmptyView(R.id.widget_list, R.id.widget_empty)
 
-            // Pending intent template — fillIn from each row supplies EXTRA_NOTE_ID
+            // Pending intent template — fillIn from each row supplies EXTRA_NOTE_ID.
+            // FLAG_MUTABLE alone: a template exists to be completed by the row's
+            // fill-in, so it cannot be immutable, and asking for both throws
+            // IllegalArgumentException on Android 12+ — which took the whole
+            // receiver down before the widget was ever populated.
             val openNoteTemplate = Intent(context, MainActivity::class.java).apply {
                 action = ACTION_OPEN_NOTE
                 flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
@@ -86,7 +90,7 @@ class QuickNoteWidget : AppWidgetProvider() {
                 context,
                 1,
                 openNoteTemplate,
-                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_MUTABLE
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
             )
             views.setPendingIntentTemplate(R.id.widget_list, openNotePending)
 

--- a/app/src/test/java/com/markleaf/notes/PendingIntentFlagsTest.kt
+++ b/app/src/test/java/com/markleaf/notes/PendingIntentFlagsTest.kt
@@ -1,0 +1,94 @@
+package com.markleaf.notes
+
+import java.io.File
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Catches a `PendingIntent` built with both `FLAG_IMMUTABLE` and `FLAG_MUTABLE`.
+ *
+ * Android 12+ rejects the pair with `IllegalArgumentException`, and the widget's
+ * row template carried it from v2.16.0 through v2.35.0 — 44 releases. The throw
+ * landed inside `onUpdate`, so the receiver died before the widget was ever
+ * populated: the recent-notes list sat on the home screen as an empty card with
+ * a dead "+" button, and every launcher refresh crashed the app.
+ *
+ * Nothing else sees it. The flags are plain ints, so the pair compiles; lint has
+ * no rule for it; and a Robolectric test does not help either — `ShadowPendingIntent`
+ * records the flags without running the platform's check, so
+ * [com.markleaf.notes.widget.QuickNoteWidgetTest] passes with the defect present.
+ * That leaves reading the source, which is what this does — the same shape as
+ * [HardcodedStringTest], and for the same reason.
+ */
+class PendingIntentFlagsTest {
+
+    @Test
+    fun noPendingIntentAsksForBothMutabilities() {
+        val offenders = sourceFiles().mapNotNull { file ->
+            val calls = pendingIntentCalls(withoutComments(file.readText()))
+            val bad = calls.filter { it.contains(IMMUTABLE) && it.contains(MUTABLE) }
+            if (bad.isEmpty()) null else "${file.invariantSeparatorsPath}: ${bad.size} call(s)"
+        }.sorted()
+
+        assertTrue(
+            buildString {
+                appendLine("These PendingIntent calls pass FLAG_IMMUTABLE and FLAG_MUTABLE together.")
+                appendLine("Android 12+ throws IllegalArgumentException for the pair — pick one:")
+                appendLine("  mutable for a RemoteViews template that a fill-in completes,")
+                appendLine("  immutable for everything else.")
+                offenders.forEach { appendLine("  - $it") }
+            },
+            offenders.isEmpty()
+        )
+    }
+
+    private fun sourceFiles(): List<File> {
+        val main = File("src/main/java")
+        assertTrue(
+            "Expected to run with the app module as the working directory, " +
+                "but ${main.absolutePath} does not exist",
+            main.isDirectory
+        )
+        return main.walkTopDown().filter { it.isFile && it.extension == "kt" }.toList()
+    }
+
+    /**
+     * The argument list of every `PendingIntent.getX(...)` call, so a flag named
+     * elsewhere in the same file — a constant, a comment's prose — cannot be read
+     * as part of one.
+     */
+    private fun pendingIntentCalls(source: String): List<String> = buildList {
+        var index = source.indexOf(CALL_PREFIX)
+        while (index >= 0) {
+            val open = source.indexOf('(', index)
+            if (open < 0) return@buildList
+            var depth = 0
+            var cursor = open
+            while (cursor < source.length) {
+                when (source[cursor]) {
+                    '(' -> depth++
+                    ')' -> {
+                        depth--
+                        if (depth == 0) break
+                    }
+                }
+                cursor++
+            }
+            if (cursor >= source.length) return@buildList
+            add(source.substring(open, cursor))
+            index = source.indexOf(CALL_PREFIX, cursor)
+        }
+    }
+
+    /** Line and block comments, so the explanation of the defect is not the defect. */
+    private fun withoutComments(source: String): String =
+        source.replace(BLOCK_COMMENT, "").replace(LINE_COMMENT, "")
+
+    private companion object {
+        const val CALL_PREFIX = "PendingIntent.get"
+        const val IMMUTABLE = "FLAG_IMMUTABLE"
+        const val MUTABLE = "FLAG_MUTABLE"
+        val BLOCK_COMMENT = Regex("""/\*.*?\*/""", RegexOption.DOT_MATCHES_ALL)
+        val LINE_COMMENT = Regex("""//[^\n]*""")
+    }
+}

--- a/app/src/test/java/com/markleaf/notes/widget/QuickNoteWidgetTest.kt
+++ b/app/src/test/java/com/markleaf/notes/widget/QuickNoteWidgetTest.kt
@@ -1,0 +1,36 @@
+package com.markleaf.notes.widget
+
+import android.appwidget.AppWidgetManager
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.markleaf.notes.R
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+/**
+ * That building the widget's views runs to completion.
+ *
+ * A smoke test, and honest about its reach: `ShadowPendingIntent` records flags
+ * without running the platform's checks, so this passes even with the
+ * FLAG_IMMUTABLE + FLAG_MUTABLE pair that crashed the receiver for 44 releases.
+ * [com.markleaf.notes.PendingIntentFlagsTest] is what catches that; this covers
+ * the rest of the method, which nothing else exercised.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class QuickNoteWidgetTest {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    @Test
+    fun `building the widget views does not throw`() {
+        val manager = AppWidgetManager.getInstance(context)
+        val ids = shadowOf(manager)
+            .createWidgets(QuickNoteWidget::class.java, R.layout.widget_quick_note, 1)
+
+        QuickNoteWidget.updateAppWidget(context, manager, ids.first())
+    }
+}


### PR DESCRIPTION
Fixes #352.

The row template asked for `FLAG_IMMUTABLE` and `FLAG_MUTABLE` at once. Android 12+ rejects the pair with `IllegalArgumentException`, thrown inside `onUpdate` — so the receiver died before `updateAppWidget` ever ran and none of the views were applied. The widget sat on the home screen as an empty green card with a dead "+" button, and every launcher refresh crashed the app.

Present since v2.16.0 (0defafc, 2026-05-21) and shipped in all 44 releases since, up to v2.35.0.

A template exists to be completed by each row's fill-in, so mutable is the correct half of the pair.

## Tests

Two, and only one of them earns its keep for this defect.

- **`PendingIntentFlagsTest`** reads the source, because nothing else can see the bug: the flags are `Int`s so the pair compiles, lint has no rule for it, and Robolectric's `ShadowPendingIntent` records flags without running the platform check. Verified in both directions — reintroducing the bug makes it fail, the fix makes it pass.
- **`QuickNoteWidgetTest`** is kept as a smoke test of the rest of `updateAppWidget`, which nothing exercised, and its KDoc says plainly that it does *not* catch the flag pair.

## Verified on a phone emulator (API 36)

| | Before | After |
|---|---|---|
| Placing the widget | `FATAL EXCEPTION ... Cannot set both FLAG_IMMUTABLE and FLAG_MUTABLE`, empty card | Ten-note list renders |
| Tapping a row | nothing | Opens that note |
| "+" button | nothing | Opens a new note |
| logcat | fatal exception | clean |

Gates: `:app:test` (all three variants), `lintRelease`, `scripts/verify-locales.ps1` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
