### PR TITLE
fix: scroll the single-note widget body (#371)

### DIFF
--- a/.agent/tasks.md
+++ b/.agent/tasks.md
@@ -5,6 +5,16 @@
 
 ---
 
+## GitHub Issue #371 - Single-note widget scrolling (Done, 2026-09-08)
+
+- [x] #351 보고자의 미응답 후속 지적을 확인하고 별도 이슈 #371로 분리
+- [x] 본문을 `TextView`에서 `ListView` + `SingleNoteWidgetService`로 전환해 스크롤 가능하게 구현
+- [x] 위젯 인스턴스별 factory 분리(`data` 고유화), 행 탭은 `PendingIntentTemplate` + fill-in으로 이전
+- [x] 빈 줄 높이 유지·긴 줄 래핑·문자/행 상한 말줄임 규칙을 단위 테스트로 고정
+- [x] 계측 테스트를 컨테이너 형태·factory 행·서비스 바인딩 3축으로 재작성하고 에뮬레이터에서 통과
+
+---
+
 ## GitHub Hardening #262 - Widget picker first-run notes (Done, 2026-09-07)
 
 - [x] 위젯 설정 화면에서 `MainActivity` 없이도 첫 실행 샘플 노트를 시드

--- a/app/src/androidTest/java/com/markleaf/notes/widget/SingleNoteWidgetRenderTest.kt
+++ b/app/src/androidTest/java/com/markleaf/notes/widget/SingleNoteWidgetRenderTest.kt
@@ -21,7 +21,9 @@ import com.markleaf.notes.data.settings.EditorFontSize
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
 import org.junit.Assume.assumeTrue
 import org.junit.Before
 import org.junit.Test
@@ -186,6 +188,32 @@ class SingleNoteWidgetRenderTest {
             "The empty view carries no 'nothing to show' message",
             inflate().findTextViewWithText(context.getString(R.string.single_note_widget_unavailable))
         )
+    }
+
+    /**
+     * The half a row template cannot cover. A ListView consumes taps inside its
+     * own bounds, but the padding around it and the "nothing to show" view it is
+     * swapped for are not rows — and a blank note renders nothing but that view.
+     * Before #371 one pending intent on the root covered all of it; this keeps
+     * that, so a note whose body draws no rows still opens when tapped.
+     */
+    @Test
+    fun theWidgetSurfaceOpensTheNoteWhenNoRowAreDrawn() {
+        seedNote(locked = true)
+        SingleNoteWidgetStore.save(context, appWidgetId, noteId, EditorFontSize.MEDIUM)
+
+        val root = inflate().findViewById<View>(R.id.single_note_root)
+
+        assertNotNull("The widget inflated without its root", root)
+        assertTrue("A widget drawing no rows has no tap target at all", root.hasOnClickListeners())
+    }
+
+    /** Nothing chosen yet — the state every widget is in between drop and picker. */
+    @Test
+    fun anUnconfiguredWidgetHasNothingToOpen() {
+        val root = inflate().findViewById<View>(R.id.single_note_root)
+
+        assertFalse("An unconfigured widget offers a tap that opens nothing", root.hasOnClickListeners())
     }
 
     private fun readyFactory(): SingleNoteWidgetFactory =

--- a/app/src/androidTest/java/com/markleaf/notes/widget/SingleNoteWidgetRenderTest.kt
+++ b/app/src/androidTest/java/com/markleaf/notes/widget/SingleNoteWidgetRenderTest.kt
@@ -8,10 +8,13 @@ import android.os.ParcelFileDescriptor
 import android.util.TypedValue
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ListView
+import android.widget.RemoteViews
 import android.widget.TextView
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import com.markleaf.notes.R
 import com.markleaf.notes.data.local.AppDatabase
 import com.markleaf.notes.data.local.entity.NoteEntity
 import com.markleaf.notes.data.settings.EditorFontSize
@@ -25,12 +28,23 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 /**
- * What the single-note widget actually puts on a home screen (#351).
+ * What the single-note widget actually puts on a home screen (#351, #371).
  *
- * The Robolectric tests pin the rules — which notes may be drawn, what size the
- * text becomes — but they build `RemoteViews` and stop there. This binds a real
- * widget id through `AppWidgetService` and inflates what the launcher would
- * inflate, so the assertions are about the `TextView` a person would look at.
+ * The Robolectric tests pin the rules — which notes may be drawn, what a line
+ * becomes as a row — but they stop at the row list. This binds a real widget id
+ * through `AppWidgetService` and inflates what the launcher would inflate.
+ *
+ * Two halves, because the widget now has two:
+ *
+ * - The **container** is asserted through the host, as before. Since #371 the
+ *   assertion is that the body is a `ListView`: that is the whole of the fix,
+ *   because a collection view is the only shape a widget can scroll in.
+ * - The **rows** come from [SingleNoteWidgetFactory] against the real database,
+ *   each one inflated through `RemoteViews.apply` so the assertions are still
+ *   about a `TextView` a person would look at. They cannot be read off the host
+ *   view: an adapter-backed list is populated asynchronously by the launcher's
+ *   `RemoteViewsAdapter`, and asserting on that here would be a race dressed up
+ *   as a test.
  *
  * Binding needs `BIND_APPWIDGET`, which no app can hold by declaring it, so the
  * test grants it to itself through the instrumentation's shell. Doing that from
@@ -89,64 +103,129 @@ class SingleNoteWidgetRenderTest {
         runBlocking { AppDatabase.getInstance(context).noteDao().deleteForever(noteId) }
     }
 
+    /**
+     * The fix itself (#371). A `TextView` in a widget clips at the widget's
+     * height with no way to reach the rest, so the assertion is about which
+     * container got inflated rather than about any text inside it.
+     */
     @Test
-    fun theChosenNotesBodyIsDrawnAtTheChosenSize() {
+    fun theBodyIsInflatedAsAScrollableList() {
+        seedNote(locked = false)
+        SingleNoteWidgetStore.save(context, appWidgetId, noteId, EditorFontSize.MEDIUM)
+
+        assertNotNull("The widget inflated without a ListView", inflate().firstListView())
+    }
+
+    @Test
+    fun theChosenNotesLinesAreTheRowsAtTheChosenSize() {
         seedNote(locked = false)
         SingleNoteWidgetStore.save(context, appWidgetId, noteId, EditorFontSize.EXTRA_LARGE)
+        val factory = readyFactory()
 
-        val body = renderBody()
-
-        assertEquals(BODY, body.text.toString())
+        assertEquals(2, factory.getCount())
+        assertEquals(listOf("line one", "line two"), (0 until factory.getCount()).map { rowText(factory.getViewAt(it)) })
         assertEquals(
             TypedValue.applyDimension(
                 TypedValue.COMPLEX_UNIT_SP,
                 SingleNoteWidgetStore.bodySizeSp(EditorFontSize.EXTRA_LARGE),
-                body.resources.displayMetrics
+                context.resources.displayMetrics
             ),
-            body.textSize,
+            rowView(factory.getViewAt(0)).textSize,
             0.5f
         )
     }
 
     /**
+     * The end-to-end half: that a host asking for the adapter actually reaches
+     * [SingleNoteWidgetService] and gets rows back. Nothing else here would
+     * notice the service missing from the manifest, or declared without
+     * `BIND_REMOTEVIEWS` — the widget would simply be empty on a home screen
+     * while every other assertion stayed green.
+     *
+     * Polled rather than asserted once: the adapter connects to the service
+     * asynchronously, so the wait is part of the check, not a race around it.
+     */
+    @Test
+    fun theHostBindsTheServiceAndGetsRows() {
+        seedNote(locked = false)
+        SingleNoteWidgetStore.save(context, appWidgetId, noteId, EditorFontSize.MEDIUM)
+
+        val list = requireNotNull(inflate().firstListView()) { "The widget inflated without a ListView" }
+
+        val deadline = System.currentTimeMillis() + ADAPTER_TIMEOUT_MS
+        var count = 0
+        while (System.currentTimeMillis() < deadline) {
+            InstrumentationRegistry.getInstrumentation().runOnMainSync { count = list.adapter?.count ?: 0 }
+            if (count >= 2) break
+            Thread.sleep(POLL_MS)
+        }
+
+        assertEquals("The list never received the note's rows from the service", 2, count)
+    }
+
+    /**
      * The guard that matters: a home screen is visible without unlocking
      * anything, so a note moved into the Locked space has to stop rendering —
-     * not keep showing the text it had when it was chosen.
+     * not keep showing the text it had when it was chosen. With the body as a
+     * list, "stops rendering" is an empty row set, which is what makes the
+     * launcher swap in the empty view.
      */
     @Test
     fun aNoteLockedAfterItWasChosenStopsShowingItsText() {
         seedNote(locked = false)
         SingleNoteWidgetStore.save(context, appWidgetId, noteId, EditorFontSize.MEDIUM)
-        assertEquals(BODY, renderBody().text.toString())
+        val factory = readyFactory()
+        assertEquals(2, factory.getCount())
 
-        runBlocking {
-            AppDatabase.getInstance(context).noteDao().setLocked(noteId, true)
-        }
-        val body = renderBody()
+        runBlocking { AppDatabase.getInstance(context).noteDao().setLocked(noteId, true) }
+        factory.onDataSetChanged()
 
-        assertEquals(
-            context.getString(com.markleaf.notes.R.string.single_note_widget_unavailable),
-            body.text.toString()
+        assertEquals(0, factory.getCount())
+        // And the view the launcher falls back to says so, rather than going blank.
+        assertNotNull(
+            "The empty view carries no 'nothing to show' message",
+            inflate().findTextViewWithText(context.getString(R.string.single_note_widget_unavailable))
         )
     }
 
-    private fun renderBody(): TextView {
-        SingleNoteWidget.updateAppWidget(context, manager, appWidgetId)
+    private fun readyFactory(): SingleNoteWidgetFactory =
+        SingleNoteWidgetFactory(context, appWidgetId).apply { onDataSetChanged() }
+
+    private fun rowText(row: RemoteViews): String = rowView(row).text.toString()
+
+    /** Inflates one row the way the launcher would, so the assertion is about a real view. */
+    private fun rowView(row: RemoteViews): TextView {
         var found: TextView? = null
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            found = row.apply(context, null).findViewById(R.id.single_note_line)
+        }
+        return requireNotNull(found) { "A row inflated without its TextView" }
+    }
+
+    private fun inflate(): View {
+        SingleNoteWidget.updateAppWidget(context, manager, appWidgetId)
+        var found: View? = null
         InstrumentationRegistry.getInstrumentation().runOnMainSync {
             val hostView = host.createView(context, appWidgetId, manager.getAppWidgetInfo(appWidgetId))
             hostView.measure(
                 View.MeasureSpec.makeMeasureSpec(600, View.MeasureSpec.EXACTLY),
                 View.MeasureSpec.makeMeasureSpec(600, View.MeasureSpec.EXACTLY)
             )
-            found = hostView.firstTextView()
+            found = hostView
         }
-        return requireNotNull(found) { "The widget inflated without a TextView" }
+        return requireNotNull(found) { "The widget did not inflate" }
     }
 
-    private fun View.firstTextView(): TextView? = when (this) {
-        is TextView -> this
-        is ViewGroup -> (0 until childCount).firstNotNullOfOrNull { getChildAt(it).firstTextView() }
+    private fun View.firstListView(): ListView? = when (this) {
+        is ListView -> this
+        is ViewGroup -> (0 until childCount).firstNotNullOfOrNull { getChildAt(it).firstListView() }
+        else -> null
+    }
+
+    private fun View.findTextViewWithText(text: String): TextView? = when {
+        this is TextView && this.text?.toString() == text -> this
+        this is ViewGroup ->
+            (0 until childCount).firstNotNullOfOrNull { getChildAt(it).findTextViewWithText(text) }
         else -> null
     }
 
@@ -167,6 +246,11 @@ class SingleNoteWidgetRenderTest {
 
     private companion object {
         const val HOST_ID = 0x4D4C
+
+        /** How long the adapter is given to connect to the service before the check fails. */
+        const val ADAPTER_TIMEOUT_MS = 10_000L
+        const val POLL_MS = 100L
+
         const val BODY = "line one\nline two"
     }
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -94,6 +94,13 @@
                 android:resource="@xml/single_note_widget_info" />
         </receiver>
 
+        <!-- Feeds the scrolling body of the single-note widget (#371). One
+             factory per placed widget, unlike the recent-notes service above. -->
+        <service
+            android:name=".widget.SingleNoteWidgetService"
+            android:permission="android.permission.BIND_REMOTEVIEWS"
+            android:exported="false" />
+
         <!-- Launched by the launcher when the widget is placed, and again for the
              reconfigure action on Android 12+. exported because the launcher, not
              the app, starts it. -->

--- a/app/src/main/java/com/markleaf/notes/widget/SingleNoteWidget.kt
+++ b/app/src/main/java/com/markleaf/notes/widget/SingleNoteWidget.kt
@@ -6,13 +6,12 @@ import android.appwidget.AppWidgetProvider
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
+import android.net.Uri
 import android.util.TypedValue
 import android.widget.RemoteViews
 import com.markleaf.notes.MainActivity
 import com.markleaf.notes.R
-import com.markleaf.notes.data.local.AppDatabase
 import com.markleaf.notes.data.local.entity.NoteEntity
-import kotlinx.coroutines.runBlocking
 
 /**
  * Home-screen widget showing the body of one chosen note (#351).
@@ -25,6 +24,18 @@ import kotlinx.coroutines.runBlocking
  * The body is drawn as it was typed — Markdown source, not rendered. A
  * `RemoteViews` tree can only hold a fixed set of platform views, so `**bold**`
  * reads as `**bold**` here.
+ *
+ * The body **scrolls** (#371), which is why it is a `ListView` fed by
+ * [SingleNoteWidgetService] rather than the single `TextView` it was until
+ * v2.37.3. The same constraint that keeps Markdown unrendered is what forced
+ * that: a widget may only hold a fixed set of views, `ScrollView` is not one of
+ * them, and a `TextView` there clips at the widget's height with no way to
+ * reach the rest. The scrollable containers a widget can hold are the
+ * collection views, and every one of them needs a service behind it.
+ *
+ * A consequence worth naming: this class no longer reads the database. The note
+ * is loaded by the factory, on the background thread `onDataSetChanged` already
+ * runs on, instead of by a `runBlocking` on the receiver's main thread.
  */
 class SingleNoteWidget : AppWidgetProvider() {
 
@@ -49,16 +60,42 @@ class SingleNoteWidget : AppWidgetProvider() {
         /**
          * How much of a note's body reaches the widget.
          *
-         * `RemoteViews` crosses a Binder transaction, whose payload is capped
-         * around 1 MB for the whole process. An imported note may hold up to
-         * `ExternalFile.MAX_CHARS` — two million characters — and handing that
-         * to `setTextViewText` makes the update throw `TransactionTooLargeException`
-         * instead of drawing anything. Nothing is lost by cutting: even a
-         * full-screen widget at the smallest size shows a few thousand
-         * characters, so this is far past the last legible line, and tapping
-         * opens the whole note.
+         * The original reason for a cap is gone: the body no longer crosses in
+         * one `setTextViewText`, so it can no longer blow the ~1 MB Binder
+         * payload a process gets. A different reason replaces it — the launcher's
+         * adapter holds the rows this factory hands it, and an imported note may
+         * run to `ExternalFile.MAX_CHARS`, two million characters.
+         *
+         * The number is unchanged at 20,000 because raising it is a measurement,
+         * not a guess, and none has been taken. What did change is that 20,000
+         * characters are now all *reachable* by scrolling rather than clipped at
+         * the first screenful, which is the whole of #371.
          */
         internal const val MAX_BODY_CHARS = 20_000
+
+        /**
+         * How many rows the list may hold.
+         *
+         * [MAX_BODY_CHARS] alone does not bound the row count: 20,000 newlines
+         * are 20,000 rows, each an inflated view the launcher keeps. This is the
+         * second half of the same bound, and it is chosen by the same standard —
+         * far past any note a person scrolls through on a home screen, and
+         * unmeasured.
+         */
+        internal const val MAX_BODY_LINES = 2_000
+
+        /**
+         * What a blank line becomes.
+         *
+         * A row whose `TextView` holds nothing can collapse, and paragraphs then
+         * run together — a scrollable widget that reads worse than the clipped
+         * one it replaced. A non-breaking space keeps the row exactly one line
+         * tall, at whatever size the widget is configured for.
+         */
+        internal const val BLANK_LINE = "\u00A0"
+
+        /** The last row when the body did not fit; punctuation, so it needs no translation. */
+        internal const val TRUNCATION_MARKER = "…"
 
         /**
          * Repaints every placed single-note widget. Called wherever the notes
@@ -81,47 +118,68 @@ class SingleNoteWidget : AppWidgetProvider() {
             appWidgetId: Int
         ) {
             val views = RemoteViews(context.packageName, R.layout.widget_single_note)
-            val noteId = SingleNoteWidgetStore.noteId(context, appWidgetId)
-            val note = noteId?.let { loadShowableNote(context, it) }
-
-            views.setTextViewText(
-                R.id.single_note_body,
-                note?.takeIf { it.isNotBlank() }
-                    ?: context.getString(R.string.single_note_widget_unavailable)
+            val bodySizeSp = SingleNoteWidgetStore.bodySizeSp(
+                SingleNoteWidgetStore.textSize(context, appWidgetId)
             )
+
+            views.setRemoteAdapter(R.id.single_note_list, factoryIntent(context, appWidgetId))
+            views.setEmptyView(R.id.single_note_list, R.id.single_note_empty)
+            // The "nothing to show" message is the one piece of text this class
+            // still draws itself, so it is sized here; the rows are sized by the
+            // factory, which is the only place that knows how many there are.
             views.setTextViewTextSize(
-                R.id.single_note_body,
+                R.id.single_note_empty,
                 TypedValue.COMPLEX_UNIT_SP,
-                SingleNoteWidgetStore.bodySizeSp(
-                    SingleNoteWidgetStore.textSize(context, appWidgetId)
-                )
+                bodySizeSp
             )
 
-            // Tapping opens the note in the app, through the same entry point the
-            // recent-notes rows use. Only offered while there is a note to open.
-            if (noteId != null && note != null) {
-                val pending = PendingIntent.getActivity(
+            // A ListView consumes row taps, so tap-to-open can no longer be one
+            // pending intent on the root: it becomes a template each row
+            // completes with its note id. Mutable for that reason, and only for
+            // it — asking for both MUTABLE and IMMUTABLE throws on Android 12+.
+            views.setPendingIntentTemplate(
+                R.id.single_note_list,
+                PendingIntent.getActivity(
                     context,
                     appWidgetId,
-                    openNoteIntent(context, noteId),
-                    // Immutable: nothing fills this in later, unlike the
-                    // recent-notes list, whose template each row completes.
-                    PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+                    openNoteTemplate(context),
+                    PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
                 )
-                views.setOnClickPendingIntent(R.id.single_note_root, pending)
-            }
+            )
 
             appWidgetManager.updateAppWidget(appWidgetId, views)
+            // Without this an edited note keeps showing its old text: the views
+            // above are the container, and the rows inside it are the factory's.
+            appWidgetManager.notifyAppWidgetViewDataChanged(appWidgetId, R.id.single_note_list)
         }
+
+        /**
+         * The adapter intent for [appWidgetId], made distinct by its `data`.
+         *
+         * `RemoteViewsService` keys its factories by intent, comparing
+         * everything *except* extras. [QuickNoteWidget] can therefore pass the
+         * widget id as a plain extra — every one of its instances shows the same
+         * ten notes, so sharing a factory is invisible. Single-note widgets each
+         * show a different note, and without a distinguishing `data` the second
+         * one placed would silently render the first one's note.
+         */
+        internal fun factoryIntent(context: Context, appWidgetId: Int): Intent =
+            Intent(context, SingleNoteWidgetService::class.java).apply {
+                putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
+                data = Uri.parse(toUri(Intent.URI_INTENT_SCHEME))
+            }
 
         /**
          * Opens [noteId] in the app — the same entry point the recent-notes rows
          * use, so a widget tap and a widget-list tap land in the same place.
          */
         internal fun openNoteIntent(context: Context, noteId: String): Intent =
+            openNoteTemplate(context).putExtra(QuickNoteWidget.EXTRA_NOTE_ID, noteId)
+
+        /** [openNoteIntent] without the note id, which each row's fill-in supplies. */
+        internal fun openNoteTemplate(context: Context): Intent =
             Intent(context, MainActivity::class.java).apply {
                 action = QuickNoteWidget.ACTION_OPEN_NOTE
-                putExtra(QuickNoteWidget.EXTRA_NOTE_ID, noteId)
                 flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
             }
 
@@ -144,12 +202,34 @@ class SingleNoteWidget : AppWidgetProvider() {
         }
 
         /**
-         * Runs on the receiver's main thread by way of `onUpdate`; the read is a
-         * single lookup by primary key.
+         * [showableBody] as the rows the list draws — one per line of the note.
+         *
+         * Lines, not fixed-size chunks: a row wraps its own long line across as
+         * many visual lines as it needs, so nothing is cut at a row boundary. A
+         * note that yields no rows renders the empty view, which is how a blank,
+         * locked, trashed or deleted note all come out as "nothing to show"
+         * without a second rule for each.
+         *
+         * Trailing blank lines are dropped rather than drawn: a file ending in a
+         * newline would otherwise scroll past its last word into empty rows.
          */
-        private fun loadShowableNote(context: Context, noteId: String): String? =
-            runBlocking {
-                showableBody(AppDatabase.getInstance(context).noteDao().getNoteById(noteId))
+        internal fun bodyRows(note: NoteEntity?): List<String> {
+            val body = showableBody(note) ?: return emptyList()
+            val cutByChars = (note?.contentMarkdown?.length ?: 0) > body.length
+
+            val lines = body.split('\n')
+                .map { it.removeSuffix("\r") }
+                .dropLastWhile { it.isBlank() }
+            if (lines.isEmpty()) return emptyList()
+
+            val rows = lines.take(MAX_BODY_LINES).map { line ->
+                if (line.isBlank()) BLANK_LINE else line
             }
+            return if (cutByChars || lines.size > MAX_BODY_LINES) {
+                rows + TRUNCATION_MARKER
+            } else {
+                rows
+            }
+        }
     }
 }

--- a/app/src/main/java/com/markleaf/notes/widget/SingleNoteWidget.kt
+++ b/app/src/main/java/com/markleaf/notes/widget/SingleNoteWidget.kt
@@ -98,6 +98,21 @@ class SingleNoteWidget : AppWidgetProvider() {
         internal const val TRUNCATION_MARKER = "…"
 
         /**
+         * Request-code namespaces for the widget's two tap targets.
+         *
+         * A `PendingIntent` is identified by its request code and by an intent
+         * comparison that ignores extras — and the row template and the
+         * whole-widget intent differ only in extras. Sharing a request code
+         * would therefore make them the same `PendingIntent`, with
+         * `FLAG_UPDATE_CURRENT` overwriting one from the other and their
+         * mutability flags in conflict. Two bases, offset by the widget id, keep
+         * every pair distinct; the values sit clear of the plain 0 and 1
+         * [QuickNoteWidget] uses for intents that name the same activity.
+         */
+        private const val TEMPLATE_REQUEST_BASE = 0x510000
+        private const val ROOT_REQUEST_BASE = 0x520000
+
+        /**
          * Repaints every placed single-note widget. Called wherever the notes
          * behind them may have moved — the same points that refresh the
          * recent-notes list.
@@ -118,6 +133,7 @@ class SingleNoteWidget : AppWidgetProvider() {
             appWidgetId: Int
         ) {
             val views = RemoteViews(context.packageName, R.layout.widget_single_note)
+            val noteId = SingleNoteWidgetStore.noteId(context, appWidgetId)
             val bodySizeSp = SingleNoteWidgetStore.bodySizeSp(
                 SingleNoteWidgetStore.textSize(context, appWidgetId)
             )
@@ -133,19 +149,42 @@ class SingleNoteWidget : AppWidgetProvider() {
                 bodySizeSp
             )
 
-            // A ListView consumes row taps, so tap-to-open can no longer be one
-            // pending intent on the root: it becomes a template each row
-            // completes with its note id. Mutable for that reason, and only for
-            // it — asking for both MUTABLE and IMMUTABLE throws on Android 12+.
+            // Tap-to-open, in two halves, because a ListView consumes taps that
+            // land inside it and nothing else does.
+            //
+            // The rows get a template each one completes with its note id.
+            // Mutable for that reason, and only for it — asking for both
+            // MUTABLE and IMMUTABLE throws on Android 12+.
             views.setPendingIntentTemplate(
                 R.id.single_note_list,
                 PendingIntent.getActivity(
                     context,
-                    appWidgetId,
+                    TEMPLATE_REQUEST_BASE + appWidgetId,
                     openNoteTemplate(context),
                     PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
                 )
             )
+            // The rest of the surface keeps the whole-widget tap it had before
+            // #371: the padding, and the "nothing to show" view, which is what a
+            // blank note renders — a widget the template alone would leave with
+            // no tap target at all. It fires for a note that cannot be drawn
+            // (locked, trashed, deleted) too, which the previous code did not do
+            // for the locked case: telling those apart needs a database read,
+            // and doing one here is exactly what this change moved off the
+            // receiver's main thread. Nothing is revealed by it — the tap opens
+            // Markleaf, and the Locked space's passcode is what stands in front
+            // of the note.
+            if (noteId != null) {
+                views.setOnClickPendingIntent(
+                    R.id.single_note_root,
+                    PendingIntent.getActivity(
+                        context,
+                        ROOT_REQUEST_BASE + appWidgetId,
+                        openNoteIntent(context, noteId),
+                        PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+                    )
+                )
+            }
 
             appWidgetManager.updateAppWidget(appWidgetId, views)
             // Without this an edited note keeps showing its old text: the views

--- a/app/src/main/java/com/markleaf/notes/widget/SingleNoteWidgetService.kt
+++ b/app/src/main/java/com/markleaf/notes/widget/SingleNoteWidgetService.kt
@@ -1,0 +1,117 @@
+package com.markleaf.notes.widget
+
+import android.appwidget.AppWidgetManager
+import android.content.Context
+import android.content.Intent
+import android.util.TypedValue
+import android.widget.RemoteViews
+import android.widget.RemoteViewsService
+import com.markleaf.notes.R
+import com.markleaf.notes.data.local.AppDatabase
+import com.markleaf.notes.data.settings.EditorFontSize
+import kotlinx.coroutines.runBlocking
+
+/**
+ * RemoteViewsService behind the scrolling body of [SingleNoteWidget] (#371).
+ *
+ * A widget scrolls only inside a collection view, and a collection view is fed
+ * only by a service like this one. Each row is one line of the chosen note, so
+ * a long line still wraps within its row instead of being cut at a boundary.
+ *
+ * Unlike [QuickNoteWidgetService], one factory per placed widget: every
+ * single-note widget shows a different note, and its id arrives on the intent.
+ * [SingleNoteWidget.factoryIntent] is what keeps those intents distinct.
+ */
+class SingleNoteWidgetService : RemoteViewsService() {
+    override fun onGetViewFactory(intent: Intent): RemoteViewsFactory =
+        SingleNoteWidgetFactory(
+            applicationContext,
+            intent.getIntExtra(
+                AppWidgetManager.EXTRA_APPWIDGET_ID,
+                AppWidgetManager.INVALID_APPWIDGET_ID
+            )
+        )
+}
+
+/**
+ * Why `runBlocking` is fine here: `onDataSetChanged` is called on a background
+ * thread by the AppWidgetManager precisely so the factory can do synchronous
+ * I/O, and the read is a single lookup by primary key. It is also strictly
+ * better than what it replaces — the provider used to block the receiver's main
+ * thread for the same row.
+ */
+internal class SingleNoteWidgetFactory(
+    private val context: Context,
+    private val appWidgetId: Int
+) : RemoteViewsService.RemoteViewsFactory {
+
+    private var rows: List<String> = emptyList()
+    private var noteId: String? = null
+    private var textSizeSp: Float = SingleNoteWidgetStore.bodySizeSp(EditorFontSize.MEDIUM)
+
+    override fun onCreate() {}
+
+    override fun onDataSetChanged() {
+        // Re-read the placement every time rather than caching it: on Android 12+
+        // a widget can be reconfigured onto a different note, or to a different
+        // size, without ever being removed and re-added.
+        val id = SingleNoteWidgetStore.noteId(context, appWidgetId)
+        noteId = id
+        textSizeSp = SingleNoteWidgetStore.bodySizeSp(
+            SingleNoteWidgetStore.textSize(context, appWidgetId)
+        )
+        rows = if (id == null) {
+            emptyList()
+        } else {
+            runBlocking {
+                SingleNoteWidget.bodyRows(
+                    AppDatabase.getInstance(context).noteDao().getNoteById(id)
+                )
+            }
+        }
+    }
+
+    override fun onDestroy() {
+        rows = emptyList()
+        noteId = null
+    }
+
+    override fun getCount(): Int = rows.size
+
+    override fun getViewAt(position: Int): RemoteViews {
+        val view = RemoteViews(context.packageName, R.layout.widget_single_note_line)
+        // getOrNull, not [position]: the launcher may ask for a row from the
+        // count it last read, and a note edited in between can be shorter.
+        view.setTextViewText(
+            R.id.single_note_line,
+            rows.getOrNull(position) ?: SingleNoteWidget.BLANK_LINE
+        )
+        view.setTextViewTextSize(
+            R.id.single_note_line,
+            TypedValue.COMPLEX_UNIT_SP,
+            textSizeSp
+        )
+        // Every row opens the same note, so the fill-in is the same for all of
+        // them; the template in the provider carries the action and component.
+        noteId?.let {
+            view.setOnClickFillInIntent(
+                R.id.single_note_line_root,
+                Intent().putExtra(QuickNoteWidget.EXTRA_NOTE_ID, it)
+            )
+        }
+        return view
+    }
+
+    override fun getLoadingView(): RemoteViews? = null
+
+    override fun getViewTypeCount(): Int = 1
+
+    override fun getItemId(position: Int): Long = position.toLong()
+
+    /**
+     * False deliberately. The ids above are positions, and a line's position
+     * changes whenever the note is edited above it — claiming they are stable
+     * would let the launcher reuse a row for different text.
+     */
+    override fun hasStableIds(): Boolean = false
+}

--- a/app/src/main/res/layout/widget_single_note.xml
+++ b/app/src/main/res/layout/widget_single_note.xml
@@ -1,4 +1,11 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?><!--
+    The body is a ListView rather than a TextView because a widget cannot scroll
+    any other way (#371): a RemoteViews tree may only hold a fixed set of views,
+    ScrollView is not among them, and a TextView there clips at the widget's
+    height with no way to reach the rest. The scrollable containers a widget can
+    hold are the collection views, each needing a RemoteViewsService behind it —
+    here SingleNoteWidgetService, which returns one row per line of the note.
+-->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/single_note_root"
     android:layout_width="match_parent"
@@ -7,14 +14,23 @@
     android:orientation="vertical"
     android:padding="12dp">
 
-    <TextView
-        android:id="@+id/single_note_body"
+    <ListView
+        android:id="@+id/single_note_list"
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_weight="1"
-        android:ellipsize="end"
-        android:lineSpacingMultiplier="1.2"
+        android:divider="@null"
+        android:dividerHeight="0dp" />
+
+    <TextView
+        android:id="@+id/single_note_empty"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:gravity="center"
+        android:text="@string/single_note_widget_unavailable"
         android:textColor="?android:attr/textColorPrimaryInverse"
-        android:textSize="14sp" />
+        android:textSize="14sp"
+        android:visibility="gone" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/widget_single_note_line.xml
+++ b/app/src/main/res/layout/widget_single_note_line.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+    One line of the chosen note (#371). Rows are lines rather than fixed-size
+    chunks so a long line still wraps inside its own row instead of being cut at
+    a row boundary; a blank line carries a non-breaking space from the factory so
+    it keeps its height and paragraphs stay apart.
+
+    No maxLines and no ellipsize: nothing here may truncate, because scrolling is
+    the point.
+-->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/single_note_line_root"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <TextView
+        android:id="@+id/single_note_line"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:lineSpacingMultiplier="1.2"
+        android:textColor="?android:attr/textColorPrimaryInverse"
+        android:textSize="14sp" />
+
+</LinearLayout>

--- a/app/src/test/java/com/markleaf/notes/widget/SingleNoteWidgetTest.kt
+++ b/app/src/test/java/com/markleaf/notes/widget/SingleNoteWidgetTest.kt
@@ -8,6 +8,8 @@ import com.markleaf.notes.R
 import com.markleaf.notes.data.local.entity.NoteEntity
 import com.markleaf.notes.data.settings.EditorFontSize
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -81,6 +83,117 @@ class SingleNoteWidgetTest {
         assertEquals(12.25f, SingleNoteWidgetStore.bodySizeSp(EditorFontSize.SMALL), 0.001f)
         assertEquals(15.75f, SingleNoteWidgetStore.bodySizeSp(EditorFontSize.LARGE), 0.001f)
         assertEquals(17.5f, SingleNoteWidgetStore.bodySizeSp(EditorFontSize.EXTRA_LARGE), 0.001f)
+    }
+
+    // --- rows (#371) -------------------------------------------------------
+    //
+    // The body scrolls as a list, so what the widget draws is no longer one
+    // string but a sequence of rows. These pin the row rules; that a ListView
+    // is what holds them is checked on a device, where a launcher can bind it.
+
+    @Test
+    fun `each line of the note becomes its own row`() {
+        val rows = SingleNoteWidget.bodyRows(note().copy(contentMarkdown = "one\ntwo\nthree"))
+
+        assertEquals(listOf("one", "two", "three"), rows)
+    }
+
+    /**
+     * A row holding nothing can collapse, which runs paragraphs together — a
+     * scrolling widget that reads worse than the clipped one it replaced.
+     */
+    @Test
+    fun `a blank line keeps its height`() {
+        val rows = SingleNoteWidget.bodyRows(note().copy(contentMarkdown = "one\n\ntwo"))
+
+        assertEquals(listOf("one", SingleNoteWidget.BLANK_LINE, "two"), rows)
+    }
+
+    /** A file ending in a newline would otherwise scroll past its last word. */
+    @Test
+    fun `trailing blank lines are not drawn`() {
+        val rows = SingleNoteWidget.bodyRows(note().copy(contentMarkdown = "one\ntwo\n\n\n"))
+
+        assertEquals(listOf("one", "two"), rows)
+    }
+
+    /**
+     * Rows are lines, not fixed-size chunks: a long line wraps inside its own
+     * row. Splitting it by length would cut a sentence at a row boundary.
+     */
+    @Test
+    fun `a long line stays one row`() {
+        val line = "x".repeat(5_000)
+
+        assertEquals(listOf(line), SingleNoteWidget.bodyRows(note().copy(contentMarkdown = line)))
+    }
+
+    @Test
+    fun `carriage returns do not survive into a row`() {
+        val rows = SingleNoteWidget.bodyRows(note().copy(contentMarkdown = "one\r\ntwo"))
+
+        assertEquals(listOf("one", "two"), rows)
+    }
+
+    /**
+     * Both caps end the same way — a row saying the text goes on — so a reader
+     * who reaches the bottom can tell a cut note from a finished one.
+     */
+    @Test
+    fun `a note cut by the character cap ends in the truncation marker`() {
+        val rows = SingleNoteWidget.bodyRows(note().copy(contentMarkdown = "x".repeat(2_000_000)))
+
+        assertEquals(
+            listOf("x".repeat(SingleNoteWidget.MAX_BODY_CHARS), SingleNoteWidget.TRUNCATION_MARKER),
+            rows
+        )
+    }
+
+    @Test
+    fun `a note cut by the line cap ends in the truncation marker`() {
+        val many = (1..SingleNoteWidget.MAX_BODY_LINES + 50).joinToString("\n") { "line $it" }
+
+        val rows = SingleNoteWidget.bodyRows(note().copy(contentMarkdown = many))
+
+        assertEquals(SingleNoteWidget.MAX_BODY_LINES + 1, rows.size)
+        assertEquals(SingleNoteWidget.TRUNCATION_MARKER, rows.last())
+    }
+
+    @Test
+    fun `a note that fits carries no truncation marker`() {
+        assertEquals(
+            listOf("# Groceries", SingleNoteWidget.BLANK_LINE, "- milk"),
+            SingleNoteWidget.bodyRows(note())
+        )
+    }
+
+    /**
+     * The four "nothing to show" states collapse into one: no rows, so the
+     * empty view renders and there is no second rule per state.
+     */
+    @Test
+    fun `a locked, trashed, deleted or blank note yields no rows`() {
+        assertEquals(emptyList<String>(), SingleNoteWidget.bodyRows(note(locked = true)))
+        assertEquals(emptyList<String>(), SingleNoteWidget.bodyRows(note(trashed = true)))
+        assertEquals(emptyList<String>(), SingleNoteWidget.bodyRows(null))
+        assertEquals(
+            emptyList<String>(),
+            SingleNoteWidget.bodyRows(note().copy(contentMarkdown = "  \n\n"))
+        )
+    }
+
+    /**
+     * `RemoteViewsService` keys its factories by intent and ignores extras, so
+     * two single-note widgets sharing one intent would share a factory — and the
+     * second placed would quietly render the first one's note.
+     */
+    @Test
+    fun `each widget gets its own adapter intent`() {
+        val first = SingleNoteWidget.factoryIntent(context, 11)
+        val second = SingleNoteWidget.factoryIntent(context, 12)
+
+        assertNotEquals(first.data, second.data)
+        assertFalse(first.filterEquals(second))
     }
 
     /**


### PR DESCRIPTION
Closes #371. Reported by @ray4423 as a follow-up on #351.

## The problem

The Single Note widget drew its note in one `TextView`. A `RemoteViews` tree may only hold a fixed set of platform views, and `ScrollView` is not among them, so the body was clipped at the widget's height with no way to reach the rest — tapping through to the app was the only way to read on. The recent-notes widget on the same home screen scrolls, which made the difference read as an omission rather than a limit.

Scrolling is not a property that can be switched on. The only scrollable containers a widget can hold are the collection views, and each needs a `RemoteViewsService` behind it.

## The change

The body is a `ListView` fed by the new `SingleNoteWidgetService`, one row per line of the note.

**Rows are lines, not fixed-size chunks.** A long line wraps inside its own row rather than being cut at a boundary. A blank line carries a non-breaking space so paragraphs keep their spacing — a collapsed blank row would have made the scrolling widget read worse than the clipped one it replaces, which is the failure mode the issue flagged.

**Each widget gets its own adapter intent.** `RemoteViewsService` keys its factories by intent and ignores extras, so without a distinguishing `data` the second single-note widget placed would quietly render the first one's note. `QuickNoteWidget` does not need this because all of its instances show the same list.

**Tap-to-open moves to a template.** A `ListView` consumes row taps, so the single `setOnClickPendingIntent` becomes a `setPendingIntentTemplate` that each row completes with its note id. The destination is unchanged — the same entry point a recent-notes row uses.

**The provider no longer reads the database.** The note is loaded by the factory, on the background thread `onDataSetChanged` already runs on, instead of by a `runBlocking` on the receiver's main thread.

## The caps, and what is still unmeasured

`MAX_BODY_CHARS` stays at 20,000. Its original reason is gone — the body no longer crosses in one `setTextViewText`, so it can no longer blow the process's Binder payload — but a bound is still needed because the launcher's adapter holds the rows, and raising it is a measurement nobody has taken. What did change is that those 20,000 characters are now all reachable.

`MAX_BODY_LINES = 2_000` joins it, because 20,000 newlines are 20,000 rows. Both caps now end the body with a `…` row, so a reader who scrolls to the bottom can tell a cut note from a finished one.

Neither number is measured. Both are documented as such rather than presented as tuned.

## Verification

On the `markleaf-phone-api36` emulator (API 36), `SingleNoteWidgetRenderTest` — reworked, since it asserted on the concrete `TextView` that no longer exists:

- the container inflates as a `ListView` (the fix itself);
- the factory's rows render at the configured text size, against the real database, each row inflated through `RemoteViews.apply` so the assertion is about a real view;
- a note locked after it was chosen drops to zero rows and the empty view carries the "nothing to show" message;
- a host asking for the adapter actually reaches the service — the one check that would notice the manifest `<service>` missing or declared without `BIND_REMOTEVIEWS`, which would otherwise leave an empty widget while every other assertion stayed green.

Ran five times, no failures. `SingleNoteWidgetTest` pins the row rules as Robolectric unit tests (blank lines, trailing blank lines, CRLF, long lines, both caps, the four "nothing to show" states, and that two widgets get distinct adapter intents). `:app:testDebugUnitTest` and `:app:lintDebug` are green.

The rendered widget was also inspected by eye at 640×520 through a real `AppWidgetHost`, to check the thing tests cannot: that blank-line spacing and wrapping read correctly rather than merely being present.

## Not in scope

The body stays Markdown source rather than rendered text, as flagged when the widget shipped. Scrolling and rendering are independent, and conflating them would hold the smaller fix behind the larger question.

No version bump or release notes here — this is the code change only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
