### PR TITLE
docs(agents): post a Discussions announcement on every release

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,12 @@ Android 프로젝트가 아직 초기화되지 않았다면 먼저 표준 Kotlin
 
 사용자가 "새 버전 만들기"를 요청하면 버전 bump, changelog, fastlane changelog, 검증, commit/tag 작업과 함께 실제 산출물 디렉터리인 `D:\Build`에 Play Console 제출용 파일을 내보낸다. 바탕화면의 `Build`는 이 디렉터리를 가리키는 바로가기일 뿐이며, 릴리스 task는 바로가기를 경유하지 않는다. 이 dump는 전용 Gradle task로 자동화되어 있다:
 
+**릴리스는 무엇이 시작했든 Discussions 공지로 끝난다.** 이슈 대응이든, 위처럼 직접
+"새 버전 만들기"를 받았든, 문서만 바뀐 릴리스든 마찬가지다 — 태그 런이 녹색이면
+[GitHub 이슈 대응](#github-이슈-대응)의 **5단계 공지**를 그대로 진행한다. 카테고리 ID와
+본문에 담을 것은 그 단계에 적혀 있다. 공지만 그 플로 안에 살고 있어서, 이슈에서 출발하지 않은
+릴리스가 조용히 빠지는 일을 막기 위해 여기에도 적는다.
+
 ```bash
 ./gradlew :app:exportReleaseToBuildDrive
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -194,13 +194,33 @@ GitLab CI용 산출물은 `-Pmarkleaf.releaseExportDir=<dir>`와 함께
    않으므로 핸드오프할 산출물이 없다. 재개하면 `MARKLEAF_PLAY_AAB` 저장소 변수를 `true`로
    두고 [Release Artifact Export](#release-artifact-export)의 절차를 되살린다 — 업로드는
    그때도 메인테이너가 수동으로 한다.
-5. **마감 + 보고.** 해결된 이슈에 감사 댓글을 달고 닫되, 사용자측 확인이 남으면 열어 둔다.
+5. **Discussions 공지.** 태그 런의 `release` 잡이 녹색이고 Release 자산(APK·mapping)을
+   눈으로 확인한 뒤, Discussions → **Announcements**에 릴리스 공지를 올린다. 그 카테고리는
+   환영글 #206이 스스로 "releases and important notices (maintainer posts)"로 정의해 둔 자리다.
+   본문은 아래 "GitHub 공개 표면 콘텐츠 — 영어 기본"에 따라 **영어**로 쓴다.
+
+   담을 것: Release 페이지 링크와 versionCode, CHANGELOG 제목 한 줄, 사용자가 실제로
+   겪을 변화와 **그 변화의 한계**(예: OS 버전 요구, 새로 고치지 못한 경계 조건),
+   외부 보고자 크레딧(`@handle` + 이슈 링크), F-Droid는 자체 일정이라 며칠 걸릴 수 있다는
+   안내, 버그는 Issues·아이디어는 Discussions라는 분기. CHANGELOG를 그대로 붙여넣지
+   않는다 — 릴리스 노트는 Release 페이지에 이미 있고, 공지는 그것을 읽혀야 할 이유다.
+
+   ```bash
+   QUERY='mutation($repo:ID!,$cat:ID!,$title:String!,$body:String!){ createDiscussion(input:{repositoryId:$repo,categoryId:$cat,title:$title,body:$body}){ discussion{ number url } } }'
+   gh api graphql -f query="$QUERY" -f repo=R_kgDOSPZMRw -f cat=DIC_kwDOSPZMR84DBtQR -f title='Markleaf vX.Y.Z — <CHANGELOG title>' -F body=@announcement.md
+   ```
+
+   `cat=DIC_kwDOSPZMR84DBtQR`가 Announcements다. **공지 고정(pin)은 웹 UI 전용**이라 API로
+   못 한다 — 고정이 필요하면 보고에 적어 메인테이너가 누르게 한다. 첫 사례는
+   v2.37.5의 [#379](https://github.com/jeiel85/markleaf-android/discussions/379)이다.
+
+6. **마감 + 보고.** 해결된 이슈에 감사 댓글을 달고 닫되, 사용자측 확인이 남으면 열어 둔다.
    굵직한 변경이면 README·랜딩 페이지의 버전 표기를 8개 언어 모두 갱신하고
    `scripts/verify-landing-versions.ps1`로 검증한다. 마지막으로 무엇이 나갔는지,
    이슈 상태, 릴리스 링크를 보고한다.
 
-코드 수정이 실제로 들어간 경우에만 3·4단계(태그·Play 핸드오프)를 진행한다. 댓글로 끝나는
-이슈는 1·5단계만 적용한다.
+코드 수정이 실제로 들어가 릴리스가 나간 경우에만 3·4·5단계(태그·Play 핸드오프·공지)를
+진행한다. 댓글로 끝나는 이슈는 1·6단계만 적용한다.
 
 이 플로에서는 **새 하드닝 후보 이슈를 만들지 않는다.** 남은 이슈를 소진하려는 작업이 매번 새
 이슈를 낳으면 백로그가 줄지 않고 끝나지 않는 굴레가 된다. 대응 중 드러난 개선점은 지금 다루는


### PR DESCRIPTION
The release flow ended at the tag. The Release page carried the notes, and nothing told the people already following the project that a build was out — the Announcements category has been reserved for "releases and important notices" since the welcome post, and had exactly one post in it.

Step 5 of the GitHub issue-response flow now posts the announcement, after the tag run's `release` job is green and the Release assets have been checked by eye. The step says what belongs in the post — release link and versionCode, the changelog title, what a user will actually notice, **the limits of the change**, credit to the reporter, the F-Droid delay, and the Issues/Discussions split — and says explicitly that it is not a paste of the changelog: the notes are already on the Release page, and the announcement is the reason to go read them.

Two mechanics are written down because both cost time to rediscover:

- the `createDiscussion` GraphQL call with the repository and Announcements category IDs (verified against the API while writing this);
- pinning is a web-UI action with no API, so the step tells the agent to hand that back to the maintainer rather than silently skip it.

The trailing sentence that gates steps by "did code actually ship" is updated to cover the new step (3·4·5 on a release, 1·6 on a comment-only issue).

First instance, written by hand before this was documented: [#379](https://github.com/jeiel85/markleaf-android/discussions/379) for v2.37.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
