### PR TITLE
feat(widget): a home-screen widget for one chosen note

### DIFF
--- a/app/src/androidTest/java/com/markleaf/notes/widget/SingleNoteWidgetRenderTest.kt
+++ b/app/src/androidTest/java/com/markleaf/notes/widget/SingleNoteWidgetRenderTest.kt
@@ -4,6 +4,8 @@ import android.appwidget.AppWidgetHost
 import android.appwidget.AppWidgetManager
 import android.content.ComponentName
 import android.content.Context
+import android.os.ParcelFileDescriptor
+import android.util.TypedValue
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
@@ -30,15 +32,15 @@ import org.junit.runner.RunWith
  * widget id through `AppWidgetService` and inflates what the launcher would
  * inflate, so the assertions are about the `TextView` a person would look at.
  *
- * Binding needs `BIND_APPWIDGET`, which no app can hold by declaring it:
+ * Binding needs `BIND_APPWIDGET`, which no app can hold by declaring it, so the
+ * test grants it to itself through the instrumentation's shell. Doing that from
+ * the CI workflow is not an option here — the managed device is created and torn
+ * down inside the Gradle task, with no `adb` step in between — and without the
+ * grant these tests skip, which is worse than not having them: a skipped test
+ * looks green while guarding nothing.
  *
- * ```
- * adb shell appwidget grantbind --package com.markleaf.notes.debug --user 0
- * ```
- *
- * Without that grant the bind is refused and these are skipped rather than
- * failed — the code under test is fine, the harness simply is not allowed to
- * stand in for a launcher.
+ * The `assumeTrue` below is the honest fallback for a device where even that is
+ * refused; if it ever fires in CI, the tests are inert and the message says so.
  */
 @RunWith(AndroidJUnit4::class)
 class SingleNoteWidgetRenderTest {
@@ -52,13 +54,29 @@ class SingleNoteWidgetRenderTest {
 
     @Before
     fun setUp() {
+        grantBindPermission()
         InstrumentationRegistry.getInstrumentation().runOnMainSync { host.startListening() }
         appWidgetId = host.allocateAppWidgetId()
         val bound = manager.bindAppWidgetIdIfAllowed(
             appWidgetId,
             ComponentName(context, SingleNoteWidget::class.java)
         )
-        assumeTrue("BIND_APPWIDGET not granted — see the class comment", bound)
+        assumeTrue(
+            "BIND_APPWIDGET was refused even after the shell grant — see the class comment",
+            bound
+        )
+    }
+
+    /**
+     * Stands the test in for a launcher. `executeShellCommand` runs as the shell
+     * user, which is what `appwidget grantbind` requires; the stream has to be
+     * drained or the command may not have finished by the time we bind.
+     */
+    private fun grantBindPermission() {
+        val fd = InstrumentationRegistry.getInstrumentation().uiAutomation.executeShellCommand(
+            "appwidget grantbind --package ${context.packageName} --user 0"
+        )
+        ParcelFileDescriptor.AutoCloseInputStream(fd).use { it.readBytes() }
     }
 
     @After
@@ -80,9 +98,13 @@ class SingleNoteWidgetRenderTest {
 
         assertEquals(BODY, body.text.toString())
         assertEquals(
-            SingleNoteWidgetStore.bodySizeSp(EditorFontSize.EXTRA_LARGE),
-            body.textSize / body.resources.displayMetrics.scaledDensity,
-            0.05f
+            TypedValue.applyDimension(
+                TypedValue.COMPLEX_UNIT_SP,
+                SingleNoteWidgetStore.bodySizeSp(EditorFontSize.EXTRA_LARGE),
+                body.resources.displayMetrics
+            ),
+            body.textSize,
+            0.5f
         )
     }
 

--- a/app/src/androidTest/java/com/markleaf/notes/widget/SingleNoteWidgetRenderTest.kt
+++ b/app/src/androidTest/java/com/markleaf/notes/widget/SingleNoteWidgetRenderTest.kt
@@ -1,0 +1,150 @@
+package com.markleaf.notes.widget
+
+import android.appwidget.AppWidgetHost
+import android.appwidget.AppWidgetManager
+import android.content.ComponentName
+import android.content.Context
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.markleaf.notes.data.local.AppDatabase
+import com.markleaf.notes.data.local.entity.NoteEntity
+import com.markleaf.notes.data.settings.EditorFontSize
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assume.assumeTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * What the single-note widget actually puts on a home screen (#351).
+ *
+ * The Robolectric tests pin the rules — which notes may be drawn, what size the
+ * text becomes — but they build `RemoteViews` and stop there. This binds a real
+ * widget id through `AppWidgetService` and inflates what the launcher would
+ * inflate, so the assertions are about the `TextView` a person would look at.
+ *
+ * Binding needs `BIND_APPWIDGET`, which no app can hold by declaring it:
+ *
+ * ```
+ * adb shell appwidget grantbind --package com.markleaf.notes.debug --user 0
+ * ```
+ *
+ * Without that grant the bind is refused and these are skipped rather than
+ * failed — the code under test is fine, the harness simply is not allowed to
+ * stand in for a launcher.
+ */
+@RunWith(AndroidJUnit4::class)
+class SingleNoteWidgetRenderTest {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val manager = AppWidgetManager.getInstance(context)
+    private val host = AppWidgetHost(context, HOST_ID)
+
+    private var appWidgetId = AppWidgetManager.INVALID_APPWIDGET_ID
+    private val noteId = "single-note-widget-render-test"
+
+    @Before
+    fun setUp() {
+        InstrumentationRegistry.getInstrumentation().runOnMainSync { host.startListening() }
+        appWidgetId = host.allocateAppWidgetId()
+        val bound = manager.bindAppWidgetIdIfAllowed(
+            appWidgetId,
+            ComponentName(context, SingleNoteWidget::class.java)
+        )
+        assumeTrue("BIND_APPWIDGET not granted — see the class comment", bound)
+    }
+
+    @After
+    fun tearDown() {
+        if (appWidgetId != AppWidgetManager.INVALID_APPWIDGET_ID) {
+            host.deleteAppWidgetId(appWidgetId)
+            SingleNoteWidgetStore.forget(context, intArrayOf(appWidgetId))
+        }
+        InstrumentationRegistry.getInstrumentation().runOnMainSync { host.stopListening() }
+        runBlocking { AppDatabase.getInstance(context).noteDao().deleteForever(noteId) }
+    }
+
+    @Test
+    fun theChosenNotesBodyIsDrawnAtTheChosenSize() {
+        seedNote(locked = false)
+        SingleNoteWidgetStore.save(context, appWidgetId, noteId, EditorFontSize.EXTRA_LARGE)
+
+        val body = renderBody()
+
+        assertEquals(BODY, body.text.toString())
+        assertEquals(
+            SingleNoteWidgetStore.bodySizeSp(EditorFontSize.EXTRA_LARGE),
+            body.textSize / body.resources.displayMetrics.scaledDensity,
+            0.05f
+        )
+    }
+
+    /**
+     * The guard that matters: a home screen is visible without unlocking
+     * anything, so a note moved into the Locked space has to stop rendering —
+     * not keep showing the text it had when it was chosen.
+     */
+    @Test
+    fun aNoteLockedAfterItWasChosenStopsShowingItsText() {
+        seedNote(locked = false)
+        SingleNoteWidgetStore.save(context, appWidgetId, noteId, EditorFontSize.MEDIUM)
+        assertEquals(BODY, renderBody().text.toString())
+
+        runBlocking {
+            AppDatabase.getInstance(context).noteDao().setLocked(noteId, true)
+        }
+        val body = renderBody()
+
+        assertEquals(
+            context.getString(com.markleaf.notes.R.string.single_note_widget_unavailable),
+            body.text.toString()
+        )
+    }
+
+    private fun renderBody(): TextView {
+        SingleNoteWidget.updateAppWidget(context, manager, appWidgetId)
+        var found: TextView? = null
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            val hostView = host.createView(context, appWidgetId, manager.getAppWidgetInfo(appWidgetId))
+            hostView.measure(
+                View.MeasureSpec.makeMeasureSpec(600, View.MeasureSpec.EXACTLY),
+                View.MeasureSpec.makeMeasureSpec(600, View.MeasureSpec.EXACTLY)
+            )
+            found = hostView.firstTextView()
+        }
+        return requireNotNull(found) { "The widget inflated without a TextView" }
+    }
+
+    private fun View.firstTextView(): TextView? = when (this) {
+        is TextView -> this
+        is ViewGroup -> (0 until childCount).firstNotNullOfOrNull { getChildAt(it).firstTextView() }
+        else -> null
+    }
+
+    private fun seedNote(locked: Boolean) = runBlocking {
+        AppDatabase.getInstance(context).noteDao().insertNote(
+            NoteEntity(
+                id = noteId,
+                title = "Render test",
+                contentMarkdown = BODY,
+                excerpt = "line one",
+                createdAt = 0L,
+                updatedAt = 0L,
+                locked = locked
+            )
+        )
+        assertNotNull(AppDatabase.getInstance(context).noteDao().getNoteById(noteId))
+    }
+
+    private companion object {
+        const val HOST_ID = 0x4D4C
+        const val BODY = "line one\nline two"
+    }
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -59,8 +59,12 @@
                 android:resource="@xml/file_paths" />
         </provider>
 
+        <!-- Labelled explicitly: without it both widgets fall back to the app
+             name and the picker offers "Markleaf" twice. `quick_note_widget_label`
+             existed unused until the second widget made the pair ambiguous. -->
         <receiver
             android:name=".widget.QuickNoteWidget"
+            android:label="@string/quick_note_widget_label"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
@@ -75,6 +79,32 @@
             android:name=".widget.QuickNoteWidgetService"
             android:permission="android.permission.BIND_REMOTEVIEWS"
             android:exported="false" />
+
+        <!-- One chosen note's text on the home screen (#351). Separate from the
+             recent-notes widget above; both can be placed. -->
+        <receiver
+            android:name=".widget.SingleNoteWidget"
+            android:label="@string/single_note_widget_label"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/single_note_widget_info" />
+        </receiver>
+
+        <!-- Launched by the launcher when the widget is placed, and again for the
+             reconfigure action on Android 12+. exported because the launcher, not
+             the app, starts it. -->
+        <activity
+            android:name=".widget.SingleNoteWidgetConfigureActivity"
+            android:exported="true"
+            android:theme="@style/Theme.Markleaf">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_CONFIGURE" />
+            </intent-filter>
+        </activity>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/markleaf/notes/MainActivity.kt
+++ b/app/src/main/java/com/markleaf/notes/MainActivity.kt
@@ -37,6 +37,7 @@ import com.markleaf.notes.ui.theme.MarkleafTheme
 import com.markleaf.notes.ui.viewmodel.MarkleafViewModelFactory
 import com.markleaf.notes.util.ExternalFile
 import com.markleaf.notes.widget.QuickNoteWidget
+import com.markleaf.notes.widget.SingleNoteWidget
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
@@ -169,8 +170,8 @@ class MainActivity : FragmentActivity() {
 
     override fun onPause() {
         super.onPause()
-        // Nudge the home-screen widget so the recent-notes list reflects any
-        // edits made in this session as soon as the user returns to launcher.
+        // Nudge the home-screen widgets so they reflect any edits made in this
+        // session as soon as the user returns to the launcher.
         runCatching {
             val mgr = android.appwidget.AppWidgetManager.getInstance(applicationContext)
             val ids = mgr.getAppWidgetIds(
@@ -180,6 +181,10 @@ class MainActivity : FragmentActivity() {
                 mgr.notifyAppWidgetViewDataChanged(ids, R.id.widget_list)
             }
         }
+        // The single-note widgets redraw rather than reload a list, and each one
+        // also re-checks that its note may still be shown — a note moved into the
+        // Locked space while the app was open must stop rendering (#351).
+        runCatching { SingleNoteWidget.refreshAll(applicationContext) }
     }
 
     // androidx.activity 1.9 tightened this override to a non-null Intent (it

--- a/app/src/main/java/com/markleaf/notes/feature/editor/EditorScreen.kt
+++ b/app/src/main/java/com/markleaf/notes/feature/editor/EditorScreen.kt
@@ -96,6 +96,7 @@ import com.markleaf.notes.util.ExportUtil
 import com.markleaf.notes.util.HapticFeedback
 import com.markleaf.notes.util.ExportPdf
 import com.markleaf.notes.util.ShareNoteUtil
+import com.markleaf.notes.widget.SingleNoteWidget
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -188,6 +189,13 @@ fun EditorScreen(
                     }
                 }
             }
+            // A single-note widget draws this note's body, so it goes stale the
+            // moment the row changes. MainActivity.onPause also refreshes, but
+            // pressing Home inside the one-second debounce window runs that
+            // refresh *before* this save lands — leaving the old text on the
+            // home screen until the next pause. Refreshing here means the widget
+            // follows the write rather than racing it (#351).
+            SingleNoteWidget.refreshAll(context)
         }
     }
     // Debounced autosave gate: every edit and formatting action bumps it, and

--- a/app/src/main/java/com/markleaf/notes/widget/SingleNoteWidget.kt
+++ b/app/src/main/java/com/markleaf/notes/widget/SingleNoteWidget.kt
@@ -1,0 +1,141 @@
+package com.markleaf.notes.widget
+
+import android.app.PendingIntent
+import android.appwidget.AppWidgetManager
+import android.appwidget.AppWidgetProvider
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.util.TypedValue
+import android.widget.RemoteViews
+import com.markleaf.notes.MainActivity
+import com.markleaf.notes.R
+import com.markleaf.notes.data.local.AppDatabase
+import com.markleaf.notes.data.local.entity.NoteEntity
+import kotlinx.coroutines.runBlocking
+
+/**
+ * Home-screen widget showing the body of one chosen note (#351).
+ *
+ * Distinct from [QuickNoteWidget], which lists the ten most recent notes as
+ * title-plus-one-line rows; the two are placed separately and neither replaces
+ * the other. The note and the text size are chosen per placed widget in
+ * [SingleNoteWidgetConfigureActivity] and kept in [SingleNoteWidgetStore].
+ *
+ * The body is drawn as it was typed — Markdown source, not rendered. A
+ * `RemoteViews` tree can only hold a fixed set of platform views, so `**bold**`
+ * reads as `**bold**` here.
+ */
+class SingleNoteWidget : AppWidgetProvider() {
+
+    override fun onUpdate(
+        context: Context,
+        appWidgetManager: AppWidgetManager,
+        appWidgetIds: IntArray
+    ) {
+        for (appWidgetId in appWidgetIds) {
+            updateAppWidget(context, appWidgetManager, appWidgetId)
+        }
+    }
+
+    /** The launcher reports removed widgets here; their stored note goes with them. */
+    override fun onDeleted(context: Context, appWidgetIds: IntArray) {
+        super.onDeleted(context, appWidgetIds)
+        SingleNoteWidgetStore.forget(context, appWidgetIds)
+    }
+
+    companion object {
+
+        /**
+         * Repaints every placed single-note widget. Called wherever the notes
+         * behind them may have moved — the same points that refresh the
+         * recent-notes list.
+         */
+        fun refreshAll(context: Context) {
+            val manager = AppWidgetManager.getInstance(context)
+            val ids = manager.getAppWidgetIds(
+                ComponentName(context, SingleNoteWidget::class.java)
+            )
+            for (appWidgetId in ids) {
+                updateAppWidget(context, manager, appWidgetId)
+            }
+        }
+
+        fun updateAppWidget(
+            context: Context,
+            appWidgetManager: AppWidgetManager,
+            appWidgetId: Int
+        ) {
+            val views = RemoteViews(context.packageName, R.layout.widget_single_note)
+            val noteId = SingleNoteWidgetStore.noteId(context, appWidgetId)
+            val note = noteId?.let { loadShowableNote(context, it) }
+
+            views.setTextViewText(
+                R.id.single_note_body,
+                note?.takeIf { it.isNotBlank() }
+                    ?: context.getString(R.string.single_note_widget_unavailable)
+            )
+            views.setTextViewTextSize(
+                R.id.single_note_body,
+                TypedValue.COMPLEX_UNIT_SP,
+                SingleNoteWidgetStore.bodySizeSp(
+                    SingleNoteWidgetStore.textSize(context, appWidgetId)
+                )
+            )
+
+            // Tapping opens the note in the app, through the same entry point the
+            // recent-notes rows use. Only offered while there is a note to open.
+            if (noteId != null && note != null) {
+                val pending = PendingIntent.getActivity(
+                    context,
+                    appWidgetId,
+                    openNoteIntent(context, noteId),
+                    // Immutable: nothing fills this in later, unlike the
+                    // recent-notes list, whose template each row completes.
+                    PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+                )
+                views.setOnClickPendingIntent(R.id.single_note_root, pending)
+            }
+
+            appWidgetManager.updateAppWidget(appWidgetId, views)
+        }
+
+        /**
+         * Opens [noteId] in the app — the same entry point the recent-notes rows
+         * use, so a widget tap and a widget-list tap land in the same place.
+         */
+        internal fun openNoteIntent(context: Context, noteId: String): Intent =
+            Intent(context, MainActivity::class.java).apply {
+                action = QuickNoteWidget.ACTION_OPEN_NOTE
+                putExtra(QuickNoteWidget.EXTRA_NOTE_ID, noteId)
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+            }
+
+        /**
+         * The body to draw for [note], or null when nothing may be drawn.
+         *
+         * A note can leave the widget's reach after it was chosen — deleted,
+         * moved to the trash, or moved into the passcode-gated Locked space. The
+         * home screen is visible without unlocking anything, so a locked note's
+         * body can never render here: the picker never offers one, and this is
+         * the guard for a note locked after it was already chosen.
+         *
+         * Separate from the read so the rule is testable without a database.
+         */
+        internal fun showableBody(note: NoteEntity?): String? = when {
+            note == null -> null
+            note.locked -> null
+            note.trashed -> null
+            else -> note.contentMarkdown
+        }
+
+        /**
+         * Runs on the receiver's main thread by way of `onUpdate`; the read is a
+         * single lookup by primary key.
+         */
+        private fun loadShowableNote(context: Context, noteId: String): String? =
+            runBlocking {
+                showableBody(AppDatabase.getInstance(context).noteDao().getNoteById(noteId))
+            }
+    }
+}

--- a/app/src/main/java/com/markleaf/notes/widget/SingleNoteWidget.kt
+++ b/app/src/main/java/com/markleaf/notes/widget/SingleNoteWidget.kt
@@ -47,6 +47,20 @@ class SingleNoteWidget : AppWidgetProvider() {
     companion object {
 
         /**
+         * How much of a note's body reaches the widget.
+         *
+         * `RemoteViews` crosses a Binder transaction, whose payload is capped
+         * around 1 MB for the whole process. An imported note may hold up to
+         * `ExternalFile.MAX_CHARS` — two million characters — and handing that
+         * to `setTextViewText` makes the update throw `TransactionTooLargeException`
+         * instead of drawing anything. Nothing is lost by cutting: even a
+         * full-screen widget at the smallest size shows a few thousand
+         * characters, so this is far past the last legible line, and tapping
+         * opens the whole note.
+         */
+        internal const val MAX_BODY_CHARS = 20_000
+
+        /**
          * Repaints every placed single-note widget. Called wherever the notes
          * behind them may have moved — the same points that refresh the
          * recent-notes list.
@@ -126,7 +140,7 @@ class SingleNoteWidget : AppWidgetProvider() {
             note == null -> null
             note.locked -> null
             note.trashed -> null
-            else -> note.contentMarkdown
+            else -> note.contentMarkdown.take(MAX_BODY_CHARS)
         }
 
         /**

--- a/app/src/main/java/com/markleaf/notes/widget/SingleNoteWidgetConfigureActivity.kt
+++ b/app/src/main/java/com/markleaf/notes/widget/SingleNoteWidgetConfigureActivity.kt
@@ -1,0 +1,224 @@
+package com.markleaf.notes.widget
+
+import android.app.Activity
+import android.appwidget.AppWidgetManager
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.markleaf.notes.R
+import com.markleaf.notes.data.local.AppDatabase
+import com.markleaf.notes.data.repository.LocalNoteRepository
+import com.markleaf.notes.data.settings.AppSettings
+import com.markleaf.notes.data.settings.AppSettingsRepository
+import com.markleaf.notes.data.settings.ColorPalette
+import com.markleaf.notes.data.settings.EditorFont
+import com.markleaf.notes.data.settings.EditorFontSize
+import com.markleaf.notes.data.settings.ThemeMode
+import com.markleaf.notes.domain.model.Note
+import com.markleaf.notes.ui.theme.MarkleafTheme
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.rememberTopAppBarState
+
+/**
+ * Placement screen for [SingleNoteWidget] (#351): choose the note the widget
+ * shows and the size its text is drawn at.
+ *
+ * Reached when the widget is dropped on the home screen, and again from the
+ * launcher's own reconfigure action on Android 12+, where the current choices
+ * arrive preselected.
+ *
+ * The list comes from `observeNotes`, which filters `locked = 0` along with
+ * trashed and archived notes — so the passcode-gated space is never offered to
+ * something drawn on an unlocked home screen. [SingleNoteWidget] guards the
+ * render path as well, for a note locked after it was chosen here.
+ */
+class SingleNoteWidgetConfigureActivity : ComponentActivity() {
+
+    @OptIn(ExperimentalMaterial3Api::class)
+    override fun onCreate(savedInstanceState: Bundle?) {
+        enableEdgeToEdge()
+        super.onCreate(savedInstanceState)
+
+        // Backing out without choosing must leave no widget behind, so the
+        // cancelled result stands until a note is actually picked.
+        setResult(Activity.RESULT_CANCELED)
+
+        val appWidgetId = intent?.extras?.getInt(
+            AppWidgetManager.EXTRA_APPWIDGET_ID,
+            AppWidgetManager.INVALID_APPWIDGET_ID
+        ) ?: AppWidgetManager.INVALID_APPWIDGET_ID
+        if (appWidgetId == AppWidgetManager.INVALID_APPWIDGET_ID) {
+            finish()
+            return
+        }
+
+        val database = AppDatabase.getInstance(applicationContext)
+        val noteRepository = LocalNoteRepository(database)
+        val settingsRepository = AppSettingsRepository(applicationContext)
+        val initialTextSize = SingleNoteWidgetStore.textSize(applicationContext, appWidgetId)
+
+        setContent {
+            val appSettings by settingsRepository.settings.collectAsState(initial = AppSettings())
+            val systemDark = isSystemInDarkTheme()
+            MarkleafTheme(
+                darkTheme = when (appSettings.themeMode) {
+                    ThemeMode.SYSTEM -> systemDark
+                    ThemeMode.LIGHT -> false
+                    ThemeMode.DARK -> true
+                },
+                dynamicColor = appSettings.colorPalette == ColorPalette.MATERIAL_YOU,
+                useSerif = appSettings.editorFont == EditorFont.SERIF
+            ) {
+                val notes by remember { noteRepository.observeNotes() }
+                    .collectAsState(initial = emptyList())
+                var textSize by rememberSaveable { mutableStateOf(initialTextSize) }
+                val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(
+                    rememberTopAppBarState()
+                )
+
+                Scaffold(
+                    modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+                    topBar = {
+                        TopAppBar(
+                            title = { Text(stringResource(R.string.single_note_widget_configure_title)) },
+                            scrollBehavior = scrollBehavior
+                        )
+                    }
+                ) { padding ->
+                    Column(modifier = Modifier.fillMaxSize().padding(padding)) {
+                        TextSizeRow(
+                            selected = textSize,
+                            onSelect = { textSize = it }
+                        )
+                        HorizontalDivider()
+                        if (notes.isEmpty()) {
+                            Text(
+                                text = stringResource(R.string.no_notes_yet),
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.fillMaxWidth().padding(24.dp)
+                            )
+                        } else {
+                            NoteList(
+                                notes = notes,
+                                onPick = { note -> complete(appWidgetId, note.id, textSize) }
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /** Stores the choice, paints the widget with it, and hands the id back. */
+    private fun complete(appWidgetId: Int, noteId: String, textSize: EditorFontSize) {
+        SingleNoteWidgetStore.save(applicationContext, appWidgetId, noteId, textSize)
+        SingleNoteWidget.updateAppWidget(
+            applicationContext,
+            AppWidgetManager.getInstance(applicationContext),
+            appWidgetId
+        )
+        setResult(
+            Activity.RESULT_OK,
+            Intent().putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
+        )
+        finish()
+    }
+}
+
+@Composable
+private fun TextSizeRow(
+    selected: EditorFontSize,
+    onSelect: (EditorFontSize) -> Unit
+) {
+    Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp)) {
+        Text(
+            text = stringResource(R.string.font_size_label),
+            style = MaterialTheme.typography.titleSmall
+        )
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            EditorFontSize.entries.forEach { size ->
+                FilterChip(
+                    selected = size == selected,
+                    onClick = { onSelect(size) },
+                    label = { Text(size.localizedLabel()) }
+                )
+            }
+        }
+        Text(
+            text = stringResource(R.string.single_note_widget_size_description),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(top = 8.dp)
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun NoteList(
+    notes: List<Note>,
+    onPick: (Note) -> Unit
+) {
+    LazyColumn(modifier = Modifier.fillMaxSize()) {
+        items(notes, key = { it.id }) { note ->
+            ListItem(
+                headlineContent = {
+                    Text(note.title.ifBlank { stringResource(R.string.untitled_parenthesized) })
+                },
+                supportingContent = {
+                    if (note.excerpt.isNotBlank()) {
+                        Text(note.excerpt, maxLines = 1)
+                    }
+                },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { onPick(note) }
+            )
+        }
+    }
+}
+
+@Composable
+private fun EditorFontSize.localizedLabel(): String = when (this) {
+    EditorFontSize.SMALL -> stringResource(R.string.font_size_small)
+    EditorFontSize.MEDIUM -> stringResource(R.string.font_size_medium)
+    EditorFontSize.LARGE -> stringResource(R.string.font_size_large)
+    EditorFontSize.EXTRA_LARGE -> stringResource(R.string.font_size_extra_large)
+}

--- a/app/src/main/java/com/markleaf/notes/widget/SingleNoteWidgetConfigureActivity.kt
+++ b/app/src/main/java/com/markleaf/notes/widget/SingleNoteWidgetConfigureActivity.kt
@@ -4,14 +4,14 @@ import android.app.Activity
 import android.appwidget.AppWidgetManager
 import android.content.Intent
 import android.os.Bundle
-import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -37,6 +37,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.fragment.app.FragmentActivity
 import com.markleaf.notes.R
 import com.markleaf.notes.data.local.AppDatabase
 import com.markleaf.notes.data.repository.LocalNoteRepository
@@ -47,6 +48,7 @@ import com.markleaf.notes.data.settings.EditorFont
 import com.markleaf.notes.data.settings.EditorFontSize
 import com.markleaf.notes.data.settings.ThemeMode
 import com.markleaf.notes.domain.model.Note
+import com.markleaf.notes.feature.lock.BiometricLockGate
 import com.markleaf.notes.ui.theme.MarkleafTheme
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
@@ -64,7 +66,7 @@ import androidx.compose.material3.rememberTopAppBarState
  * something drawn on an unlocked home screen. [SingleNoteWidget] guards the
  * render path as well, for a note locked after it was chosen here.
  */
-class SingleNoteWidgetConfigureActivity : ComponentActivity() {
+class SingleNoteWidgetConfigureActivity : FragmentActivity() {
 
     @OptIn(ExperimentalMaterial3Api::class)
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -101,40 +103,49 @@ class SingleNoteWidgetConfigureActivity : ComponentActivity() {
                 dynamicColor = appSettings.colorPalette == ColorPalette.MATERIAL_YOU,
                 useSerif = appSettings.editorFont == EditorFont.SERIF
             ) {
-                val notes by remember { noteRepository.observeNotes() }
-                    .collectAsState(initial = emptyList())
-                var textSize by rememberSaveable { mutableStateOf(initialTextSize) }
-                val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(
-                    rememberTopAppBarState()
-                )
+                // The launcher starts this activity directly, so app lock has to
+                // be honoured here as it is in MainActivity — otherwise placing a
+                // widget is a way to read every note's title and excerpt, and to
+                // publish one note's body to the home screen, without ever
+                // passing the lock.
+                BiometricLockGate(enabled = appSettings.biometricLockEnabled) {
+                    val notes by remember { noteRepository.observeNotes() }
+                        .collectAsState(initial = emptyList())
+                    var textSize by rememberSaveable { mutableStateOf(initialTextSize) }
+                    val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(
+                        rememberTopAppBarState()
+                    )
 
-                Scaffold(
-                    modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
-                    topBar = {
-                        TopAppBar(
-                            title = { Text(stringResource(R.string.single_note_widget_configure_title)) },
-                            scrollBehavior = scrollBehavior
-                        )
-                    }
-                ) { padding ->
-                    Column(modifier = Modifier.fillMaxSize().padding(padding)) {
-                        TextSizeRow(
-                            selected = textSize,
-                            onSelect = { textSize = it }
-                        )
-                        HorizontalDivider()
-                        if (notes.isEmpty()) {
-                            Text(
-                                text = stringResource(R.string.no_notes_yet),
-                                style = MaterialTheme.typography.bodyMedium,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                modifier = Modifier.fillMaxWidth().padding(24.dp)
+                    Scaffold(
+                        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+                        topBar = {
+                            TopAppBar(
+                                title = {
+                                    Text(stringResource(R.string.single_note_widget_configure_title))
+                                },
+                                scrollBehavior = scrollBehavior
                             )
-                        } else {
-                            NoteList(
-                                notes = notes,
-                                onPick = { note -> complete(appWidgetId, note.id, textSize) }
+                        }
+                    ) { padding ->
+                        Column(modifier = Modifier.fillMaxSize().padding(padding)) {
+                            TextSizeRow(
+                                selected = textSize,
+                                onSelect = { textSize = it }
                             )
+                            HorizontalDivider()
+                            if (notes.isEmpty()) {
+                                Text(
+                                    text = stringResource(R.string.no_notes_yet),
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    modifier = Modifier.fillMaxWidth().padding(24.dp)
+                                )
+                            } else {
+                                NoteList(
+                                    notes = notes,
+                                    onPick = { note -> complete(appWidgetId, note.id, textSize) }
+                                )
+                            }
                         }
                     }
                 }
@@ -158,6 +169,7 @@ class SingleNoteWidgetConfigureActivity : ComponentActivity() {
     }
 }
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun TextSizeRow(
     selected: EditorFontSize,
@@ -168,10 +180,13 @@ private fun TextSizeRow(
             text = stringResource(R.string.font_size_label),
             style = MaterialTheme.typography.titleSmall
         )
-        Row(
+        // FlowRow rather than Row: four chips carrying labels like "Extra
+        // grande" or "Vrlo velika" run past the right edge of a narrow phone,
+        // and a chip that is off-screen in a fixed Row cannot be tapped at all.
+        FlowRow(
             modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
             horizontalArrangement = Arrangement.spacedBy(8.dp),
-            verticalAlignment = Alignment.CenterVertically
+            verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
             EditorFontSize.entries.forEach { size ->
                 FilterChip(

--- a/app/src/main/java/com/markleaf/notes/widget/SingleNoteWidgetStore.kt
+++ b/app/src/main/java/com/markleaf/notes/widget/SingleNoteWidgetStore.kt
@@ -1,0 +1,59 @@
+package com.markleaf.notes.widget
+
+import android.content.Context
+import com.markleaf.notes.data.settings.EditorFontSize
+
+/**
+ * Which note each placed [SingleNoteWidget] shows, and at what text size (#351).
+ *
+ * SharedPreferences rather than the app's DataStore: an `onUpdate` runs on the
+ * receiver's main thread and has to answer immediately, and DataStore would mean
+ * blocking a coroutine there for a value this small. Nothing outside the widget
+ * reads it — it is placement state belonging to an id the launcher owns, not a
+ * user setting, which is also why it is a separate file from `markleaf_settings`.
+ *
+ * Entries are keyed by `appWidgetId` and removed in [forget] when the launcher
+ * reports the widget deleted, so removing a widget does not leave its note id
+ * behind.
+ */
+object SingleNoteWidgetStore {
+
+    private const val PREFS_NAME = "single_note_widget"
+    private const val KEY_NOTE_PREFIX = "note_"
+    private const val KEY_TEXT_SIZE_PREFIX = "text_size_"
+
+    /** Text size of the widget's body, in sp, before [EditorFontSize] scaling. */
+    const val BASE_TEXT_SIZE_SP = 14f
+
+    fun noteId(context: Context, appWidgetId: Int): String? =
+        prefs(context).getString(KEY_NOTE_PREFIX + appWidgetId, null)
+
+    fun textSize(context: Context, appWidgetId: Int): EditorFontSize {
+        val stored = prefs(context).getString(KEY_TEXT_SIZE_PREFIX + appWidgetId, null)
+            ?: return EditorFontSize.MEDIUM
+        return EditorFontSize.entries.firstOrNull { it.name == stored } ?: EditorFontSize.MEDIUM
+    }
+
+    fun save(context: Context, appWidgetId: Int, noteId: String, textSize: EditorFontSize) {
+        prefs(context).edit()
+            .putString(KEY_NOTE_PREFIX + appWidgetId, noteId)
+            .putString(KEY_TEXT_SIZE_PREFIX + appWidgetId, textSize.name)
+            .apply()
+    }
+
+    /** Drops every stored value for [appWidgetIds]. Called from `onDeleted`. */
+    fun forget(context: Context, appWidgetIds: IntArray) {
+        val editor = prefs(context).edit()
+        for (appWidgetId in appWidgetIds) {
+            editor.remove(KEY_NOTE_PREFIX + appWidgetId)
+            editor.remove(KEY_TEXT_SIZE_PREFIX + appWidgetId)
+        }
+        editor.apply()
+    }
+
+    /** Body text size in sp for a widget configured at [textSize]. */
+    fun bodySizeSp(textSize: EditorFontSize): Float = BASE_TEXT_SIZE_SP * textSize.scale
+
+    private fun prefs(context: Context) =
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+}

--- a/app/src/main/res/layout/widget_single_note.xml
+++ b/app/src/main/res/layout/widget_single_note.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/single_note_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@drawable/widget_background"
+    android:orientation="vertical"
+    android:padding="12dp">
+
+    <TextView
+        android:id="@+id/single_note_body"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:ellipsize="end"
+        android:lineSpacingMultiplier="1.2"
+        android:textColor="?android:attr/textColorPrimaryInverse"
+        android:textSize="14sp" />
+
+</LinearLayout>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -367,6 +367,11 @@
     <!-- Widget -->
     <string name="quick_note_widget_label">Schnelle Notiz</string>
     <string name="quick_note_widget_description">Tippen, um schnell eine neue Notiz zu erstellen</string>
+    <string name="single_note_widget_label">Einzelne Notiz</string>
+    <string name="single_note_widget_description">Den Text einer Notiz auf dem Startbildschirm anzeigen</string>
+    <string name="single_note_widget_configure_title">Notiz auswählen</string>
+    <string name="single_note_widget_size_description">Gilt nur für dieses Widget. Andere Widgets und der Editor behalten ihre eigene Größe.</string>
+    <string name="single_note_widget_unavailable">Diese Notiz ist nicht mehr verfügbar</string>
 
     <!-- Privacy Dashboard -->
     <string name="privacy_dashboard_title">Datenschutz-Dashboard</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -288,6 +288,11 @@
     <!-- Widget -->
     <string name="quick_note_widget_label">Nota rápida</string>
     <string name="quick_note_widget_description">Toca para crear rápidamente una nueva nota</string>
+    <string name="single_note_widget_label">Nota única</string>
+    <string name="single_note_widget_description">Muestra el texto de una nota en la pantalla de inicio</string>
+    <string name="single_note_widget_configure_title">Elegir una nota</string>
+    <string name="single_note_widget_size_description">Se aplica solo a este widget. Los demás widgets y el editor conservan su propio tamaño.</string>
+    <string name="single_note_widget_unavailable">Esta nota ya no está disponible</string>
 
     <!-- Privacy Dashboard -->
     <string name="privacy_dashboard_title">Panel de privacidad</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -367,6 +367,11 @@
     <!-- Widget -->
     <string name="quick_note_widget_label">Note rapide</string>
     <string name="quick_note_widget_description">Appuyez pour créer rapidement une nouvelle note</string>
+    <string name="single_note_widget_label">Note unique</string>
+    <string name="single_note_widget_description">Affiche le texte d\'une note sur l\'écran d\'accueil</string>
+    <string name="single_note_widget_configure_title">Choisir une note</string>
+    <string name="single_note_widget_size_description">S\'applique uniquement à ce widget. Les autres widgets et l\'éditeur conservent leur propre taille.</string>
+    <string name="single_note_widget_unavailable">Cette note n\'est plus disponible</string>
 
     <!-- Privacy Dashboard -->
     <string name="privacy_dashboard_title">Tableau de bord de confidentialité</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -386,6 +386,11 @@
     <!-- Widget -->
     <string name="quick_note_widget_label">Brza bilješka</string>
     <string name="quick_note_widget_description">Dodirnite za brzo stvaranje nove bilješke</string>
+    <string name="single_note_widget_label">Jedna bilješka</string>
+    <string name="single_note_widget_description">Prikaži tekst jedne bilješke na početnom zaslonu</string>
+    <string name="single_note_widget_configure_title">Odaberite bilješku</string>
+    <string name="single_note_widget_size_description">Primjenjuje se samo na ovaj widget. Ostali widgeti i uređivač zadržavaju vlastitu veličinu.</string>
+    <string name="single_note_widget_unavailable">Ova bilješka više nije dostupna</string>
 
     <!-- Privacy Dashboard -->
     <string name="privacy_dashboard_title">Nadzor privatnosti</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -358,6 +358,11 @@
     <!-- Widget -->
     <string name="quick_note_widget_label">クイックノート</string>
     <string name="quick_note_widget_description">タップしてすぐに新しいノートを作成</string>
+    <string name="single_note_widget_label">単一ノート</string>
+    <string name="single_note_widget_description">ノート 1 件の本文をホーム画面に表示します</string>
+    <string name="single_note_widget_configure_title">ノートを選択</string>
+    <string name="single_note_widget_size_description">このウィジェットにのみ適用されます。他のウィジェットとエディターはそれぞれのサイズを保ちます。</string>
+    <string name="single_note_widget_unavailable">このノートは利用できなくなりました</string>
 
     <!-- Privacy Dashboard -->
     <string name="privacy_dashboard_title">プライバシーダッシュボード</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -358,6 +358,11 @@
     <!-- Widget -->
     <string name="quick_note_widget_label">빠른 노트</string>
     <string name="quick_note_widget_description">탭해서 새 노트 바로 만들기</string>
+    <string name="single_note_widget_label">단일 노트</string>
+    <string name="single_note_widget_description">노트 하나의 내용을 홈 화면에 표시합니다</string>
+    <string name="single_note_widget_configure_title">노트 선택</string>
+    <string name="single_note_widget_size_description">이 위젯에만 적용됩니다. 다른 위젯과 편집기는 각자의 크기를 유지합니다.</string>
+    <string name="single_note_widget_unavailable">이 노트는 더 이상 사용할 수 없습니다</string>
 
     <!-- Privacy Dashboard -->
     <string name="privacy_dashboard_title">개인정보 대시보드</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -364,6 +364,11 @@
     <!-- Widget -->
     <string name="quick_note_widget_label">快速笔记</string>
     <string name="quick_note_widget_description">点击即可快速创建新笔记</string>
+    <string name="single_note_widget_label">单条笔记</string>
+    <string name="single_note_widget_description">在主屏幕上显示一条笔记的正文</string>
+    <string name="single_note_widget_configure_title">选择笔记</string>
+    <string name="single_note_widget_size_description">仅对此小部件生效。其他小部件和编辑器保持各自的大小。</string>
+    <string name="single_note_widget_unavailable">此笔记已不可用</string>
 
     <!-- Privacy Dashboard -->
     <string name="privacy_dashboard_title">隐私面板</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -377,6 +377,11 @@
     <!-- Widget -->
     <string name="quick_note_widget_label">Quick Note</string>
     <string name="quick_note_widget_description">Tap to quickly create a new note</string>
+    <string name="single_note_widget_label">Single Note</string>
+    <string name="single_note_widget_description">Show one note\'s text on the home screen</string>
+    <string name="single_note_widget_configure_title">Choose a note</string>
+    <string name="single_note_widget_size_description">Applies to this widget only. Other widgets and the editor keep their own size.</string>
+    <string name="single_note_widget_unavailable">This note is no longer available</string>
 
     <!-- Privacy Dashboard -->
     <string name="privacy_dashboard_title">Privacy Dashboard</string>

--- a/app/src/main/res/xml/single_note_widget_info.xml
+++ b/app/src/main/res/xml/single_note_widget_info.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:configure="com.markleaf.notes.widget.SingleNoteWidgetConfigureActivity"
+    android:description="@string/single_note_widget_description"
+    android:initialLayout="@layout/widget_single_note"
+    android:minWidth="110dp"
+    android:minHeight="110dp"
+    android:previewImage="@mipmap/ic_launcher"
+    android:resizeMode="horizontal|vertical"
+    android:targetCellWidth="2"
+    android:targetCellHeight="2"
+    android:updatePeriodMillis="0"
+    android:widgetCategory="home_screen"
+    android:widgetFeatures="reconfigurable" />

--- a/app/src/test/java/com/markleaf/notes/AppLockGateTest.kt
+++ b/app/src/test/java/com/markleaf/notes/AppLockGateTest.kt
@@ -1,0 +1,74 @@
+package com.markleaf.notes
+
+import java.io.File
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Every activity a launcher or another app can start, and that can put a note's
+ * text on screen, has to sit behind `BiometricLockGate`.
+ *
+ * `MainActivity` always did. `SingleNoteWidgetConfigureActivity` did not when it
+ * was written: the launcher starts it directly when a widget is dropped, so with
+ * app lock on it listed every note's title and excerpt without authentication,
+ * and choosing one published that note's body to the home screen — a way past
+ * the lock that did not involve the lock at all.
+ *
+ * Nothing else catches this. The gate is a composition, so leaving it out
+ * compiles and renders perfectly well; the only signal is that it is missing.
+ * Same shape as [PendingIntentFlagsTest] and [HardcodedStringTest], and for the
+ * same reason.
+ */
+class AppLockGateTest {
+
+    @Test
+    fun everyExportedNoteShowingActivityIsGated() {
+        val ungated = GATED_ACTIVITIES.filterNot { path ->
+            File("src/main/java/$path").readText().callsGate()
+        }.sorted()
+
+        assertTrue(
+            buildString {
+                appendLine("These activities can show note content but do not wrap it in $GATE.")
+                appendLine("An activity another app can start is a way around app lock unless it")
+                appendLine("asks for authentication itself:")
+                ungated.forEach { appendLine("  - $it") }
+            },
+            ungated.isEmpty()
+        )
+    }
+
+    @Test
+    fun theListItselfStillPointsAtRealFiles() {
+        val missing = GATED_ACTIVITIES.filterNot { File("src/main/java/$it").isFile }
+
+        assertTrue(
+            "Renamed or moved — update GATED_ACTIVITIES: $missing",
+            missing.isEmpty()
+        )
+    }
+
+    /**
+     * The gate has to be *called*, not merely imported. Written the obvious way
+     * first, this test passed with the call deleted, because the leftover
+     * `import …BiometricLockGate` still carried the name — so import lines are
+     * dropped before looking, and the open paren is required.
+     */
+    private fun String.callsGate(): Boolean = lineSequence()
+        .filterNot { it.trimStart().startsWith("import ") }
+        .any { it.contains("$GATE(") }
+
+    private companion object {
+        const val GATE = "BiometricLockGate"
+
+        /**
+         * Kept by hand rather than discovered, because "can show note content"
+         * is not something a scan can decide. Adding an activity that renders
+         * notes means adding it here.
+         */
+        val GATED_ACTIVITIES = listOf(
+            "com/markleaf/notes/MainActivity.kt",
+            "com/markleaf/notes/widget/SingleNoteWidgetConfigureActivity.kt"
+        )
+    }
+}

--- a/app/src/test/java/com/markleaf/notes/widget/SingleNoteWidgetStoreTest.kt
+++ b/app/src/test/java/com/markleaf/notes/widget/SingleNoteWidgetStoreTest.kt
@@ -1,0 +1,66 @@
+package com.markleaf.notes.widget
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.markleaf.notes.data.settings.EditorFontSize
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/** Per-widget placement state for [SingleNoteWidget] (#351). */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class SingleNoteWidgetStoreTest {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    @Test
+    fun `an unconfigured widget has no note and the default size`() {
+        assertNull(SingleNoteWidgetStore.noteId(context, 1))
+        assertEquals(EditorFontSize.MEDIUM, SingleNoteWidgetStore.textSize(context, 1))
+    }
+
+    @Test
+    fun `each widget keeps its own note and size`() {
+        SingleNoteWidgetStore.save(context, 1, "note-a", EditorFontSize.SMALL)
+        SingleNoteWidgetStore.save(context, 2, "note-b", EditorFontSize.EXTRA_LARGE)
+
+        assertEquals("note-a", SingleNoteWidgetStore.noteId(context, 1))
+        assertEquals(EditorFontSize.SMALL, SingleNoteWidgetStore.textSize(context, 1))
+        assertEquals("note-b", SingleNoteWidgetStore.noteId(context, 2))
+        assertEquals(EditorFontSize.EXTRA_LARGE, SingleNoteWidgetStore.textSize(context, 2))
+    }
+
+    /**
+     * Launcher ids are reused, so a removed widget that left its note behind
+     * would hand that note to whatever is placed next.
+     */
+    @Test
+    fun `removing a widget forgets its note`() {
+        SingleNoteWidgetStore.save(context, 1, "note-a", EditorFontSize.LARGE)
+        SingleNoteWidgetStore.save(context, 2, "note-b", EditorFontSize.LARGE)
+
+        SingleNoteWidgetStore.forget(context, intArrayOf(1))
+
+        assertNull(SingleNoteWidgetStore.noteId(context, 1))
+        assertEquals(EditorFontSize.MEDIUM, SingleNoteWidgetStore.textSize(context, 1))
+        assertEquals("note-b", SingleNoteWidgetStore.noteId(context, 2))
+    }
+
+    /**
+     * A size written by a build that had different names — or a corrupted file —
+     * must not stop the widget rendering.
+     */
+    @Test
+    fun `an unrecognised stored size falls back to the default`() {
+        context.getSharedPreferences("single_note_widget", Context.MODE_PRIVATE)
+            .edit()
+            .putString("text_size_7", "GIGANTIC")
+            .apply()
+
+        assertEquals(EditorFontSize.MEDIUM, SingleNoteWidgetStore.textSize(context, 7))
+    }
+}

--- a/app/src/test/java/com/markleaf/notes/widget/SingleNoteWidgetTest.kt
+++ b/app/src/test/java/com/markleaf/notes/widget/SingleNoteWidgetTest.kt
@@ -50,6 +50,27 @@ class SingleNoteWidgetTest {
         assertNull(SingleNoteWidget.showableBody(null))
     }
 
+    /**
+     * `RemoteViews` crosses a Binder transaction with a payload cap around 1 MB
+     * for the whole process, and an imported note may hold `ExternalFile.MAX_CHARS`
+     * — two million characters. Handing that over makes the update throw
+     * `TransactionTooLargeException` instead of drawing, so the body is cut long
+     * after the last line any widget could show.
+     */
+    @Test
+    fun `a very long note is cut before it reaches the parcel`() {
+        val huge = note().copy(contentMarkdown = "x".repeat(2_000_000))
+
+        val body = SingleNoteWidget.showableBody(huge)
+
+        assertEquals(SingleNoteWidget.MAX_BODY_CHARS, body?.length)
+    }
+
+    @Test
+    fun `a note shorter than the cap is untouched`() {
+        assertEquals("# Groceries\n\n- milk", SingleNoteWidget.showableBody(note()))
+    }
+
     @Test
     fun `text size scales the widget body around the medium default`() {
         assertEquals(

--- a/app/src/test/java/com/markleaf/notes/widget/SingleNoteWidgetTest.kt
+++ b/app/src/test/java/com/markleaf/notes/widget/SingleNoteWidgetTest.kt
@@ -1,0 +1,107 @@
+package com.markleaf.notes.widget
+
+import android.appwidget.AppWidgetManager
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.markleaf.notes.MainActivity
+import com.markleaf.notes.R
+import com.markleaf.notes.data.local.entity.NoteEntity
+import com.markleaf.notes.data.settings.EditorFontSize
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+/**
+ * The single-note widget's two rules (#351): which notes may be drawn on a home
+ * screen, and how the chosen text size becomes a size in sp.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class SingleNoteWidgetTest {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    @Test
+    fun `an ordinary note contributes its body`() {
+        assertEquals("# Groceries\n\n- milk", SingleNoteWidget.showableBody(note()))
+    }
+
+    /**
+     * The home screen is visible without unlocking anything, so a note moved into
+     * the passcode-gated space after it was chosen must stop rendering rather
+     * than keep showing the text it had when it was picked.
+     */
+    @Test
+    fun `a locked note contributes nothing`() {
+        assertNull(SingleNoteWidget.showableBody(note(locked = true)))
+    }
+
+    @Test
+    fun `a trashed note contributes nothing`() {
+        assertNull(SingleNoteWidget.showableBody(note(trashed = true)))
+    }
+
+    @Test
+    fun `a deleted note contributes nothing`() {
+        assertNull(SingleNoteWidget.showableBody(null))
+    }
+
+    @Test
+    fun `text size scales the widget body around the medium default`() {
+        assertEquals(
+            SingleNoteWidgetStore.BASE_TEXT_SIZE_SP,
+            SingleNoteWidgetStore.bodySizeSp(EditorFontSize.MEDIUM),
+            0.001f
+        )
+        assertEquals(12.25f, SingleNoteWidgetStore.bodySizeSp(EditorFontSize.SMALL), 0.001f)
+        assertEquals(15.75f, SingleNoteWidgetStore.bodySizeSp(EditorFontSize.LARGE), 0.001f)
+        assertEquals(17.5f, SingleNoteWidgetStore.bodySizeSp(EditorFontSize.EXTRA_LARGE), 0.001f)
+    }
+
+    /**
+     * A widget tap has to land in the same place a recent-notes row does —
+     * `MainActivity` already handles this action, including when it is already
+     * running, so the widget adds no second way of opening a note.
+     */
+    @Test
+    fun `tapping the widget opens its note through the shared entry point`() {
+        val intent = SingleNoteWidget.openNoteIntent(context, "note-1")
+
+        assertEquals(QuickNoteWidget.ACTION_OPEN_NOTE, intent.action)
+        assertEquals("note-1", intent.getStringExtra(QuickNoteWidget.EXTRA_NOTE_ID))
+        assertEquals(
+            MainActivity::class.java.name,
+            intent.component?.className
+        )
+    }
+
+    /**
+     * A smoke test of the same shape as [QuickNoteWidgetTest], and with the same
+     * reach: it exercises the whole of `updateAppWidget` — including an
+     * unconfigured widget, which is the state every widget is in for the moment
+     * between being dropped and the picker returning.
+     */
+    @Test
+    fun `building the widget views does not throw`() {
+        val manager = AppWidgetManager.getInstance(context)
+        val ids = shadowOf(manager)
+            .createWidgets(SingleNoteWidget::class.java, R.layout.widget_single_note, 1)
+
+        SingleNoteWidget.updateAppWidget(context, manager, ids.first())
+    }
+
+    private fun note(locked: Boolean = false, trashed: Boolean = false) = NoteEntity(
+        id = "note-1",
+        title = "Groceries",
+        contentMarkdown = "# Groceries\n\n- milk",
+        excerpt = "- milk",
+        createdAt = 0L,
+        updatedAt = 0L,
+        locked = locked,
+        trashed = trashed
+    )
+}


### PR DESCRIPTION
Closes #351. Requested by @ray4423, who confirmed on the thread that they wanted a **single-note widget** rather than a longer preview in the existing one, and asked for a widget text size while they were there.

## What this adds

A second widget. The recent-notes widget is a different shape — ten rows of title plus a stored 100-character summary — so this does not replace it; both can be placed, and neither affects the other.

- Placing it opens a picker: **choose the note, choose the text size**.
- The widget shows that note's body. Tapping it opens the note, through the same entry point a recent-notes row uses.
- The text is drawn **as it was typed** — Markdown source, not rendered. A `RemoteViews` tree holds a fixed set of platform views, so `**bold**` reads as `**bold**`. Stated on the issue up front rather than left to be discovered.

## Text size is per widget

The widget's sizes were fixed in its layout, which is why **Settings → Markdown → Text size** never reached one. Rather than making widgets follow that setting, each widget carries its own: two widgets at different sizes on one home screen is a reasonable thing to want, and a widget's constraints have nothing to do with the editor's.

It reuses `EditorFontSize`'s four steps and their existing strings, scaled around a 14sp widget body rather than the editor's 16sp — so no new enum, no new vocabulary.

## Locked notes, both sides

The picker reads `observeNotes`, which already filters `locked = 0`, so the passcode-gated space is never offered. `showableBody` is the guard for the other direction — a note moved into Locked **after** it was chosen — because a home screen is visible without unlocking anything. Trashed and deleted notes take the same path, and the widget says so rather than going blank.

## Placement state

`SharedPreferences`, not the app's DataStore: `onUpdate` runs on the receiver's main thread and has to answer immediately. `onDeleted` drops the entry, so a launcher reusing an id does not inherit someone else's note.

## Both receivers are now labelled

Without `android:label` they fall back to the app name, and the picker offered "Markleaf" twice. `quick_note_widget_label` had existed unused since v2.16.0; the second widget is what made the pair ambiguous.

## Tests

- `SingleNoteWidgetTest` — the render rule (ordinary / locked / trashed / deleted), the sp mapping for all four sizes, the open-note intent, and a smoke test of `updateAppWidget` including the unconfigured state every widget passes through.
- `SingleNoteWidgetStoreTest` — per-widget isolation, the default, `onDeleted` cleanup, and an unrecognised stored size falling back rather than throwing.
- `SingleNoteWidgetRenderTest` (instrumented) — binds a real widget id through `AppWidgetService` and inflates what a launcher would inflate, asserting the body text and its size **on the actual `TextView`**, and that a note locked afterwards stops showing its text. It skips rather than fails where `BIND_APPWIDGET` has not been granted, since that is the harness lacking a permission rather than the code being wrong.

`:app:testDebugUnitTest`, `:app:lintDebug` and `scripts/verify-locales.ps1` are green. Strings are translated into all seven other locales.

## Verification

Phone emulator (API 36). The picker lists **Single Note** and **Quick Note** by name with the right descriptions; the configure screen renders in the app's own theme, lists the non-locked notes, and choosing *Large* plus a note writes `note_999` / `text_size_999`. The instrumented tests ran with `skipped="0"`.

**Not verified on device:** the drag from the widget picker onto the home screen — Launcher3 does not accept it from synthetic input (`input draganddrop` and a hand-built `motionevent` sequence both failed to place anything). The bind and the render on either side of that step are what the instrumented test covers.

## Known limit

Reconfiguring a placed widget — changing the note or the size without removing and re-adding it — is `widgetFeatures="reconfigurable"`, which Android supports from **12** onward. Below that, re-placing is the way. Flagged to the reporter on the issue.


---

## Review round (fc34078)

Codex raised four findings. All four were checked against the code, all four were real, and all four are fixed in `fc34078`:

- **P1 — app lock did not cover the picker.** The launcher starts the configure activity directly, and unlike `MainActivity` it never wrapped its content in `BiometricLockGate`: with app lock on, placing a widget listed every note's title and excerpt without authentication, and choosing one published that note's body to the home screen. Now a `FragmentActivity` behind the same gate, with `AppLockGateTest` guarding it.
- **P2 — the body could outgrow a Binder transaction.** An imported note may hold `ExternalFile.MAX_CHARS` (2,000,000); handing that to `setTextViewText` throws `TransactionTooLargeException` instead of drawing. Cut at 20,000 characters.
- **P2 — the widget could show text older than the note.** Pressing Home inside the editor's one-second autosave debounce ran the `onPause` refresh *before* the save landed. The refresh now also runs after `autosave` persists.
- **P2 — a size chip could sit off-screen.** Four chips in a fixed `Row` overflow a narrow phone once localized ("Extra grande", "Sehr groß", "Vrlo velika"). `FlowRow` instead — verified in Spanish at 308dp, where "Extra grande" wraps and stays tappable.

`AppLockGateTest` is worth a note: written as a plain substring scan it passed with the gate call deleted, because the leftover import still carried the name. It now drops import lines and requires the call, verified by removing the gate and rerunning.

**Still not covered on device:** the app-lock gate itself — the emulator has no enrolled biometric, so what runs there is the fail-open path. It is the same composable `MainActivity` has always used, and the test is what guards the composition.
