### PR TITLE
fix: mirror notes saved from file viewer

### DIFF
--- a/.agent/decisions.md
+++ b/.agent/decisions.md
@@ -1243,3 +1243,18 @@ Implications:
 - For ordinary providers that expose only a modification time, use that value
   for both note timestamps; SAF has no portable creation-time column.
 - Read-only viewing never writes to the source URI.
+
+### D021 - Mirror an External Note at Save Time
+
+When the read-only file viewer creates a note, treat that action as a complete
+note creation path and write the new note to the configured sync folder
+immediately.
+
+Implications:
+
+- Use the same `writeNoteAndStamp` path as other seeded notes so the mirror file
+  is created before the user edits the new note.
+- Keep the note local if the mirror provider is unavailable; a later edit can
+  retry through the normal editor autosave path.
+- Record `lastImportedAt` only after the mirror write succeeds, preventing a
+  failed first write from being treated as synchronized.

--- a/.agent/progress.md
+++ b/.agent/progress.md
@@ -2630,3 +2630,19 @@ Issue response:
 
 Verification:
 - `./gradlew :app:testDebugUnitTest :app:lintRelease` — passed.
+
+---
+
+## 2026-09-06 - GitHub Issue #366 Sync Save-as-note
+
+Selected task:
+- Follow up on the reporter's confirmation on #363: a note saved from the
+  read-only viewer was not mirrored until its first edit.
+
+What was implemented:
+- Opened #366 to track the separate synchronization behavior.
+- `Save as note` now writes the new note to the configured sync folder
+  immediately and stamps `lastImportedAt` only after a successful write.
+
+Verification:
+- `./gradlew :app:testDebugUnitTest :app:lintRelease` — passed.

--- a/.agent/tasks.md
+++ b/.agent/tasks.md
@@ -5,6 +5,14 @@
 
 ---
 
+## GitHub Issue #366 - Sync Save-as-note (In progress, 2026-09-06)
+
+- [x] #363 보고자의 후속 확인을 별도 이슈 #366으로 분리하고 원인 재현
+- [x] 읽기 전용 뷰어에서 노트를 저장할 때 설정된 동기화 폴더에도 즉시 미러링
+- [ ] PR 리뷰·머지 및 릴리스 배포
+
+---
+
 ## GitHub Issue #363 - External File Timestamps (Done, 2026-09-06)
 
 - [x] 외부 보고자에게 감사·트리아지 댓글을 남기고 `Open file…` 및 공유 파일 가져오기 경로를 재현

--- a/app/src/main/java/com/markleaf/notes/navigation/MarkleafNavHost.kt
+++ b/app/src/main/java/com/markleaf/notes/navigation/MarkleafNavHost.kt
@@ -77,6 +77,9 @@ import com.markleaf.notes.data.local.AppDatabase
 import com.markleaf.notes.data.repository.LocalNoteRepository
 import com.markleaf.notes.data.settings.AppSettings
 import com.markleaf.notes.data.settings.AppSettingsRepository
+import com.markleaf.notes.data.sync.NoteFolderMirror
+import com.markleaf.notes.data.sync.mirrorMetadata
+import com.markleaf.notes.data.sync.syncFolderUriOrNull
 import com.markleaf.notes.ui.viewmodel.ArchiveViewModel
 import com.markleaf.notes.ui.viewmodel.LockedNotesViewModel
 import com.markleaf.notes.ui.viewmodel.NotesViewModel
@@ -532,13 +535,29 @@ fun MarkleafNavHost(
                 onBack = { navController.popBackStack() },
                 onSaveAsNote = { body, createdAt, updatedAt ->
                     coroutineScope.launch {
-                        val titleSource = settingsRepository.settings.first().noteTitleSource
+                        val settings = settingsRepository.settings.first()
                         val newNote = viewerViewModel.createNote(
                             initialContent = body,
-                            titleSource = titleSource,
+                            titleSource = settings.noteTitleSource,
                             createdAt = createdAt,
                             updatedAt = updatedAt
                         )
+                        // Saving from the read-only viewer is a complete note
+                        // creation path. Mirror it immediately when folder
+                        // sync is enabled; waiting for the first editor change
+                        // leaves the new note local-only until then (#366).
+                        settings.syncFolderUriOrNull()?.let { folderUri ->
+                            withContext(Dispatchers.IO) {
+                                NoteFolderMirror.writeNoteAndStamp(
+                                    context = context,
+                                    folderUri = folderUri,
+                                    note = newNote,
+                                    extension = settings.syncFileExtension,
+                                    metadata = settings.mirrorMetadata(),
+                                    onStamped = { stamped -> noteRepository.updateNote(stamped) }
+                                )
+                            }
+                        }
                         withContext(Dispatchers.Main.immediate) {
                             navController.navigate(NavRoutes.editorRoute(newNote.id)) {
                                 // The file has been kept; backing out of the new


### PR DESCRIPTION
## Summary
- immediately mirror notes saved from the read-only external file viewer when folder sync is enabled
- stamp `lastImportedAt` only after the mirror write succeeds, matching other seeded-note paths
- track the reporter's follow-up as #366 and document the decision

## Verification
- `./gradlew :app:testDebugUnitTest :app:lintRelease`
- `git diff --check`

Closes #366
