### PR TITLE
fix(theme): make the cold-start splash follow the app's Theme

### DIFF
--- a/app/src/main/java/com/markleaf/notes/MainActivity.kt
+++ b/app/src/main/java/com/markleaf/notes/MainActivity.kt
@@ -1,12 +1,15 @@
 package com.markleaf.notes
 
+import android.app.UiModeManager
 import android.content.Intent
+import android.content.res.Configuration
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.view.WindowManager
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.annotation.RequiresApi
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.fragment.app.FragmentActivity
 import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
@@ -117,6 +120,27 @@ class MainActivity : FragmentActivity() {
             }
         }
 
+        // Tell the system which night mode this app is in, so the *starting
+        // window* — the splash the system draws before any app code runs — is
+        // resolved with the Theme the user chose rather than the phone's
+        // dark-mode setting. #354 fixed the window the app itself owns; this is
+        // the one it does not, and nothing an activity does later can reach it.
+        //
+        // setApplicationNightMode persists the -night qualifier for this app, so
+        // the effect is on the *next* cold start rather than this one. API 31+;
+        // below that the splash keeps following the system, which is what every
+        // version has done so far.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            lifecycleScope.launch {
+                repeatOnLifecycle(Lifecycle.State.STARTED) {
+                    settingsRepository.settings
+                        .map { it.themeMode }
+                        .distinctUntilChanged()
+                        .collect(::applyApplicationNightMode)
+                }
+            }
+        }
+
         val shouldCreateNote = intent.action == QuickNoteWidget.ACTION_CREATE_NOTE
         val openNoteId = if (intent.action == QuickNoteWidget.ACTION_OPEN_NOTE) {
             intent.getStringExtra(QuickNoteWidget.EXTRA_NOTE_ID)
@@ -165,6 +189,39 @@ class MainActivity : FragmentActivity() {
                     }
                 }
             }
+        }
+    }
+
+    /**
+     * Hands [mode] to the system as this app's night mode (#354).
+     *
+     * `MODE_NIGHT_AUTO` is what returns a Theme of [ThemeMode.SYSTEM] to
+     * following the device, which is why SYSTEM maps to it rather than to
+     * "leave whatever was set last".
+     *
+     * Only called when the mode actually changes — the flow is
+     * `distinctUntilChanged`, and the check below drops the redundant call on
+     * every launch, because the setting arrives once per process whether or not
+     * the user touched it and each real call is a configuration change.
+     */
+    @RequiresApi(Build.VERSION_CODES.S)
+    private fun applyApplicationNightMode(mode: ThemeMode) {
+        val manager = getSystemService(UiModeManager::class.java) ?: return
+        val desired = mode.toApplicationNightMode()
+        val nightNow = resources.configuration.uiMode and
+            Configuration.UI_MODE_NIGHT_MASK == Configuration.UI_MODE_NIGHT_YES
+        val alreadyThere = when (desired) {
+            UiModeManager.MODE_NIGHT_YES -> nightNow
+            UiModeManager.MODE_NIGHT_NO -> !nightNow
+            // SYSTEM cannot be read back — there is no getApplicationNightMode —
+            // so it is re-applied once per process. Measured on an API 36
+            // emulator: with the Theme on System, a cold start logs one
+            // "Displayed MainActivity" and no relaunch, so the redundant call
+            // costs nothing visible.
+            else -> false
+        }
+        if (!alreadyThere) {
+            runCatching { manager.setApplicationNightMode(desired) }
         }
     }
 
@@ -265,4 +322,23 @@ class MainActivity : FragmentActivity() {
      */
     private fun readNoteFromUri(uri: Uri): String? =
         ExternalFile.read(this, uri)?.let(ExternalFile::noteBody)
+}
+
+/**
+ * The `UiModeManager` night mode that makes the system resolve this app — and
+ * the starting window it draws before the app runs — the way [this] asks (#354).
+ *
+ * [ThemeMode.SYSTEM] maps to `MODE_NIGHT_AUTO` rather than to "leave the last
+ * override in place", and that mapping is the part worth pinning: there is no
+ * `getApplicationNightMode` and the documentation describes AUTO in terms of
+ * location and sensors, so whether it releases an app-local override is not
+ * something the API tells you. Measured on an API 36 emulator: after the Theme
+ * had been set to Dark on a light phone, switching back to System returned the
+ * cold-start splash to 229.6/255 average luma on a light system and 66.2 on a
+ * dark one — i.e. following the device again in both directions.
+ */
+internal fun ThemeMode.toApplicationNightMode(): Int = when (this) {
+    ThemeMode.SYSTEM -> UiModeManager.MODE_NIGHT_AUTO
+    ThemeMode.LIGHT -> UiModeManager.MODE_NIGHT_NO
+    ThemeMode.DARK -> UiModeManager.MODE_NIGHT_YES
 }

--- a/app/src/main/java/com/markleaf/notes/MainActivity.kt
+++ b/app/src/main/java/com/markleaf/notes/MainActivity.kt
@@ -2,7 +2,6 @@ package com.markleaf.notes
 
 import android.app.UiModeManager
 import android.content.Intent
-import android.content.res.Configuration
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
@@ -207,22 +206,20 @@ class MainActivity : FragmentActivity() {
     @RequiresApi(Build.VERSION_CODES.S)
     private fun applyApplicationNightMode(mode: ThemeMode) {
         val manager = getSystemService(UiModeManager::class.java) ?: return
-        val desired = mode.toApplicationNightMode()
-        val nightNow = resources.configuration.uiMode and
-            Configuration.UI_MODE_NIGHT_MASK == Configuration.UI_MODE_NIGHT_YES
-        val alreadyThere = when (desired) {
-            UiModeManager.MODE_NIGHT_YES -> nightNow
-            UiModeManager.MODE_NIGHT_NO -> !nightNow
-            // SYSTEM cannot be read back — there is no getApplicationNightMode —
-            // so it is re-applied once per process. Measured on an API 36
-            // emulator: with the Theme on System, a cold start logs one
-            // "Displayed MainActivity" and no relaunch, so the redundant call
-            // costs nothing visible.
-            else -> false
-        }
-        if (!alreadyThere) {
-            runCatching { manager.setApplicationNightMode(desired) }
-        }
+        // Unconditional on purpose. The effective `uiMode` says what the app is
+        // rendering, not whether an override has been *persisted* — picking Dark
+        // while the phone is already dark matches without storing anything, and
+        // the next system flip would then resolve the splash from the phone
+        // again. There is no getApplicationNightMode to ask, so the setting is
+        // re-asserted once per process; measured on an API 36 emulator, a cold
+        // start in each of the three modes logs one "Displayed MainActivity" and
+        // no relaunch, so re-asserting an unchanged mode costs nothing.
+        //
+        // Not wrapped in runCatching: every value this can pass is in the
+        // platform's own @NightMode IntDef, so a throw here would mean the
+        // system server died — not something to hide from the user by leaving
+        // the Theme silently unapplied.
+        manager.setApplicationNightMode(mode.toApplicationNightMode())
     }
 
     override fun onPause() {

--- a/app/src/test/java/com/markleaf/notes/ApplicationNightModeTest.kt
+++ b/app/src/test/java/com/markleaf/notes/ApplicationNightModeTest.kt
@@ -1,0 +1,53 @@
+package com.markleaf.notes
+
+import android.app.UiModeManager
+import com.markleaf.notes.data.settings.ThemeMode
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Which night mode the app hands the system for each Theme (#354).
+ *
+ * This is what reaches the *starting window* — the splash the system draws
+ * before any app code runs, and the one thing the in-app window repaint could
+ * not touch. Getting a value wrong here does not fail anything at build time
+ * and shows up only as a splash in the wrong colour on the launch *after* the
+ * setting is changed, which is a slow way to find out.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class ApplicationNightModeTest {
+
+    @Test
+    fun `dark asks the system for night`() {
+        assertEquals(UiModeManager.MODE_NIGHT_YES, ThemeMode.DARK.toApplicationNightMode())
+    }
+
+    @Test
+    fun `light asks the system for notnight`() {
+        assertEquals(UiModeManager.MODE_NIGHT_NO, ThemeMode.LIGHT.toApplicationNightMode())
+    }
+
+    /**
+     * The one that is not obvious. There is no `getApplicationNightMode`, and
+     * `MODE_NIGHT_AUTO` is documented in terms of location and sensors rather
+     * than as "release the app override" — so this is the value that had to be
+     * established on a device rather than read off the API, and the one a future
+     * reader is most likely to talk themselves out of.
+     */
+    @Test
+    fun `system releases the override instead of leaving the last one in place`() {
+        assertEquals(UiModeManager.MODE_NIGHT_AUTO, ThemeMode.SYSTEM.toApplicationNightMode())
+    }
+
+    /** Every mode maps to something; a new one must not fall through. */
+    @Test
+    fun `every theme mode has a night mode`() {
+        val modes = ThemeMode.entries.map { it.toApplicationNightMode() }
+
+        assertEquals(ThemeMode.entries.size, modes.distinct().size)
+    }
+}


### PR DESCRIPTION
Closes the splash item left open on [#354](https://github.com/jeiel85/markleaf-android/issues/354#issuecomment-5507641998) and carried as the first entry of the `## v2.36.0` section on [#262](https://github.com/jeiel85/markleaf-android/issues/262).

## What was left

#355 gave the activity's window the colour the app's theme resolved to, which removed the flash between the notes list and a note. It could not reach the **starting window** — the splash the system draws before any app code runs — because the system resolves that from the app's theme against the app's configuration, and the app has not started yet. A Dark Markleaf on a light phone still opened on a white splash at **225.7**/255 average luma, against 44 once the app drew.

The write-up on #354 concluded that the only fix was a theme-independent splash background, and framed it as a visual identity decision. **That conclusion was wrong**, and the reason it was wrong is worth stating: it assumed nothing could tell the system what the app's night mode is. `UiModeManager.setApplicationNightMode` does exactly that — it *persists* the `-night` qualifier for the application — so the splash can follow the Theme setting instead of being repainted a fixed colour for everyone.

## Measured

API 36 emulator, cold-start splash luma (0–255):

| System | Theme | Before | After |
| --- | --- | --- | --- |
| Light | **Dark** | 225.7 — white | **66.2** |
| Dark | **Light** | dark | **229.6** |
| Light | System | 229.6 | 229.6 — unchanged |
| Dark | System | 66.2 | 66.2 — unchanged |

Nobody whose Theme already matches their system sees any change, which is what a fixed brand colour could not have offered.

## The System mapping had to be measured, not read

There is no `getApplicationNightMode`, and `MODE_NIGHT_AUTO` is documented in terms of "the device's current location and certain other sensors" — not as "release the app-local override". Whether choosing **System** after having chosen **Dark** actually hands control back was therefore an open question, and a wrong answer would have stranded users on a mode they had turned off.

It does release it. After setting Dark on a light phone, switching back to System returned the cold-start splash to 229.6 on a light system and 66.2 on a dark one — following the device in both directions. `ApplicationNightModeTest` pins that value with the reasoning attached, because it is the one a future reader is most likely to talk themselves out of.

## Cost of the call

Skipped when the app's configuration already matches, so it runs at most once per process. **System** cannot be read back and so is re-applied on each launch; a cold start with the Theme on System logs one `Displayed … MainActivity` and no relaunch, so the redundant call costs nothing visible. Checked in logcat rather than assumed.

## Reach

API 31+. Below that the splash keeps following the system, which is what every released version has done — no regression for those devices, and no behaviour to explain to anyone on them.

`:app:testDebugUnitTest` and `:app:lintDebug` green.
