### PR TITLE
ci: retry am start through the post-install resolution window

### DIFF
--- a/.github/scripts/launch-smoke.sh
+++ b/.github/scripts/launch-smoke.sh
@@ -35,22 +35,30 @@ echo "sys.boot_completed=${BOOT_COMPLETED}"
 
 # Waits until the device's package manager answers, or gives up.
 #
-# `Can't find service: package` is the device saying its own package service is
-# not there -- system_server dropped it -- and no amount of restarting the *adb
-# server* touches that. The string is matched by name because it is the one this
-# job has actually produced (twice: 2026-08-05 and on #377's own CI run); a
-# success format is not parsed, so nothing here depends on guessing what "ready"
-# looks like.
+# The probe must fail closed. An unrecognised answer is *not* evidence of
+# health: `Failure calling service package: Broken pipe (32)` is a second error
+# this job has produced, and treating anything-but-one-known-string as ready
+# would let it through and spend the next install attempt against a device that
+# is still broken -- which is the exhaustion this wait exists to prevent. So a
+# non-zero probe means not ready, and so does either observed error string; only
+# a clean exit with neither of them proceeds.
+#
+# The strings are still matched by name rather than a success format being
+# parsed: nothing here depends on guessing what "ready" looks like, only on
+# refusing to call "unknown" ready.
 #
 # Output is captured rather than piped, so `set -o pipefail` cannot turn an adb
-# failure into a false "service is back".
+# failure into a false "service is back"; the assignment sits in an `if` so its
+# exit status is kept instead of discarded.
 wait_for_package_service() {
   for _ in $(seq 1 30); do
-    probe="$(adb shell cmd package list packages 2>&1 || true)"
-    case "$probe" in
-      *"Can't find service: package"*) ;;
-      *) return 0 ;;
-    esac
+    if probe="$(adb shell cmd package list packages 2>&1)"; then
+      case "$probe" in
+        *"Can't find service: package"*) ;;
+        *"Failure calling service package"*) ;;
+        *) return 0 ;;
+      esac
+    fi
     echo "Package service is not answering yet"
     sleep 2
   done

--- a/.github/scripts/launch-smoke.sh
+++ b/.github/scripts/launch-smoke.sh
@@ -33,8 +33,38 @@ adb wait-for-device
 BOOT_COMPLETED="$(adb shell getprop sys.boot_completed | tr -d '\r')"
 echo "sys.boot_completed=${BOOT_COMPLETED}"
 
-# adb install can intermittently fail with broken pipe on CI emulators.
-# Retry with adb server restart before failing the job.
+# Waits until the device's package manager answers, or gives up.
+#
+# `Can't find service: package` is the device saying its own package service is
+# not there -- system_server dropped it -- and no amount of restarting the *adb
+# server* touches that. The string is matched by name because it is the one this
+# job has actually produced (twice: 2026-08-05 and on #377's own CI run); a
+# success format is not parsed, so nothing here depends on guessing what "ready"
+# looks like.
+#
+# Output is captured rather than piped, so `set -o pipefail` cannot turn an adb
+# failure into a false "service is back".
+wait_for_package_service() {
+  for _ in $(seq 1 30); do
+    probe="$(adb shell cmd package list packages 2>&1 || true)"
+    case "$probe" in
+      *"Can't find service: package"*) ;;
+      *) return 0 ;;
+    esac
+    echo "Package service is not answering yet"
+    sleep 2
+  done
+  return 1
+}
+
+# adb install can intermittently fail on CI emulators, in two different places.
+# `Broken pipe (32)` is the connection; `Can't find service: package` is the
+# device's own package service being gone. Restarting the adb server addresses
+# only the first -- so the second half of this loop waits for the service to
+# come back before spending the next attempt on it, which the previous version
+# did not: it burned attempts 2 and 3 six seconds apart against a device that
+# had no package manager, and reported "adb install failed after retries" as
+# though the APK were at fault.
 for attempt in 1 2 3; do
   echo "Install attempt ${attempt}"
   if adb install -r "$APK"; then
@@ -49,6 +79,10 @@ for attempt in 1 2 3; do
   adb kill-server || true
   adb start-server
   adb wait-for-device
+  if ! wait_for_package_service; then
+    echo "The device's package service never came back; the emulator is gone, not the build."
+    exit 1
+  fi
   sleep 5
 done
 

--- a/.github/scripts/launch-smoke.sh
+++ b/.github/scripts/launch-smoke.sh
@@ -75,5 +75,52 @@ if ! adb shell pm path "$PACKAGE" 2>/dev/null | tr -d '\r' | grep -q '^package:'
   exit 1
 fi
 
-adb shell am start -W -n "$PACKAGE/$ACTIVITY"
+# The wait above is necessary and not sufficient. `am start` can still answer
+# "Error type 3 / Activity class ... does not exist" after `pm path` has already
+# said yes: that query is satisfied once the APK path is registered, which is
+# earlier than the package manager's component index being complete. It is the
+# same post-install window, one step further along.
+#
+# Three runs of #376 failed exactly there -- install reported Success, this
+# script printed "Package indexed.", and `am start` then said the activity did
+# not exist -- on a runner whose emulator took six minutes to boot, while
+# `instrumented-tests` installed and drove the same build on the same commit.
+# A fourth run passed with no relevant change in between.
+#
+# Retrying the command that failed is deliberate. Waiting on some other query
+# instead would need an assumption about which one is authoritative for
+# component resolution, and the wrong choice is how the current guard came to
+# report success before `am start` could work. Retrying `am start` needs only
+# that this particular error is transient, and it is checked for by name:
+# anything else the command says is a real failure and stops immediately, so a
+# genuinely broken build still fails on the first attempt rather than after a
+# minute of retries.
+START_ATTEMPTS=15
+for attempt in $(seq 1 "$START_ATTEMPTS"); do
+  set +e
+  start_output="$(adb shell am start -W -n "$PACKAGE/$ACTIVITY" 2>&1)"
+  start_status=$?
+  set -e
+  printf '%s\n' "$start_output"
+
+  if ! printf '%s\n' "$start_output" | grep -q 'does not exist'; then
+    if [ "$start_status" -ne 0 ]; then
+      echo "am start failed (exit $start_status) for a reason other than the post-install window"
+      exit 1
+    fi
+    break
+  fi
+
+  if [ "$attempt" -eq "$START_ATTEMPTS" ]; then
+    echo "The activity was still unresolvable after $START_ATTEMPTS attempts."
+    echo "That is longer than the post-install window has ever taken; treat it as a real failure."
+    exit 1
+  fi
+
+  echo "Activity not resolvable yet -- retrying ($attempt/$START_ATTEMPTS)"
+  sleep 2
+done
+
+# The assertion the whole job exists for: the process is alive after the launch.
+# `set -e` fails the script when pidof prints nothing.
 adb shell pidof "$PACKAGE"


### PR DESCRIPTION
Follow-up to #376, where `launch-smoke` failed repeatedly. Two guards in `launch-smoke.sh` act on the wrong layer; this fixes both. Neither changes what the job asserts — the app still has to install, start, and be alive at the end.

## Guard 1 — `am start` through the post-install resolution window

```
Waiting for the package manager to see the app
Package indexed.
Starting: Intent { cmp=com.markleaf.notes.debug/com.markleaf.notes.MainActivity }
Error type 3
Error: Activity class {…MainActivity} does not exist.
```

The script already knows this error and guards it by polling `pm path` before `am start`. The log shows the guard **passing** — "Package indexed." is printed — and `am start` failing anyway. `pm path` is satisfied once the APK path is registered, which is earlier than the component index being complete: the same window, one step further along.

**That it was the window and not the app:** the diff on those heads touched no manifest and no activity declaration; `instrumented-tests` installed and drove the same build on the same commits and passed; the emulator took 361 s to boot; and a fourth run passed with no relevant change in between.

The fix retries the command that failed, rather than waiting on a different query first. Waiting on another query would need an assumption about which one is authoritative for component resolution — and picking wrong is how the present guard came to report success before `am start` could work. Retrying needs only that this error is transient. It is matched **by name**, so anything else stops on the first attempt: a genuinely broken build fails as fast as it does today.

## Guard 2 — waiting for the device's package service between install retries

This PR's own CI then produced the other half:

```
Install attempt 1 → cmd: Failure calling service package: Broken pipe (32)
Install attempt 2 → cmd: Can't find service: package
Install attempt 3 → cmd: Can't find service: package
adb install failed after retries
```

`Can't find service: package` is the **device** saying its own package service is gone. Restarting the **adb server** addresses the connection and nothing else, so attempts 2 and 3 were spent six seconds apart against a device with no package manager — and the job blamed the APK. The retry now waits for that service to answer before spending the next attempt, and says plainly when it never does.

## Verification

No emulator in this environment, so both loops were driven against a stub `adb`. The blocks executed are the ones this PR ships, **extracted from the file** rather than retyped.

`am start` retry:

| case | `am start` calls | exit | behaviour |
|---|---|---|---|
| succeeds first try | 1 | 0 | no retries, `pidof` reached |
| 3 transient failures, then success | 4 | 0 | retries 1–3, then proceeds |
| transient forever | 15 | 1 | stops at the bound |
| **a different error** | **1** | 1 | no retries, fails immediately |

install retry:

| case | `adb install` calls | exit | behaviour |
|---|---|---|---|
| healthy install | 1 | 0 | no probing at all |
| one failure, service healthy | 2 | 0 | probe passes, retries |
| one failure, service down 3 probes | 2 | 0 | waits, then installs |
| **service never returns** | **1** | 1 | gives up with the emulator message, without burning the remaining attempts |
| install fails 3×, service healthy | 3 | 1 | still bounded at 3, unchanged |

`bash -n` passes. `shellcheck` is not available here and has not been run.

## CI on this PR is red, on a third mode neither guard covers

```
java.lang.NullPointerException: Attempt to invoke virtual method
  'java.util.List android.os.storage.StorageManager.getVolumes()' on a null object reference
    at com.android.internal.content.PackageHelper.resolveInstallVolume(PackageHelper.java:200)
    at com.android.server.pm.PackageInstallerService.createSessionInternal(…)
```

The package service was **alive** here — it received the command and threw from inside it — so guard 2 correctly did not fire, and guard 1's code was again never reached. `StorageManager` is null inside system_server while the install session is being created; `sys.boot_completed` was 1, but the storage service was not usable.

**I have not added a third guard.** This PR exists because a guard watched a signal that was not the authoritative one, and any probe for this (`service check mount`, a settle delay, retrying the NPE by name) would be another unverified guess — there is no emulator here to check it against. The two guards above are validated; a third would not be.

Six `launch-smoke` failures across #376 and #377, in three distinct modes, all on runners taking six-plus minutes to boot an emulator — while `instrumented-tests` installed and drove the same builds and passed every time. That is evidence for the #291 decision to gate `main` on `build` + `instrumented-tests` and leave this job advisory, not against it. Both gating jobs are green here.

I have no means to re-run: `rerun-failed-jobs` and `workflow_dispatch` both return `403 Resource not accessible by integration` for this session.

## What this does not do

It does not make `launch-smoke` gate anything, and it does not address the runners' six-minute emulator boots, which are the condition all three modes appear under.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AiAyYi74nnxpbmyMBaFrMA