### PR TITLE
ci: build the release entirely in CI, and carry the mapping again

### DIFF
--- a/.agent/decisions.md
+++ b/.agent/decisions.md
@@ -1073,6 +1073,48 @@ Implications:
 - GitHub Actions는 `MARKLEAF_RELEASE_KEYSTORE_BASE64` 시크릿을 복원해 태그 릴리즈에서만 signed APK를 생성한다.
 - 일반 PR/main 빌드는 debug 빌드와 테스트만 수행해 공개 소스 빌드 가능성을 유지한다.
 
+### D072 - The Release Is Built Entirely By CI, And Carries The Mapping Again
+
+Play 업로드가 보류된 동안 릴리스 경로에서 로컬 단계를 없앤다. 태그 런이 서명 APK와
+R8 mapping을 만들어 **둘 다** GitHub Release에 붙이고, AAB는 만들지 않는다. 태그를
+밀기 전에 사람이 할 일은 없다.
+
+Why:
+- **D064가 이 재검토를 명시적으로 요구했다.** "If the local export is ever dropped,
+  this entry has to be revisited before it is." D064가 mapping을 Release 자산에서
+  뺀 근거는 "영구 사본이 이미 있다"(`D:\Build`)였고, 그 export를 릴리스 경로에서
+  빼면 근거가 사라진다. 남는 것은 30일 아티팩트뿐이고, 그건 영구 사본이 아니다.
+  결정을 그대로 두고 전제만 무너뜨리는 것이 최악이므로 되돌린다.
+- **AAB는 소비자가 하나뿐인데 그 하나가 멈춰 있다.** Play Console 전용이고 Play
+  업데이트는 보류 중이다(README 8개 언어). `.aab`는 사이드로드가 불가능해 Release
+  자산도 아니었다(D062). 태그마다 몇 분과 산출물 하나를 아무도 쓰지 않는 데 쓴다.
+- **사람이 기억해야만 도는 단계는 실제로 잊힌다.** `D:\Build`는 CI가 볼 수 없는
+  로컬 경로라 건너뛰어도 아무것도 빨개지지 않았고, v2.27.2부터 v2.29.0까지 여섯
+  릴리스가 AAB·mapping 없이 지나갔다(#247). `verify-release-export.ps1`은 그 뒤에
+  추가된 보정이지만, 그것 역시 사람이 실행해야 돈다. 산출물을 태그 런으로 옮기면
+  이 실패 양식 자체가 사라진다.
+- mapping이 Release에 다시 붙는 대가는 D064가 적은 그대로다: 41 MB 파일이 2.7 MB
+  APK 옆에 놓인다. 다운로드 0회라는 관찰도 유효하다. 다만 그건 **필요할 때 없는 것**
+  보다 나은 문제이고, 사이드로드 크래시 역난독화는 이 파일이 유일한 수단이다.
+
+Implications:
+
+- `gh release create`는 `markleaf-vX.Y.Z.apk`와 `markleaf-vX.Y.Z.mapping.txt` 둘을
+  붙인다. 목록의 세 복사본(워크플로 인자, 스테이징 스텝, 문서 마커 3곳)은
+  `scripts/verify-release-assets.ps1`이 계속 대조하므로 함께 고쳐야 한다.
+- AAB 3개 스텝(빌드·검증·아티팩트)은 저장소 변수 `MARKLEAF_PLAY_AAB` 뒤로 들어간다.
+  변수는 미설정이라 전부 skip 된다. **삭제가 아니라 게이트인 이유**는 #211/#212
+  선례(D067이 인용)다 — 지워진 메커니즘은 그것이 있었는지 모르는 사람이 되살릴 수
+  없고, Play는 포기가 아니라 보류다. 재개 시 변수를 `true`로 두면 그대로 돌아온다.
+- `:app:exportReleaseToBuildDrive`와 `scripts/verify-release-export.ps1`은 지우지
+  않는다. 같은 이유로 남겨 두되 `AGENTS.md`의 릴리스 절차에서는 빠진다. 되살릴 때는
+  `MARKLEAF_PLAY_AAB`와 함께 켠다.
+- **D066을 다시 건드리지는 않는다.** GitLab은 여전히 아무것도 미러하지 않는다.
+  이 결정은 "영구 사본이 어디인가"를 `D:\Build`에서 GitHub Release로 옮기는 것이지,
+  미러를 되살리는 것이 아니다.
+- `markleaf-release-mapping` 아티팩트(30일)는 남긴다. 이제 유일한 GitHub 사본이
+  아니라 태그 런에서 바로 집기 위한 편의다.
+
 ### D071 - The Widgets Read The Colors Setting From A SharedPreferences Mirror
 
 홈 화면 위젯은 Settings → Appearance → Colors 값을 DataStore가 아니라

--- a/.agent/progress.md
+++ b/.agent/progress.md
@@ -2694,3 +2694,29 @@ Verification:
   `a fixed theme gives the host no choice`,
   `the mirror heals itself from the authoritative settings`).
 - `./gradlew :app:testDebugUnitTest :app:lintRelease` — passed.
+
+---
+
+## 2026-09-09 - Release build handed to CI (D072)
+
+Selected task:
+- 메인테이너 요청: Play 보류 중이라 AAB가 필요 없으니 릴리스 빌드를 CI로 넘긴다.
+
+What was implemented:
+- AAB 3개 스텝(빌드·검증·아티팩트)을 `MARKLEAF_PLAY_AAB` 저장소 변수 뒤로 넣었다.
+  삭제가 아니라 게이트인 이유는 #211/#212 선례(D067 인용) — Play는 포기가 아니라 보류다.
+- R8 mapping을 다시 Release 자산으로 붙인다. D064가 mapping을 뺀 근거가
+  "`D:\Build`에 영구 사본이 있다"였고, 그 export가 릴리스 경로에서 빠지면 그 전제가
+  무너진다. D064 자신이 "the local export is ever dropped → revisit this entry first"
+  라고 적어 둔 상황이라 그대로 재검토해 되돌렸다.
+- `AGENTS.md` 릴리스 절차에서 태그 전 로컬 단계를 없앴다. `exportReleaseToBuildDrive`와
+  `verify-release-export.ps1`은 지우지 않고 남겨 Play 재개 시 되살린다.
+- 자산 목록 세 복사본(워크플로 인자, 스테이징 스텝, 문서 마커 3곳)을 함께 갱신했다.
+
+Verification:
+- `verify-release-assets.ps1`의 세 검사를 파이썬으로 재현해 통과 확인
+  (pwsh 미설치). 워크플로 YAML 파싱 확인. CI가 스크립트 자체를 `build`에서 돌린다.
+
+Decision:
+- D072 기록.
+

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -340,9 +340,27 @@ jobs:
           MARKLEAF_RELEASE_KEY_ALIAS: ${{ secrets.MARKLEAF_RELEASE_KEY_ALIAS }}
           MARKLEAF_RELEASE_KEY_PASSWORD: ${{ secrets.MARKLEAF_RELEASE_KEY_PASSWORD }}
           ORG_GRADLE_PROJECT_markleaf.requireReleaseSigning: "true"
-        run: |
-          ./gradlew :app:assembleRelease
-          ./gradlew :app:bundleRelease
+        run: ./gradlew :app:assembleRelease
+
+      # The AAB exists for exactly one consumer, Play Console, and Play updates
+      # are on hold (README, all eight languages). Building it anyway costs a
+      # couple of minutes per tag and produces a file nobody can take: an .aab
+      # cannot be sideloaded, and D062 already keeps it off the Release for that
+      # reason.
+      #
+      # Gated rather than deleted, on the #211/#212 precedent D067 cites: a
+      # deleted mechanism cannot be turned back on by someone who does not know
+      # it existed, and Play is paused rather than abandoned. Set the repository
+      # variable MARKLEAF_PLAY_AAB to 'true' and the three AAB steps come back.
+      - name: Build Play Console AAB
+        if: vars.MARKLEAF_PLAY_AAB == 'true'
+        env:
+          MARKLEAF_RELEASE_STORE_FILE: release/markleaf-release.p12
+          MARKLEAF_RELEASE_STORE_PASSWORD: ${{ secrets.MARKLEAF_RELEASE_STORE_PASSWORD }}
+          MARKLEAF_RELEASE_KEY_ALIAS: ${{ secrets.MARKLEAF_RELEASE_KEY_ALIAS }}
+          MARKLEAF_RELEASE_KEY_PASSWORD: ${{ secrets.MARKLEAF_RELEASE_KEY_PASSWORD }}
+          ORG_GRADLE_PROJECT_markleaf.requireReleaseSigning: "true"
+        run: ./gradlew :app:bundleRelease
 
       - name: Verify release signing certificate
         run: |
@@ -371,8 +389,14 @@ jobs:
           cp "$APK" "markleaf-${GITHUB_REF_NAME}.apk"
           test -s "markleaf-${GITHUB_REF_NAME}.apk"
           ls -lh "markleaf-${GITHUB_REF_NAME}.apk"
+          MAPPING="app/build/outputs/mapping/release/mapping.txt"
+          test -f "$MAPPING"
+          cp "$MAPPING" "markleaf-${GITHUB_REF_NAME}.mapping.txt"
+          test -s "markleaf-${GITHUB_REF_NAME}.mapping.txt"
+          ls -lh "markleaf-${GITHUB_REF_NAME}.mapping.txt"
 
       - name: Verify Play Console AAB exists
+        if: vars.MARKLEAF_PLAY_AAB == 'true'
         run: |
           AAB="app/build/outputs/bundle/release/app-release.aab"
           test -f "$AAB"
@@ -387,6 +411,7 @@ jobs:
           ls -lh "$MAPPING"
 
       - name: Upload Play Console AAB artifact
+        if: vars.MARKLEAF_PLAY_AAB == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: markleaf-release-aab
@@ -402,9 +427,9 @@ jobs:
           name: markleaf-release-mapping
           path: app/build/outputs/mapping/release/mapping.txt
           if-no-files-found: error
-          # 릴리스 에셋에서 뺀 뒤로는 GitHub 쪽 유일한 사본이다(영구 사본은
-          # D:\Build 와 GitLab 패키지 레지스트리, D064). 크래시 역난독화
-          # 요청이 뒤늦게 들어올 여유를 두어 30일로 잡는다.
+          # 영구 사본은 이제 Release 자산 쪽이다(D072). 이 아티팩트는 태그 런의
+          # 다른 산출물과 같은 자리에서 바로 집을 수 있다는 편의로 남기고,
+          # 30일이면 그 용도에는 충분하다.
           retention-days: 30
 
       - name: Prepare release notes
@@ -445,6 +470,7 @@ jobs:
           fi
           gh release create "$GITHUB_REF_NAME" \
             "markleaf-${GITHUB_REF_NAME}.apk" \
+            "markleaf-${GITHUB_REF_NAME}.mapping.txt" \
             --repo "$GITHUB_REPOSITORY" \
             --title "$(cat release-title.txt)" \
             --notes-file release-notes.md
@@ -471,9 +497,12 @@ jobs:
       #   * re-issue GITLAB_TOKEN with the `api` scope (then this works), or
       #   * unset GITLAB_RELEASE_MIRROR (then both steps skip, as before).
       #
-      # assembleRelease and bundleRelease already ran above; this re-runs them
-      # as dependencies, finds them up to date, and copies the outputs out under
-      # their versioned names alongside the six-locale notes.
+      # assembleRelease already ran above; this re-runs it as a dependency and
+      # finds it up to date, then copies the outputs out under their versioned
+      # names alongside the six-locale notes. bundleRelease no longer runs above
+      # unless MARKLEAF_PLAY_AAB is set (D072), so when this step is revived it
+      # builds the AAB itself — slower on the first tag after the revival, and
+      # correct either way.
       - name: Export versioned release artifacts
         if: vars.GITLAB_RELEASE_MIRROR == 'true'
         env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,11 @@ Android 프로젝트가 아직 초기화되지 않았다면 먼저 표준 Kotlin
 
 ## Release Artifact Export
 
+> **이 절차는 Play 업로드가 보류된 동안 릴리스 경로에서 빠져 있다(D072).** 태그 런이
+> APK와 mapping을 만들어 GitHub Release에 붙이므로 태그 전에 할 로컬 작업은 없다.
+> 아래 내용은 Play 업로드가 재개될 때 되살리기 위해 그대로 둔다 — 그때는
+> `MARKLEAF_PLAY_AAB` 저장소 변수를 `true`로 두면 CI가 서명 AAB도 다시 만든다.
+
 사용자가 "새 버전 만들기"를 요청하면 버전 bump, changelog, fastlane changelog, 검증, commit/tag 작업과 함께 실제 산출물 디렉터리인 `D:\Build`에 Play Console 제출용 파일을 내보낸다. 바탕화면의 `Build`는 이 디렉터리를 가리키는 바로가기일 뿐이며, 릴리스 task는 바로가기를 경유하지 않는다. 이 dump는 전용 Gradle task로 자동화되어 있다:
 
 ```bash
@@ -154,16 +159,18 @@ GitLab CI용 산출물은 `-Pmarkleaf.releaseExportDir=<dir>`와 함께
    workflow_dispatch — 로컬 재기록은 폰트 힌팅 차이로 CI verify와 어긋난다).
 3. **F-Droid — 태그 푸시로 자동 배포.** versionCode/versionName bump + `CHANGELOG.md`(영어,
    릴리즈 노트 원본) + `CHANGELOG.ko.md`(한국어판) + fastlane changelog 작성 후 main에
-   푸시한다. **태그를 밀기 전에** `:app:exportReleaseToBuildDrive`로 `D:\Build` 산출물을
-   남기고 `pwsh scripts/verify-release-export.ps1`로 확인한다 — `D:\Build`는 CI가 볼 수 없는
-   로컬 경로라 이 단계가 빠져도 아무것도 실패하지 않으며, 실제로 v2.27.2부터 v2.29.0까지
-   여섯 릴리스가 AAB·mapping 없이 지나갔다(#247). 그다음 `vX.Y.Z` 태그를 **GitHub에만**
+   푸시한다. **태그를 밀기 전에 할 로컬 작업은 없다(D072).** 릴리스 산출물은 태그 런이
+   전부 만들고 Release에 붙인다 — APK와 mapping 둘 다. `:app:exportReleaseToBuildDrive`와
+   `verify-release-export.ps1`은 지우지 않고 남겨 두었지만 릴리스 절차에서 빠졌다:
+   Play 업로드가 재개되면 그때 되살린다. 사람이 기억해야만 도는 단계였기에 v2.27.2부터
+   v2.29.0까지 여섯 릴리스가 AAB·mapping 없이 지나갔고(#247), 그 실패 양식을 없애는 것이
+   이 변경의 목적이다. `vX.Y.Z` 태그는 **GitHub에만**
    푸시한다 — GitLab 태그 푸시는 D068에서 뺐다(GitLab은 v2.32.4에 얼어붙은 스냅샷이라,
    태그를 밀면 그쪽 `main`에서 도달하지 못하는 커밋을 가리키게 된다).
-   **릴리스 자산이 붙는 곳은 GitHub 하나뿐이다** — GitHub
-   Release는 APK 하나만 담고(AAB 제외는 D062, mapping을 30일 아티팩트로만 두는 이유는
-   D064), **GitLab은 아무것도 미러하지 않는다**(D066 → D067·D068).
-   <!-- release-assets: markleaf-vX.Y.Z.apk -->
+   **릴리스 자산이 붙는 곳은 GitHub 하나뿐이다** — GitHub Release는 APK와 mapping
+   두 개를 담고(mapping을 자산으로 되돌린 이유는 D072, AAB 제외는 D062),
+   **GitLab은 아무것도 미러하지 않는다**(D066 → D067·D068).
+   <!-- release-assets: markleaf-vX.Y.Z.apk, markleaf-vX.Y.Z.mapping.txt -->
    위 마커는 `scripts/verify-release-assets.ps1`이 읽어 워크플로의 실제
    `gh release create` 인자와 대조한다. 목록을 바꾸려면 세 복사본(워크플로,
    스테이징 스텝, 이 마커)을 함께 고쳐야 하며 그렇지 않으면 PR CI가 실패한다.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,9 +80,10 @@ CI 또는 릴리즈 검증 시에는 APK 산출물 확인을 반드시 포함한
 
 - `app/build/outputs/apk/debug/app-debug.apk` 파일 존재 여부 확인
 - GitHub Release에서 APK 다운로드 가능 여부와 크기가 0보다 큰지 확인
-- 태그 전에 `pwsh scripts/verify-release-export.ps1` — `D:\Build`의 AAB·mapping·8개
-  로케일 노트가 현재 versionName/versionCode로 존재하고 비어 있지 않은지 확인한다.
-  **이것이 릴리스 자산의 유일한 영구 사본 검증이다**(D066).
+- **태그 전 로컬 검증은 없다(D072).** `verify-release-export.ps1`은 `D:\Build`를 보는
+  스크립트인데 그 export가 릴리스 경로에서 빠졌다. 릴리스 자산은 태그 런이 만들어
+  GitHub Release에 붙이므로, 확인할 곳은 Release 페이지다 — APK와 mapping 두 개.
+  Play가 재개되면 `MARKLEAF_PLAY_AAB`와 함께 이 검증도 되살린다.
 - **GitLab 쪽 검증은 해당 없음이다 — GitLab은 아무것도 발행·미러하지 않는다(D067·D068).**
   `GITLAB_RELEASE_MIRROR`와 `GITLAB_REF_MIRROR` 둘 다 미설정이라 릴리스 발행 스텝 2개와
   `mirror-push`·`mirror-check`가 전부 skip 된다. GitLab `main`은 v2.32.4 시점에 얼어
@@ -179,8 +180,8 @@ GitLab CI용 산출물은 `-Pmarkleaf.releaseExportDir=<dir>`와 함께
    내렸다(D068).** 두 스텝이 skip 되므로 태그 런은 녹색이고, GitLab Release는 만들지
    않는다 — `GITLAB_TOKEN`이 `api` 스코프가 아니라 v2.28.0~v2.32.2 열한 릴리스가 이미
    403으로 실패했고(#247, #252), 미러 자체를 끈 마당에 토큰을 재발급할 이유가 없다.
-   따라서 released AAB·mapping의 영구 사본은 `D:\Build` 하나이며, 위의
-   `exportReleaseToBuildDrive` 단계를 건너뛰면 대체 사본이 없다.
+   released mapping의 영구 사본은 이제 GitHub Release 자산이다(D072) — `D:\Build`가
+   유일한 사본이던 시절의 서술은 여기서 끝난다. AAB는 Play 보류 동안 아예 만들지 않는다.
    GitHub 태그는 F-Droid 자동 픽업도 발동하므로 별도 F-Droid 제출 단계는 없다.
    릴리스 커밋은 `git add -A`로 만들지 않는다 — 변경 파일을 명시적으로 stage하거나 커밋 전
    working tree가 릴리스 대상만 담고 있는지 확인한다(무관한 작업이 태그에 섞여 나가는 것을
@@ -189,9 +190,10 @@ GitLab CI용 산출물은 `-Pmarkleaf.releaseExportDir=<dir>`와 함께
    `build` 워크플로가 `scripts/verify-release-notes.ps1`과 `scripts/verify-landing-versions.ps1`로
    검사한다. 기준은 `app/build.gradle.kts`의 versionName/versionCode이므로, bump만 하고 나머지를
    빠뜨리면 태그를 밀기 전에 PR 단계에서 실패한다(#167).
-4. **Play Store — 산출물 핸드오프.** [Release Artifact Export](#release-artifact-export)에 따라
-   Play 제출용 서명 AAB와 릴리즈 노트 TXT를 내보낸다(서명 AAB는 CI 릴리스 산출물 기준).
-   업로드는 메인테이너가 수동으로 한다.
+4. **Play Store — 현재 해당 없음(D072).** Play 업데이트가 보류 중이라 서명 AAB를 만들지
+   않으므로 핸드오프할 산출물이 없다. 재개하면 `MARKLEAF_PLAY_AAB` 저장소 변수를 `true`로
+   두고 [Release Artifact Export](#release-artifact-export)의 절차를 되살린다 — 업로드는
+   그때도 메인테이너가 수동으로 한다.
 5. **마감 + 보고.** 해결된 이슈에 감사 댓글을 달고 닫되, 사용자측 확인이 남으면 열어 둔다.
    굵직한 변경이면 README·랜딩 페이지의 버전 표기를 8개 언어 모두 갱신하고
    `scripts/verify-landing-versions.ps1`로 검증한다. 마지막으로 무엇이 나갔는지,

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -175,12 +175,13 @@ crash reports:
 app/build/outputs/mapping/release/mapping.txt
 ```
 
-Keep the mapping that corresponds to each released APK. The permanent copies
-live in `D:\Build` through the local `exportReleaseToBuildDrive` hand-off and
-in the GitLab package registry. GitHub keeps it only as the 30-day
-`markleaf-release-mapping` workflow artifact — it is no longer attached to the
-GitHub Release, so pull it from one of the permanent copies when an older
-version needs deobfuscating.
+Keep the mapping that corresponds to each released APK. Since D072 the
+permanent copy is the GitHub Release itself: every tag attaches
+`markleaf-vX.Y.Z.mapping.txt` beside the APK, so deobfuscating an older version
+means downloading it from that version's Release. The 30-day
+`markleaf-release-mapping` workflow artifact is still produced, now as a
+convenience for picking it up next to the tag run's other outputs rather than as
+the only GitHub-side copy.
 
 If R8 strips something at runtime (NoClassDefFoundError, missing reflection
 target, lost Compose Composer slot), the fix is to add a precise `-keep`
@@ -334,6 +335,12 @@ A failure that survives a cold boot is real. One that does not is the emulator.
 
 ## Release Export — Local Gate, Not CI
 
+> **Out of the release path since D072.** Play uploads are on hold, so the AAB
+> is not built and the mapping ships as a GitHub Release asset instead. There is
+> nothing to run before pushing a tag, and nothing below is a gate today. It is
+> kept for the day Play resumes: set the repository variable `MARKLEAF_PLAY_AAB`
+> to `true` and this section applies again as written.
+
 **CI cannot check this.** `D:\Build` is a local path on the maintainer's
 machine, so no pipeline can confirm the export ran. Run it, then verify it,
 before pushing a tag:
@@ -382,6 +389,12 @@ leaves behind. Lowering `-Xmx` is the right instinct, because the starvation is
 native rather than heap, and it is not always enough — v2.32.6 crashed at both
 `2048m` and `1536m` with roughly 1.7 GB free. Close what you can and retry
 first; the rest of this section is for when that does not work.
+
+> Also out of the release path since D072, and doubly so: with
+> `MARKLEAF_PLAY_AAB` unset there is no `markleaf-release-aab` artifact to
+> download, and the mapping no longer needs recovering from a workflow artifact
+> because it is attached to the Release itself. What remains below applies only
+> once the AAB build is switched back on.
 
 **The tag job has already built the same two artifacts.** `release` runs
 `:app:exportReleaseArtifacts` on the tagged commit with the CI signing secrets,

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -600,11 +600,12 @@ tag pipelines can read the signing variables. Never expose these variables to
 branch or merge-request jobs.
 
 On tag pushes matching `v*`, GitHub Actions runs tests, builds the signed
-release APK and AAB, and creates a GitHub Release with **one** asset attached:
+release APK, and creates a GitHub Release with **two** assets attached:
 
-<!-- release-assets: markleaf-vX.Y.Z.apk -->
+<!-- release-assets: markleaf-vX.Y.Z.apk, markleaf-vX.Y.Z.mapping.txt -->
 
 - `markleaf-vX.Y.Z.apk` — signed, R8-shrunk APK for sideload installs and the Releases mirror
+- `markleaf-vX.Y.Z.mapping.txt` — R8 mapping for deobfuscating crash reports from that build
 
 The comment above is not decoration. `scripts/verify-release-assets.ps1` reads
 it and fails the `build` job if it disagrees with the arguments the workflow
@@ -612,23 +613,27 @@ actually passes to `gh release create` — this list drifted twice while D062 an
 D064 shrank it, and nothing failed either time. Change the list and you change
 all three copies together, or CI says so.
 
-<!-- release-assets: markleaf-vX.Y.Z.apk -->
+<!-- release-assets: markleaf-vX.Y.Z.apk, markleaf-vX.Y.Z.mapping.txt -->
 
-The signed AAB and the R8 mapping are built and verified in the same job but are
-**not** attached to the GitHub Release. Both are uploaded as workflow artifacts
-instead — `markleaf-release-aab` (14-day retention) and
-`markleaf-release-mapping` (30-day retention) — and both reach their permanent
-home through the local `exportReleaseToBuildDrive` hand-off
-(see [Release Artifact Export](../AGENTS.md#release-artifact-export)) rather
-than from GitHub. That hand-off is the **only** permanent copy: GitLab's
-package registry stopped receiving them at v2.27.2, and as of D068 the mirror
-steps do not run at all — see [GitLab Release Assets](#gitlab-release-assets),
-D066 and D068.
+The mapping is attached because the Release is now where it permanently lives
+(D072). It used to reach `D:\Build` through the local `exportReleaseToBuildDrive`
+hand-off, and that hand-off left the release path when Play uploads were paused —
+so the reason D064 gave for keeping the mapping off the Release ("permanent
+copies already exist") stopped being true, and the decision was reversed rather
+than left to rot. `markleaf-release-mapping` is still uploaded as a 30-day
+workflow artifact, now for convenience rather than as the only GitHub-side copy.
+
+The signed AAB is **not built at all** while Play updates are on hold. Its three
+steps — build, verify, artifact upload — are gated behind the repository
+variable `MARKLEAF_PLAY_AAB`, which is unset. Setting it to `true` brings them
+back; nothing was deleted, on the same precedent D067 cites for the GitLab
+mirror. An `.aab` cannot be sideloaded, so it was never a Release asset anyway
+(D062).
 
 The release job fails before publishing if the keystore secret is missing, if
 the APK certificate SHA-256 digest differs from the fixed production
-certificate, or if the APK, AAB, or mapping file is missing from the build
-outputs.
+certificate, or if the APK or mapping file is missing from the build outputs —
+and, when `MARKLEAF_PLAY_AAB` is set, the AAB as well.
 
 ## GitLab Release Assets
 

--- a/scripts/verify-release-assets.ps1
+++ b/scripts/verify-release-assets.ps1
@@ -20,7 +20,7 @@
 
   문서 쪽은 산문을 파싱하지 않는다. 기계가 읽을 마커 한 줄을 두고 그것을 비교한다:
 
-      <!-- release-assets: markleaf-vX.Y.Z.apk -->
+      <!-- release-assets: markleaf-vX.Y.Z.apk, markleaf-vX.Y.Z.mapping.txt -->
 
   마커는 자기를 설명하는 산문 바로 옆에 둔다. 목록을 고치는 사람이 마커를 못 보고
   지나가기 어렵고, 지나가면 이 검사가 잡는다.


### PR DESCRIPTION
Play uploads are on hold, so the AAB has no consumer — and with it the local `D:\Build` hand-off has nothing left to carry that the tag run cannot. This moves the whole release build into CI: **nothing to run by hand before pushing a tag.**

Recorded as **D072**.

## The AAB stops being built

Its three steps — build, verify, artifact upload — go behind the repository variable `MARKLEAF_PLAY_AAB`, which is unset. An `.aab` has exactly one consumer, Play Console, and it was never a Release asset because it cannot be sideloaded (D062).

**Gated rather than deleted**, on the #211/#212 precedent D067 cites: a deleted mechanism cannot be turned back on by someone who does not know it existed, and Play is paused rather than abandoned. Set the variable to `true` and the AAB comes back exactly as it was.

## The mapping becomes a Release asset again

D064 took the mapping off the asset list because *"permanent copies already exist"* — meaning `D:\Build`. Dropping that export from the release path removes the premise and leaves a 30-day workflow artifact and nothing else. D064 anticipated this in as many words:

> `D:\Build` is now the primary permanent copy, not a redundant one. **If the local export is ever dropped, this entry has to be revisited before it is.**

So it is revisited rather than quietly falsified. The cost D064 recorded still stands and is not disputed: a ~41 MB file sitting beside a 2.7 MB APK, with a download count of zero. That is a better problem than not having the file when a sideloaded crash report needs deobfuscating — which is the only thing it is for now that Play holds no copy of its own for these builds.

## Why the local step goes rather than staying as a belt

It was a step a person had to remember. `D:\Build` is a local path CI cannot see, so skipping it reddens nothing — and six releases from v2.27.2 to v2.29.0 shipped without an AAB or a mapping before anyone noticed (#247). `verify-release-export.ps1` was the correction, but it too only runs when a person runs it. Moving the artifacts into the tag run removes the failure shape instead of guarding it.

`:app:exportReleaseToBuildDrive` and `scripts/verify-release-export.ps1` are **kept**, and simply leave the release ritual in `AGENTS.md`. They come back with `MARKLEAF_PLAY_AAB` when Play resumes.

## The asset list's three copies

`scripts/verify-release-assets.ps1` cross-checks the `gh release create` arguments, the files `Prepare release asset` stages, and the `<!-- release-assets: … -->` markers. All are updated together — the markers in `AGENTS.md` and **both** `docs/RELEASE.md` paragraphs — or the `build` job fails.

## Verification

`pwsh` is not available in this environment, so the script could not be run as itself; its three checks were reproduced against the same inputs instead:

| check | result |
|---|---|
| `gh release create` file arguments | `markleaf-vX.Y.Z.apk`, `markleaf-vX.Y.Z.mapping.txt` |
| files staged by `Prepare release asset` | same two, exactly |
| doc markers (3, across 2 files) | all agree with the workflow |

The workflow YAML parses. CI runs the real script in `build`, which is the point of it living there.

## Not covered

- The gated AAB path is not exercised by this PR; it runs only on a tag with `MARKLEAF_PLAY_AAB` set. What is checked is that with the variable unset the steps skip and nothing downstream reads the AAB.
- `D066` is untouched: GitLab still mirrors nothing. This moves where the permanent copy lives, from `D:\Build` to the GitHub Release; it does not revive a mirror.
- The `Export versioned release artifacts` step (behind `GITLAB_RELEASE_MIRROR`, unset) had a comment claiming `bundleRelease` already ran; it is corrected, since that is now conditional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AiAyYi74nnxpbmyMBaFrMA

---
_Generated by [Claude Code](https://claude.ai/code/session_01AiAyYi74nnxpbmyMBaFrMA)_