### PR TITLE
fix(theme): paint the window background with the app's own theme

### DIFF
--- a/app/src/main/java/com/markleaf/notes/ui/theme/Theme.kt
+++ b/app/src/main/java/com/markleaf/notes/ui/theme/Theme.kt
@@ -1,6 +1,7 @@
 package com.markleaf.notes.ui.theme
 
 import android.app.Activity
+import android.graphics.drawable.ColorDrawable
 import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
@@ -11,6 +12,7 @@ import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.text.TextStyle
@@ -215,7 +217,20 @@ fun MarkleafTheme(
     // activity start, so a runtime theme switch (e.g. system dark mode flips,
     // or the user toggles between Markleaf green and Material You) used to
     // leave the status bar icons stale — visible on the wrong background.
+    //
+    // The window background needs the same treatment for a different reason.
+    // `Theme.Markleaf` is declared twice — Material Light in `values/`, Material
+    // Dark in `values-night/` — so the platform picks between them by the
+    // `-night` resource qualifier, which is the *system* dark-mode setting and
+    // not the Theme the user chose in Settings. Nothing covered that gap, so a
+    // Dark app on a light system kept a white window underneath it. It is
+    // invisible while an app surface is drawn over it and shows through the
+    // NavHost cross-fade, where both destinations are briefly translucent —
+    // measured at 189/255 average frame luma mid-transition against 44 at rest
+    // (#354, reported on #345). Repainting it with the scheme's own background
+    // keeps the two in step through every runtime theme change.
     val view = LocalView.current
+    val windowBackground = colorScheme.background
     if (!view.isInEditMode) {
         SideEffect {
             val window = (view.context as? Activity)?.window
@@ -223,6 +238,7 @@ fun MarkleafTheme(
                 val controller = WindowCompat.getInsetsController(window, view)
                 controller.isAppearanceLightStatusBars = !darkTheme
                 controller.isAppearanceLightNavigationBars = !darkTheme
+                window.setBackgroundDrawable(ColorDrawable(windowBackground.toArgb()))
             }
         }
     }

--- a/app/src/testDebug/java/com/markleaf/notes/ui/theme/ThemeWindowBackgroundTest.kt
+++ b/app/src/testDebug/java/com/markleaf/notes/ui/theme/ThemeWindowBackgroundTest.kt
@@ -1,0 +1,78 @@
+package com.markleaf.notes.ui.theme
+
+import android.graphics.drawable.ColorDrawable
+import androidx.activity.ComponentActivity
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * The activity window background has to follow the theme the app resolved to,
+ * not the `-night` resource qualifier (#354).
+ *
+ * `Theme.Markleaf` is Material Light in `values/` and Material Dark in
+ * `values-night/`, so the platform picks between them by the system dark-mode
+ * setting alone. With Settings → Appearance → Theme set against the system, the
+ * window underneath the app kept the platform's colour and showed through the
+ * navigation cross-fade. These assertions pin the colour that used to be wrong.
+ */
+@RunWith(AndroidJUnit4::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(sdk = [33], qualifiers = "w360dp-h640dp-mdpi")
+class ThemeWindowBackgroundTest {
+
+    @get:Rule
+    val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun darkThemePaintsTheWindowWithTheDarkBackground() {
+        composeRule.setContent {
+            MarkleafTheme(darkTheme = true) {}
+        }
+        composeRule.waitForIdle()
+
+        assertEquals(DarkColorScheme.background.toArgb(), windowBackgroundArgb())
+    }
+
+    @Test
+    fun lightThemePaintsTheWindowWithTheLightBackground() {
+        composeRule.setContent {
+            MarkleafTheme(darkTheme = false) {}
+        }
+        composeRule.waitForIdle()
+
+        assertEquals(LightColorScheme.background.toArgb(), windowBackgroundArgb())
+    }
+
+    /**
+     * The regression itself: the theme changes at runtime — the Settings toggle
+     * writes a preference, the app recomposes — so a background applied only at
+     * activity start would be stale from the second frame onwards.
+     */
+    @Test
+    fun switchingThemeAtRuntimeRepaintsTheWindow() {
+        val dark = mutableStateOf(false)
+        composeRule.setContent {
+            MarkleafTheme(darkTheme = dark.value) {}
+        }
+        composeRule.waitForIdle()
+        assertEquals(LightColorScheme.background.toArgb(), windowBackgroundArgb())
+
+        dark.value = true
+        composeRule.waitForIdle()
+
+        assertEquals(DarkColorScheme.background.toArgb(), windowBackgroundArgb())
+    }
+
+    private fun windowBackgroundArgb(): Int {
+        val background = composeRule.activity.window.decorView.background
+        return (background as ColorDrawable).color
+    }
+}


### PR DESCRIPTION
Closes #354. Reported by @gamersat678 on #345, against v2.35.0 — the release that introduced the Theme setting.

## The defect

**Settings → Appearance → Theme** reached Compose but not the activity window underneath it. `Theme.Markleaf` is declared twice — Material Light in `values/styles.xml`, Material Dark in `values-night/styles.xml` — so the platform chose between them by the `-night` resource qualifier, which is the *system* dark-mode setting and nothing else. A Dark app on a light system kept a white window beneath it.

That window is invisible while an app surface covers it. `MarkleafNavHost`'s cross-fade makes both destinations briefly translucent, and it showed through.

## Measured

`markleaf-phone-api36` emulator, API 36. Average frame luma (`ffmpeg signalstats`, 0–255) across the notes-list → editor transition:

| System | App theme | At rest | During transition |
| --- | --- | --- | --- |
| Light | Dark | 44 | **189** — near-white |
| Dark | Light | 226 | **86** — dark grey |
| Dark | System | 44 | 44–55 — no excursion |
| Light | Dark, **after this change** | 44.6 | **44.6–46.2** |

The matched control has no excursion, which is what makes this the mismatch rather than the animation. The reverse pairing is the same defect mirrored, so the reporter's "it will flicker white" in that direction is really a dark-grey flash — noted back to them on #345.

## The change

`MarkleafTheme` already syncs the system-bar icon appearance on every runtime theme change, for the same class of reason. The window background now rides along in that `SideEffect`, so it tracks the theme through the Settings toggle, a system dark-mode flip, and a palette switch alike.

## Tests

Three, in `ThemeWindowBackgroundTest` — light, dark, and a runtime switch. All three fail with the one line removed; verified by removing it and rerunning, not assumed. The runtime-switch case is the defect's own shape: a background applied once at activity start would be stale from the second frame on.

`:app:testDebugUnitTest` is green.

## What this does not fix

The **starting window**. The system creates it from the app's theme before any app code runs, so a cold start with a mismatched Theme still shows the platform's splash background — measured at 225.7 luma for a Dark app on a light system, unchanged by this commit.

No in-app override can reach it; the fix would be to give the splash a theme-independent background, which is a visual identity decision rather than a defect fix. Left open on #354 with the measurement.

## Verification

Phone emulator (API 36), debug build. Before: the transition is dominated by the white platform background with only the container-transform band in the app's own colour. After: flat at 44.6–46.2 across the same transition, with the app still in Dark on a light system.
