### PR TITLE
fix: preserve external file timestamps on import

### DIFF
--- a/.agent/decisions.md
+++ b/.agent/decisions.md
@@ -1189,3 +1189,17 @@ Implications:
 - 스키마 변경은 명시적 Room migration으로 처리한다.
 - 메모 앱의 핵심 데이터인 노트, 태그, 링크는 앱 업데이트 때문에 삭제되면 안 된다.
 - 오래된 개발 빌드와 호환이 불가능한 경우에도 정식 릴리즈 경로는 데이터 보존을 우선한다.
+
+### D020 - Preserve External File Time at Import
+
+When an external Markdown file is explicitly kept as a Markleaf note, preserve
+its source time without writing back to the file.
+
+Implications:
+
+- Capture the provider's last-modified value before opening the input stream.
+- If Markleaf frontmatter contains `created_at` or `updated_at`, those explicit
+  values take precedence for the corresponding note fields.
+- For ordinary providers that expose only a modification time, use that value
+  for both note timestamps; SAF has no portable creation-time column.
+- Read-only viewing never writes to the source URI.

--- a/.agent/progress.md
+++ b/.agent/progress.md
@@ -2610,3 +2610,23 @@ Files changed:
 
 Build/test result:
 - Not run locally (workflow/config change)
+
+---
+
+## 2026-09-06 - GitHub Issue #363 Timestamp Preservation
+
+Selected task:
+- GitHub issue #363: preserve source timestamps when an external Markdown file is explicitly imported
+
+What was implemented:
+- Capture the provider's last-modified timestamp before opening the input stream.
+- Preserve Markleaf `created_at` / `updated_at` frontmatter when present.
+- Use the captured source modification time for both note timestamps when the provider exposes no Markleaf frontmatter.
+- Apply the same timestamp-aware import seed to `Open file…` → `Save as note` and `ACTION_SEND` file imports.
+- Added regression tests for ordinary files and Markleaf frontmatter timestamps.
+
+Issue response:
+- Thanked external reporter @ray4423 on issue #363 and explained the investigation path.
+
+Verification:
+- `./gradlew :app:testDebugUnitTest :app:lintRelease` — passed.

--- a/app/src/main/java/com/markleaf/notes/MainActivity.kt
+++ b/app/src/main/java/com/markleaf/notes/MainActivity.kt
@@ -43,6 +43,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.time.Instant
 
 class MainActivity : FragmentActivity() {
     @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
@@ -120,7 +121,7 @@ class MainActivity : FragmentActivity() {
         val openNoteId = if (intent.action == QuickNoteWidget.ACTION_OPEN_NOTE) {
             intent.getStringExtra(QuickNoteWidget.EXTRA_NOTE_ID)
         } else null
-        val sharedText = extractInitialContent(intent)
+        val sharedContent = extractInitialContent(intent)
         // A file opened from elsewhere (ACTION_VIEW) is shown for reading rather
         // than imported (#326); sharing one in (ACTION_SEND) still means "take
         // this", and keeps creating a note.
@@ -149,7 +150,9 @@ class MainActivity : FragmentActivity() {
                         windowSizeClass = windowSizeClass,
                         viewModelFactory = viewModelFactory,
                         shouldCreateNote = shouldCreateNote,
-                        sharedText = sharedText,
+                        sharedText = sharedContent?.body,
+                        sharedCreatedAt = sharedContent?.createdAt,
+                        sharedUpdatedAt = sharedContent?.updatedAt,
                         openNoteId = openNoteId,
                         viewFileUri = viewFileUri
                     )
@@ -224,10 +227,17 @@ class MainActivity : FragmentActivity() {
      * and importing wrote a note and, with folder sync on, a second copy of the
      * file, for every file merely looked at. Keeping it is one tap in the viewer.
      */
-    private fun extractInitialContent(intent: Intent?): String? {
+    private data class ImportedContent(
+        val body: String,
+        val createdAt: Instant?,
+        val updatedAt: Instant?
+    )
+
+    private fun extractInitialContent(intent: Intent?): ImportedContent? {
         intent ?: return null
         if (intent.action != Intent.ACTION_SEND) return null
-        return intent.streamUri()?.let(::readNoteFromUri) ?: extractSharedText(intent)
+        return intent.streamUri()?.let(::readNoteFromUri)
+            ?: extractSharedText(intent)?.let { ImportedContent(it, null, null) }
     }
 
     private fun extractSharedText(intent: Intent?): String? {
@@ -258,6 +268,8 @@ class MainActivity : FragmentActivity() {
      * — the size cap, and seeding the title from the file name — live in
      * [ExternalFile], which the file viewer reads through as well.
      */
-    private fun readNoteFromUri(uri: Uri): String? =
-        ExternalFile.read(this, uri)?.let(ExternalFile::noteBody)
+    private fun readNoteFromUri(uri: Uri): ImportedContent? =
+        ExternalFile.read(this, uri)?.let(ExternalFile::noteSeed)?.let {
+            ImportedContent(it.body, it.createdAt, it.updatedAt)
+        }
 }

--- a/app/src/main/java/com/markleaf/notes/feature/viewer/FileViewerScreen.kt
+++ b/app/src/main/java/com/markleaf/notes/feature/viewer/FileViewerScreen.kt
@@ -40,6 +40,7 @@ import com.markleaf.notes.core.markdown.PreviewLine
 import com.markleaf.notes.util.ExternalFile
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import java.time.Instant
 
 /**
  * Reading one file that is not a note (#326).
@@ -62,7 +63,9 @@ sealed interface FileViewerState {
         val displayName: String?,
         val lines: List<PreviewLine>,
         /** What [FileViewerScreen]'s save action hands back — title seeding included. */
-        val noteBody: String
+        val noteBody: String,
+        val createdAt: Instant? = null,
+        val updatedAt: Instant? = null
     ) : FileViewerState
 
     /** Moved, deleted, not text, or a permission that lapsed while the app was away. */
@@ -73,7 +76,7 @@ sealed interface FileViewerState {
 fun FileViewerScreen(
     uri: Uri,
     onBack: () -> Unit = {},
-    onSaveAsNote: (String) -> Unit = {},
+    onSaveAsNote: (String, Instant?, Instant?) -> Unit = { _, _, _ -> },
     contentMaxWidth: Dp = Dp.Unspecified
 ) {
     val context = LocalContext.current
@@ -86,10 +89,13 @@ fun FileViewerScreen(
         state = withContext(Dispatchers.IO) {
             val document = ExternalFile.read(context, uri)
                 ?: return@withContext FileViewerState.Unreadable
+            val noteSeed = ExternalFile.noteSeed(document)
             FileViewerState.Loaded(
                 displayName = document.displayName,
                 lines = SimpleMarkdownPreview.parse(document.text),
-                noteBody = ExternalFile.noteBody(document)
+                noteBody = noteSeed.body,
+                createdAt = noteSeed.createdAt,
+                updatedAt = noteSeed.updatedAt
             )
         }
     }
@@ -107,7 +113,7 @@ fun FileViewerScreen(
 internal fun FileViewerContent(
     state: FileViewerState,
     onBack: () -> Unit = {},
-    onSaveAsNote: (String) -> Unit = {},
+    onSaveAsNote: (String, Instant?, Instant?) -> Unit = { _, _, _ -> },
     /** The reading measure the editor honours on wide screens; unconstrained on a phone. */
     contentMaxWidth: Dp = Dp.Unspecified
 ) {
@@ -145,7 +151,9 @@ internal fun FileViewerContent(
                 },
                 actions = {
                     if (state is FileViewerState.Loaded) {
-                        IconButton(onClick = { onSaveAsNote(state.noteBody) }) {
+                        IconButton(onClick = {
+                            onSaveAsNote(state.noteBody, state.createdAt, state.updatedAt)
+                        }) {
                             Icon(
                                 Icons.AutoMirrored.Outlined.NoteAdd,
                                 contentDescription = stringResource(R.string.file_viewer_save_as_note)

--- a/app/src/main/java/com/markleaf/notes/navigation/MarkleafNavHost.kt
+++ b/app/src/main/java/com/markleaf/notes/navigation/MarkleafNavHost.kt
@@ -87,6 +87,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.time.Instant
 
 // Scopes for the list-card -> editor shared-element (container transform). They
 // are only non-null on the phone navigation path (provided around the NavHost
@@ -103,6 +104,8 @@ fun MarkleafNavHost(
     viewModelFactory: ViewModelProvider.Factory,
     shouldCreateNote: Boolean = false,
     sharedText: String? = null,
+    sharedCreatedAt: Instant? = null,
+    sharedUpdatedAt: Instant? = null,
     openNoteId: String? = null,
     viewFileUri: String? = null
 ) {
@@ -146,7 +149,12 @@ fun MarkleafNavHost(
                 // state: this effect runs on the first composition, where
                 // `appSettings` is still the initial default (#280).
                 val titleSource = settingsRepository.settings.first().noteTitleSource
-                val newNote = intentEntryViewModel.createNote(sharedText, titleSource)
+                val newNote = intentEntryViewModel.createNote(
+                    initialContent = sharedText,
+                    titleSource = titleSource,
+                    createdAt = sharedCreatedAt,
+                    updatedAt = sharedUpdatedAt
+                )
                 navController.navigateOnMain(NavRoutes.editorRoute(newNote.id))
             }
             !openNoteId.isNullOrBlank() -> {
@@ -522,10 +530,15 @@ fun MarkleafNavHost(
                 uri = uri,
                 contentMaxWidth = appSettings.lineWidth.maxWidthDp.dp,
                 onBack = { navController.popBackStack() },
-                onSaveAsNote = { body ->
+                onSaveAsNote = { body, createdAt, updatedAt ->
                     coroutineScope.launch {
                         val titleSource = settingsRepository.settings.first().noteTitleSource
-                        val newNote = viewerViewModel.createNote(body, titleSource)
+                        val newNote = viewerViewModel.createNote(
+                            initialContent = body,
+                            titleSource = titleSource,
+                            createdAt = createdAt,
+                            updatedAt = updatedAt
+                        )
                         withContext(Dispatchers.Main.immediate) {
                             navController.navigate(NavRoutes.editorRoute(newNote.id)) {
                                 // The file has been kept; backing out of the new

--- a/app/src/main/java/com/markleaf/notes/ui/viewmodel/NotesViewModel.kt
+++ b/app/src/main/java/com/markleaf/notes/ui/viewmodel/NotesViewModel.kt
@@ -62,8 +62,11 @@ class NotesViewModel(
      */
     suspend fun createNote(
         initialContent: String = "",
-        titleSource: NoteTitleSource = NoteTitleSource.FIRST_HEADING
+        titleSource: NoteTitleSource = NoteTitleSource.FIRST_HEADING,
+        createdAt: Instant? = null,
+        updatedAt: Instant? = null
     ): Note {
+        val now = Instant.now()
         val newNote = Note(
             id = UUID.randomUUID().toString(),
             title = if (initialContent.isBlank()) {
@@ -77,8 +80,8 @@ class NotesViewModel(
             } else {
                 TitleExtractor.generateExcerpt(initialContent, titleSource)
             },
-            createdAt = Instant.now(),
-            updatedAt = Instant.now()
+            createdAt = createdAt ?: updatedAt ?: now,
+            updatedAt = updatedAt ?: createdAt ?: now
         )
         noteRepository.createNote(newNote)
         return newNote

--- a/app/src/main/java/com/markleaf/notes/util/ExternalFile.kt
+++ b/app/src/main/java/com/markleaf/notes/util/ExternalFile.kt
@@ -2,8 +2,11 @@ package com.markleaf.notes.util
 
 import android.content.Context
 import android.net.Uri
+import android.provider.DocumentsContract
 import android.provider.OpenableColumns
+import com.markleaf.notes.data.sync.SyncFrontmatter
 import java.io.InputStream
+import java.time.Instant
 
 /**
  * One text file that lives outside Markleaf's own storage — the `.md`/`.txt` a
@@ -28,7 +31,15 @@ object ExternalFile {
     /** A file that was read successfully. [displayName] is null when the provider withholds it. */
     data class Document(
         val displayName: String?,
-        val text: String
+        val text: String,
+        val lastModifiedAt: Instant? = null
+    )
+
+    /** The body and timestamps to use when a document is explicitly kept as a note. */
+    data class NoteSeed(
+        val body: String,
+        val createdAt: Instant?,
+        val updatedAt: Instant?
     )
 
     /**
@@ -40,14 +51,38 @@ object ExternalFile {
      * Does I/O: call from a background dispatcher wherever the caller can.
      */
     fun read(context: Context, uri: Uri): Document? {
+        // Capture provider metadata before opening the stream. Some cloud
+        // providers update their remote/cache metadata as a file is read; the
+        // import must retain the timestamp that existed when the user picked it.
+        val name = displayName(context, uri)
+        val lastModified = lastModifiedAt(context, uri)
         val text = runCatching {
             context.contentResolver.openInputStream(uri)?.use(::readCapped)
         }.getOrNull()?.takeIf { it.isNotBlank() } ?: return null
-        return Document(displayName = displayName(context, uri), text = text)
+        return Document(
+            displayName = name,
+            text = text,
+            lastModifiedAt = lastModified
+        )
     }
 
     /** The note body [document] becomes when it is kept as a note. */
     fun noteBody(document: Document): String = noteBody(document.text, document.displayName)
+
+    /**
+     * Build the metadata for an explicit import without changing the source.
+     * Markleaf files carry both timestamps in frontmatter; ordinary providers
+     * generally expose only LAST_MODIFIED, which is used for both note dates.
+     */
+    fun noteSeed(document: Document): NoteSeed {
+        val parsed = SyncFrontmatter.decode(document.text)
+        val fallback = document.lastModifiedAt
+        return NoteSeed(
+            body = noteBody(document),
+            createdAt = parsed.createdAt ?: fallback,
+            updatedAt = parsed.updatedAt ?: fallback ?: parsed.createdAt
+        )
+    }
 
     /**
      * Seed a title from the file name when the text does not already carry one.
@@ -74,6 +109,27 @@ object ExternalFile {
                 if (cursor.moveToFirst()) cursor.getString(0) else null
             }
         }.getOrNull()
+    }
+
+    /** The provider's original modification time, if it exposes one. */
+    fun lastModifiedAt(context: Context, uri: Uri): Instant? {
+        val millis = if (uri.scheme == "file") {
+            uri.path?.let { java.io.File(it).lastModified() }
+        } else {
+            runCatching {
+                context.contentResolver.query(
+                    uri, arrayOf(DocumentsContract.Document.COLUMN_LAST_MODIFIED), null, null, null
+                )?.use { cursor ->
+                    if (cursor.moveToFirst()) {
+                        val index = cursor.getColumnIndex(DocumentsContract.Document.COLUMN_LAST_MODIFIED)
+                        if (index >= 0 && !cursor.isNull(index)) cursor.getLong(index) else null
+                    } else {
+                        null
+                    }
+                }
+            }.getOrNull()
+        }
+        return millis?.takeIf { it >= 0L }?.let(Instant::ofEpochMilli)
     }
 
     internal fun readCapped(input: InputStream): String {

--- a/app/src/test/java/com/markleaf/notes/util/ExternalFileTest.kt
+++ b/app/src/test/java/com/markleaf/notes/util/ExternalFileTest.kt
@@ -3,6 +3,7 @@ package com.markleaf.notes.util
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.time.Instant
 
 /**
  * The two rules that decide what an outside file becomes (#139, #326): the name
@@ -71,5 +72,39 @@ class ExternalFileTest {
         val text = "# 회의록\n\n다국어 파일도 열린다 — ünicode, 日本語, 中文."
 
         assertTrue(ExternalFile.readCapped(text.byteInputStream()) == text)
+    }
+
+    @Test
+    fun `ordinary files use the source modification time for both note dates`() {
+        val modified = Instant.parse("2026-08-20T10:15:30Z")
+
+        val seed = ExternalFile.noteSeed(
+            ExternalFile.Document("notes.md", "A note", lastModifiedAt = modified)
+        )
+
+        assertEquals(modified, seed.createdAt)
+        assertEquals(modified, seed.updatedAt)
+    }
+
+    @Test
+    fun `Markleaf frontmatter preserves both explicit note dates`() {
+        val created = Instant.parse("2026-08-19T10:15:30Z")
+        val updated = Instant.parse("2026-08-20T10:15:30Z")
+        val text = """
+            ---
+            markleaf_id: note-1
+            created_at: $created
+            updated_at: $updated
+            ---
+
+            # Body
+        """.trimIndent()
+
+        val seed = ExternalFile.noteSeed(
+            ExternalFile.Document("notes.md", text, lastModifiedAt = Instant.now())
+        )
+
+        assertEquals(created, seed.createdAt)
+        assertEquals(updated, seed.updatedAt)
     }
 }

--- a/app/src/testDebug/java/com/markleaf/notes/feature/viewer/FileViewerScreenTest.kt
+++ b/app/src/testDebug/java/com/markleaf/notes/feature/viewer/FileViewerScreenTest.kt
@@ -15,6 +15,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.GraphicsMode
+import java.time.Instant
 
 /**
  * The read-only file viewer (#326). What matters here is what it does *not* do:
@@ -41,11 +42,15 @@ class FileViewerScreenTest {
     private fun render(
         state: FileViewerState,
         onBack: () -> Unit = {},
-        onSaveAsNote: (String) -> Unit = {}
+        onSaveAsNote: (String, Instant?, Instant?) -> Unit = { _, _, _ -> }
     ) {
         composeRule.setContent {
             MarkleafTheme(dynamicColor = false) {
-                FileViewerContent(state = state, onBack = onBack, onSaveAsNote = onSaveAsNote)
+                FileViewerContent(
+                    state = state,
+                    onBack = onBack,
+                    onSaveAsNote = onSaveAsNote
+                )
             }
         }
     }
@@ -76,7 +81,7 @@ class FileViewerScreenTest {
     @Test
     fun savingHandsBackTheNoteBody() {
         var saved: String? = null
-        render(loaded(), onSaveAsNote = { saved = it })
+        render(loaded(), onSaveAsNote = { body, _, _ -> saved = body })
 
         composeRule.onNodeWithContentDescription("Save as note").performClick()
 
@@ -95,13 +100,34 @@ class FileViewerScreenTest {
     @Test
     fun anUnreadableFileSaysSoAndOffersNoSave() {
         var saved: String? = null
-        render(FileViewerState.Unreadable, onSaveAsNote = { saved = it })
+        render(FileViewerState.Unreadable, onSaveAsNote = { body, _, _ -> saved = body })
 
         composeRule.onNodeWithText(
             "This file couldn't be shown. It may be empty, may have been moved or deleted, or may not be a text file."
         ).assertIsDisplayed()
         composeRule.onNodeWithContentDescription("Save as note").assertDoesNotExist()
         assertNull(saved)
+    }
+
+    @Test
+    fun savingHandsBackSourceTimestamps() {
+        val created = Instant.parse("2026-08-19T10:15:30Z")
+        val updated = Instant.parse("2026-08-20T10:15:30Z")
+        var savedCreated: Instant? = null
+        var savedUpdated: Instant? = null
+
+        render(
+            loaded().copy(createdAt = created, updatedAt = updated),
+            onSaveAsNote = { _, sourceCreated, sourceUpdated ->
+                savedCreated = sourceCreated
+                savedUpdated = sourceUpdated
+            }
+        )
+
+        composeRule.onNodeWithContentDescription("Save as note").performClick()
+
+        assertEquals(created, savedCreated)
+        assertEquals(updated, savedUpdated)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Preserve Markleaf created_at and updated_at frontmatter when a Markdown file is explicitly saved as a note.
- Capture a provider's original modification time before reading and use it for imported note timestamps when no Markleaf metadata is available.
- Apply the same timestamp-aware seed to Open file -> Save as note and ACTION_SEND file imports.
- Add unit and viewer regression coverage.

This addresses #363. Read-only viewing still performs no write to the source URI; provider-side timestamp changes observed during a read are outside Markleaf's write path, but the import now retains the timestamp captured before the read.

## Verification

- ./gradlew :app:testDebugUnitTest :app:lintRelease
