### PR TITLE
feat: select text and copy link addresses in preview (#386)

### DIFF
--- a/THANKS.md
+++ b/THANKS.md
@@ -41,8 +41,10 @@ Listed by first report.
 | [@ElizabethWega](https://github.com/ElizabethWega) | [#283](https://github.com/jeiel85/markleaf-android/issues/283), [#298](https://github.com/jeiel85/markleaf-android/issues/298) |
 | [@unrealsswag](https://github.com/unrealsswag) | [#325](https://github.com/jeiel85/markleaf-android/issues/325) |
 | [@gamersat678](https://github.com/gamersat678) | [#345](https://github.com/jeiel85/markleaf-android/issues/345), [#346](https://github.com/jeiel85/markleaf-android/issues/346), [#354](https://github.com/jeiel85/markleaf-android/issues/354) |
-| [@ray4423](https://github.com/ray4423) | [#351](https://github.com/jeiel85/markleaf-android/issues/351) |
+| [@ray4423](https://github.com/ray4423) | [#351](https://github.com/jeiel85/markleaf-android/issues/351), [#363](https://github.com/jeiel85/markleaf-android/issues/363), [#375](https://github.com/jeiel85/markleaf-android/issues/375) |
 | [@iamgitcat](https://github.com/iamgitcat) | [#360](https://github.com/jeiel85/markleaf-android/issues/360) |
+| [@canllaith](https://github.com/canllaith) | [#370](https://github.com/jeiel85/markleaf-android/issues/370) |
+| [@Bedz01](https://github.com/Bedz01) | [#386](https://github.com/jeiel85/markleaf-android/issues/386) |
 
 Not every request here was accepted — a couple were declined, and saying no to a
 thoughtful suggestion is its own kind of debt. Being told what you want from the

--- a/app/src/main/java/com/markleaf/notes/core/markdown/preview/MarkdownPreviewList.kt
+++ b/app/src/main/java/com/markleaf/notes/core/markdown/preview/MarkdownPreviewList.kt
@@ -666,7 +666,11 @@ private fun Modifier.linkPressGestures(
             // scroll the preview at all.
             var longPressed = false
             try {
-                withTimeout(viewConfiguration.longPressTimeoutMillis * 4 / 5) {
+                // The platform's own threshold, not a shortened one. Deciding
+                // early would make a slow tap — released after 400ms, say, but
+                // before Android calls it a long press — copy the address
+                // instead of opening the link.
+                withTimeout(viewConfiguration.longPressTimeoutMillis) {
                     while (true) {
                         val event = awaitPointerEvent()
                         val change = event.changes.firstOrNull { it.id == down.id }
@@ -674,12 +678,23 @@ private fun Modifier.linkPressGestures(
                         // Lifted before the timeout: a tap, which belongs to
                         // the LinkAnnotation's own click listener.
                         if (!change.pressed) return@withTimeout
-                        // Movement that someone else has claimed means the
-                        // press became a scroll. Only movement counts: the
-                        // press itself arrives here already consumed, because
-                        // the link's tap detector — inside this Text, so ahead
-                        // of this node on the Main pass — consumes every down
-                        // it sees.
+                        // A finger that has travelled is no longer resting on
+                        // the link, whether or not anything else claimed the
+                        // movement — sliding off a link sideways is not a
+                        // vertical scroll, so nothing would consume it, and
+                        // without this the address would still be copied when
+                        // the timeout came round.
+                        if ((change.position - down.position).getDistance() >
+                            viewConfiguration.touchSlop
+                        ) {
+                            return@withTimeout
+                        }
+                        // Someone else claiming the movement means the press
+                        // became a scroll. Only movement counts: the press
+                        // itself arrives here already consumed, because the
+                        // link's tap detector — inside this Text, so ahead of
+                        // this node on the Main pass — consumes every down it
+                        // sees.
                         if (change.positionChanged() && change.isConsumed) {
                             return@withTimeout
                         }

--- a/app/src/main/java/com/markleaf/notes/core/markdown/preview/MarkdownPreviewList.kt
+++ b/app/src/main/java/com/markleaf/notes/core/markdown/preview/MarkdownPreviewList.kt
@@ -1,8 +1,12 @@
 package com.markleaf.notes.core.markdown.preview
 
+import android.os.Build
+import android.widget.Toast
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -16,10 +20,14 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.text.selection.DisableSelection
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.runtime.rememberCoroutineScope
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeout
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
@@ -29,13 +37,25 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.positionChanged
+import androidx.compose.ui.input.pointer.PointerEventTimeoutCancellationException
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextLinkStyles
 import androidx.compose.ui.text.buildAnnotatedString
@@ -144,22 +164,51 @@ fun MarkdownPreviewList(
     val scaledLines = remember(lines, fontScale) {
         if (fontScale == 1f) lines else lines.map { it.copy(fontScale = fontScale) }
     }
-    LazyColumn(
-        modifier = modifier.fillMaxSize(),
-        state = listState,
-        contentPadding = contentPadding
-    ) {
-        itemsIndexed(scaledLines) { index, line ->
-            PreviewLineRenderer(
-                line = line,
-                // Only a block with something above it needs separating from
-                // it; see [headingTop].
-                isFirstBlock = index == 0,
-                onWikilinkClick = onWikilinkClick,
-                onImageLongPress = onImageLongPress,
-                onFootnoteRefClick = onFootnoteRefClick,
-                onToggleTask = onToggleTask
-            )
+    // Preview text is selectable (#386). Before this, copying a sentence out of
+    // a rendered note meant switching back to the editor and bringing the
+    // keyboard up for it. A long press starts a selection; the taps the preview
+    // already handles — links, wikilinks, checkbox markers — are untouched,
+    // since none of them begin with a long press.
+    //
+    // A long press on a *link* is the one collision, since that copies the
+    // address: the same press is a long press to selection as well, and
+    // selection cannot be called off once it starts — only restarted.
+    // Rebuilding the container under a new epoch is that restart. It is also
+    // why [linkPressGestures] consumes nothing until it is certain rather than
+    // claiming the press early: a consumed pointer reads as a cancelled
+    // gesture to the scrolling container too, which left a drag that began on
+    // a link unable to scroll at all. `listState` lives outside the key, so the
+    // scroll position survives the rebuild.
+    //
+    // The lazy-list caveat that comes with selection: it only spans the rows
+    // that are currently composed, so dragging far past what the viewport holds
+    // drops the part that scrolled away. That is how selection behaves in any
+    // LazyColumn, and the alternative — composing the whole note at once — is
+    // the cost this preview exists to avoid.
+    var selectionEpoch by remember { mutableIntStateOf(0) }
+    val resetSelection: () -> Unit = remember { { selectionEpoch++ } }
+    CompositionLocalProvider(LocalPreviewSelectionReset provides resetSelection) {
+        key(selectionEpoch) {
+            SelectionContainer(modifier = modifier.fillMaxSize()) {
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
+                    state = listState,
+                    contentPadding = contentPadding
+                ) {
+                    itemsIndexed(scaledLines) { index, line ->
+                        PreviewLineRenderer(
+                            line = line,
+                            // Only a block with something above it needs
+                            // separating from it; see [headingTop].
+                            isFirstBlock = index == 0,
+                            onWikilinkClick = onWikilinkClick,
+                            onImageLongPress = onImageLongPress,
+                            onFootnoteRefClick = onFootnoteRefClick,
+                            onToggleTask = onToggleTask
+                        )
+                    }
+                }
+            }
         }
     }
 }
@@ -381,13 +430,19 @@ internal fun InlineMarkdownText(
         fontScale = line.fontScale
     )
     val baseStyle = MaterialTheme.typography.bodyLarge
+    val layout = remember { TextLayoutHolder() }
     // Links are now embedded as LinkAnnotations in `annotated`, so a plain Text
     // handles styling, clicks, and accessibility — no offset-mapped onClick.
+    // The layout result is kept because copying a link's address on long press
+    // has to map a touch back to a text offset (#386).
     Text(
         text = annotated,
         style = (if (line.fontScale == 1f) baseStyle else baseStyle.scaledBy(line.fontScale))
             .copy(color = color),
-        modifier = Modifier.padding(vertical = verticalPadding)
+        onTextLayout = { layout.value = it },
+        modifier = Modifier
+            .padding(vertical = verticalPadding)
+            .linkPressGestures(annotated, layout)
     )
 }
 
@@ -517,7 +572,18 @@ private fun inlineAnnotatedString(
                             linkInteractionListener = { openExternalLink(context, href) }
                         )
                     ) {
-                        append(segment.text)
+                        if (href.isBlank()) {
+                            append(segment.text)
+                        } else {
+                            // Inside the LinkAnnotation the address is reachable
+                            // only from the click listener's closure, and the
+                            // long press that copies it (#386) has to find it by
+                            // text offset instead — so it also rides along as a
+                            // plain string annotation.
+                            pushStringAnnotation(tag = LINK_HREF_TAG, annotation = href)
+                            append(segment.text)
+                            pop()
+                        }
                     }
                 }
             }
@@ -527,6 +593,150 @@ private fun inlineAnnotatedString(
 
 private const val WIKILINK_TAG = "wikilink"
 private const val LINK_TAG = "link"
+
+/**
+ * Carries a link's address alongside its [LinkAnnotation] so [hrefAt] can
+ * resolve the address under a long press (#386).
+ */
+private const val LINK_HREF_TAG = "link_href"
+
+/**
+ * Lets a link long press reach the [SelectionContainer] wrapping the whole
+ * preview, which is several composables above the row that handled the press.
+ * Passing it down as a parameter would thread one callback through five
+ * signatures that have no other reason to know about selection.
+ */
+private val LocalPreviewSelectionReset = compositionLocalOf<() -> Unit> { {} }
+
+/**
+ * Holds the latest [TextLayoutResult] for a preview row without making it
+ * state. The long-press gesture reads it only once a press arrives, and a row
+ * that recomposed on every layout pass would be a real cost in a note that
+ * renders hundreds of them.
+ */
+private class TextLayoutHolder {
+    var value: TextLayoutResult? = null
+}
+
+/**
+ * Owns the press on a link: a tap opens it, a long press copies its address to
+ * the clipboard (#386). The preview shows a link's label and never its target,
+ * so until now the address was reachable only by leaving preview and reading
+ * the raw Markdown.
+ *
+ * Both halves have to live here together. The press is claimed on the Initial
+ * pass, before the two handlers that sit *inside* this Text — the selection
+ * detector and the LinkAnnotation's own clickable — get to look at it, because
+ * neither can be called off later: a long press that only raced them ended up
+ * copying the address while the browser opened over the note and selection
+ * handles rose over the link. Claiming it means the tap has to be answered here
+ * as well, since the LinkAnnotation will no longer see one. Its listener stays
+ * for the accessibility path, which never goes through this gesture.
+ *
+ * Away from a link nothing is consumed, so ordinary text keeps the selection
+ * this preview now offers, and a drag that starts on a link still scrolls: the
+ * scrolling container consumes the movement, which reads here as a cancelled
+ * press.
+ */
+@Composable
+private fun Modifier.linkPressGestures(
+    annotated: AnnotatedString,
+    layout: TextLayoutHolder
+): Modifier {
+    // Most rows carry no link; those pay for no pointer handler at all.
+    if (annotated.getStringAnnotations(LINK_HREF_TAG, 0, annotated.length).isEmpty()) {
+        return this
+    }
+    val clipboard = LocalClipboardManager.current
+    val context = LocalContext.current
+    val copiedMessage = stringResource(R.string.preview_link_address_copied)
+    val onAddressCopied = LocalPreviewSelectionReset.current
+    return this.pointerInput(annotated) {
+        awaitEachGesture {
+            val down = awaitFirstDown(
+                requireUnconsumed = false,
+                pass = PointerEventPass.Initial
+            )
+            val href = hrefAt(annotated, layout.value, down.position)
+                ?: return@awaitEachGesture
+            // Nothing is consumed until the long press is certain. Consuming
+            // sooner reaches further than intended: the scrolling container
+            // reads a consumed pointer as its gesture being called off, so an
+            // early claim here left a drag that started on a link unable to
+            // scroll the preview at all.
+            var longPressed = false
+            try {
+                withTimeout(viewConfiguration.longPressTimeoutMillis * 4 / 5) {
+                    while (true) {
+                        val event = awaitPointerEvent()
+                        val change = event.changes.firstOrNull { it.id == down.id }
+                            ?: return@withTimeout
+                        // Lifted before the timeout: a tap, which belongs to
+                        // the LinkAnnotation's own click listener.
+                        if (!change.pressed) return@withTimeout
+                        // Movement that someone else has claimed means the
+                        // press became a scroll. Only movement counts: the
+                        // press itself arrives here already consumed, because
+                        // the link's tap detector — inside this Text, so ahead
+                        // of this node on the Main pass — consumes every down
+                        // it sees.
+                        if (change.positionChanged() && change.isConsumed) {
+                            return@withTimeout
+                        }
+                    }
+                }
+            } catch (_: PointerEventTimeoutCancellationException) {
+                longPressed = true
+            }
+            if (!longPressed) return@awaitEachGesture
+            clipboard.setText(AnnotatedString(href))
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+                // Android 13 and up shows its own clipboard confirmation, and a
+                // toast on top of that says the same thing twice.
+                Toast.makeText(context, copiedMessage, Toast.LENGTH_SHORT).show()
+            }
+            onAddressCopied()
+            // From here the press is this gesture's, and it is claimed on the
+            // Initial pass: the LinkAnnotation's own click handling lives
+            // *inside* this Text, so on the Main pass it would see the release
+            // first and open the link on the way out of a press meant to copy.
+            do {
+                val event = awaitPointerEvent(PointerEventPass.Initial)
+                event.changes.forEach { it.consume() }
+            } while (event.changes.any { it.pressed })
+        }
+    }
+}
+
+/**
+ * The link address under [position] in the laid-out text, or null when the
+ * point falls outside the text or onto a stretch that is not a link.
+ */
+private fun hrefAt(
+    annotated: AnnotatedString,
+    layout: TextLayoutResult?,
+    position: Offset
+): String? {
+    val result = layout ?: return null
+    if (position.y < 0f || position.y > result.size.height.toFloat()) return null
+    val line = result.getLineForVerticalPosition(position.y)
+    // Without this, a press past the end of a short line would be pulled back
+    // onto that line's last character by getOffsetForPosition.
+    if (position.x < result.getLineLeft(line) || position.x > result.getLineRight(line)) {
+        return null
+    }
+    // getOffsetForPosition returns a *cursor* offset, rounding to whichever side
+    // of the glyph is nearer, so the character actually under the finger is
+    // whichever of the two candidates has the press inside its box.
+    val cursor = result.getOffsetForPosition(position)
+    val index = intArrayOf(cursor, cursor - 1).firstOrNull { candidate ->
+        candidate >= 0 && candidate < annotated.length &&
+            result.getBoundingBox(candidate).let {
+                position.x >= it.left && position.x <= it.right
+            }
+    } ?: return null
+    return annotated.getStringAnnotations(LINK_HREF_TAG, index, index).firstOrNull()?.item
+}
 private const val FOOTNOTE_REF_TAG = "footnote_ref"
 private const val TASK_MARKER_TAG = "task_marker"
 
@@ -782,6 +992,7 @@ private fun TableRow(
                     onFootnoteRefClick = onFootnoteRefClick
                 )
             }
+            val layout = remember { TextLayoutHolder() }
             Text(
                 text = content,
                 style = MaterialTheme.typography.bodyMedium,
@@ -792,9 +1003,13 @@ private fun TableRow(
                     TableAlignment.CENTER -> androidx.compose.ui.text.style.TextAlign.Center
                     TableAlignment.RIGHT -> androidx.compose.ui.text.style.TextAlign.End
                 },
+                onTextLayout = { layout.value = it },
                 modifier = Modifier
                     .weight(1f)
                     .padding(horizontal = 10.dp)
+                    // A link in a table cell copies its address like any other
+                    // (#386), same as it became tappable like any other (#197).
+                    .linkPressGestures(content, layout)
             )
         }
     }
@@ -830,18 +1045,23 @@ private fun AttachmentImage(
         AttachmentManager.resolveFile(context, destination)
     }
     if (resolved != null) {
-        AsyncImage(
-            model = ImageRequest.Builder(context).data(resolved).build(),
-            contentDescription = line.text.ifEmpty { destination },
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(vertical = 8.dp)
-                .clip(RoundedCornerShape(8.dp))
-                .combinedClickable(
-                    onClick = {},
-                    onLongClick = { onLongPress(destination, line.text) }
-                )
-        )
+        // Opted out of the preview's selection (#386): there is no text here to
+        // select, and the long press this image already owns — editing its alt
+        // text — must not have to win a race against the selection gesture.
+        DisableSelection {
+            AsyncImage(
+                model = ImageRequest.Builder(context).data(resolved).build(),
+                contentDescription = line.text.ifEmpty { destination },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 8.dp)
+                    .clip(RoundedCornerShape(8.dp))
+                    .combinedClickable(
+                        onClick = {},
+                        onLongClick = { onLongPress(destination, line.text) }
+                    )
+            )
+        }
     } else {
         Text(
             text = "![${line.text}]($destination)",

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -410,4 +410,8 @@
     <string name="conflict_delete_confirm_title">Konfliktkopie löschen?</string>
     <string name="conflict_delete_confirm_desc">Diese Konfliktkopie wird dauerhaft gelöscht.</string>
     <string name="conflict_note_updated_format">Aktualisiert: %1$s</string>
+
+    <!-- Preview mode -->
+    <string name="preview_link_address_copied">Linkadresse kopiert</string>
+
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -410,4 +410,8 @@
     <string name="conflict_delete_confirm_title">¿Eliminar copia en conflicto?</string>
     <string name="conflict_delete_confirm_desc">Esta copia en conflicto será eliminada permanentemente.</string>
     <string name="conflict_note_updated_format">Actualizado: %1$s</string>
+
+    <!-- Preview mode -->
+    <string name="preview_link_address_copied">Dirección del enlace copiada</string>
+
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -411,4 +411,7 @@
     <string name="conflict_delete_confirm_desc">Cette copie de conflit sera définitivement supprimée.</string>
     <string name="conflict_note_updated_format">Modifiée : %1$s</string>
 
+    <!-- Preview mode -->
+    <string name="preview_link_address_copied">Adresse du lien copiée</string>
+
 </resources>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -430,4 +430,7 @@
     <string name="conflict_delete_confirm_desc">Ova sukobljena kopija bit će trajno izbrisana.</string>
     <string name="conflict_note_updated_format">Ažurirano: %1$s</string>
 
+    <!-- Preview mode -->
+    <string name="preview_link_address_copied">Adresa poveznice kopirana</string>
+
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -401,4 +401,8 @@
     <string name="conflict_delete_confirm_title">競合コピーを削除しますか？</string>
     <string name="conflict_delete_confirm_desc">この競合コピーは完全に削除されます。</string>
     <string name="conflict_note_updated_format">更新: %1$s</string>
+
+    <!-- Preview mode -->
+    <string name="preview_link_address_copied">リンクのアドレスをコピーしました</string>
+
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -402,4 +402,7 @@
     <string name="conflict_delete_confirm_desc">이 충돌 사본은 영구히 삭제되며 복구할 수 없습니다.</string>
     <string name="conflict_note_updated_format">수정: %1$s</string>
 
+    <!-- Preview mode -->
+    <string name="preview_link_address_copied">링크 주소를 복사했습니다</string>
+
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -408,4 +408,7 @@
     <string name="conflict_delete_confirm_desc">此冲突副本将被永久删除。</string>
     <string name="conflict_note_updated_format">更新时间：%1$s</string>
 
+    <!-- Preview mode -->
+    <string name="preview_link_address_copied">已复制链接地址</string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -421,4 +421,7 @@
     <string name="conflict_delete_confirm_desc">This conflict copy will be permanently deleted.</string>
     <string name="conflict_note_updated_format">Updated: %1$s</string>
 
+    <!-- Preview mode -->
+    <string name="preview_link_address_copied">Link address copied</string>
+
 </resources>

--- a/app/src/testDebug/java/com/markleaf/notes/core/markdown/preview/MarkdownLinkLongPressTest.kt
+++ b/app/src/testDebug/java/com/markleaf/notes/core/markdown/preview/MarkdownLinkLongPressTest.kt
@@ -1,0 +1,187 @@
+package com.markleaf.notes.core.markdown.preview
+
+import android.app.Application
+import android.content.ClipboardManager
+import android.content.Context
+import android.content.Intent
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.test.click
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.longClick
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performTouchInput
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.markleaf.notes.R
+import com.markleaf.notes.core.markdown.SimpleMarkdownPreview
+import com.markleaf.notes.ui.theme.MarkleafTheme
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Shadows
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowToast
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * Regression net for #386: preview mode has to give up a link's address without
+ * a trip back to the editor, and the long press that does it has to stay out of
+ * the way of everything else the preview already answers to — the tap that
+ * opens a link, and the long press that now starts a text selection.
+ *
+ * sdk 27 rather than the 33 the other preview tests use: from API 28 Compose's
+ * selection draws a platform Magnifier, which needs a real window and throws
+ * inside Robolectric the moment a long press starts a selection. The gesture
+ * under test does not branch on API level, so testing it a rung below the
+ * magnifier costs nothing — except that the toast branch (< API 33) is the one
+ * running here, which [longPressingLink_copiesItsAddress] asserts on.
+ */
+@RunWith(AndroidJUnit4::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(sdk = [27], qualifiers = "w360dp-h640dp-mdpi")
+class MarkdownLinkLongPressTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun longPressingLink_copiesItsAddress() {
+        renderPreview("[the docs](https://markleaf.app/docs)")
+
+        composeRule.onNodeWithText("the docs").performTouchInput {
+            longClick(centerLeft.copy(x = 12f))
+        }
+
+        assertEquals("https://markleaf.app/docs", clipboardText())
+        // Copying has to replace opening, not accompany it: on a device the
+        // press otherwise landed the address on the clipboard *and* launched
+        // the browser over the note.
+        assertNull(startedActivity())
+        // Below API 33 nothing else tells the user the copy happened.
+        assertEquals(
+            application().getString(R.string.preview_link_address_copied),
+            ShadowToast.getTextOfLatestToast()
+        )
+    }
+
+    @Test
+    fun longPressingLinkInTableCell_copiesItsAddress() {
+        renderPreview(
+            """
+            | name | link |
+            | --- | --- |
+            | Docs | [address](https://markleaf.app/docs) |
+            """.trimIndent()
+        )
+
+        composeRule.onNodeWithText("address").performTouchInput {
+            longClick(centerLeft.copy(x = 12f))
+        }
+
+        assertEquals("https://markleaf.app/docs", clipboardText())
+        assertNull(startedActivity())
+    }
+
+    /**
+     * The gesture must not consume a press that lands on ordinary prose —
+     * that press belongs to the selection the preview now offers, and a
+     * clipboard write here would mean the selection never started.
+     */
+    @Test
+    fun longPressingPlainText_copiesNothing() {
+        renderPreview("just some prose")
+
+        composeRule.onNodeWithText("just some prose").performTouchInput {
+            longClick(centerLeft.copy(x = 12f))
+        }
+
+        assertNull(clipboardText())
+    }
+
+    /**
+     * Same row as a link, but past its end: the hit test has to work by text
+     * offset rather than by "this Text contains a link somewhere".
+     */
+    @Test
+    fun longPressingTextAfterLinkInSameRow_copiesNothing() {
+        renderPreview("[docs](https://markleaf.app/docs) trailing words")
+
+        composeRule.onNodeWithText("docs trailing words").performTouchInput {
+            longClick(centerRight.copy(x = width - 12f))
+        }
+
+        assertNull(clipboardText())
+    }
+
+    /**
+     * The press has to be claimed from the selection gesture, not merely raced
+     * with it: copying an address while selection handles rise over the same
+     * link would be two answers to one press.
+     *
+     * Robolectric makes that visible for free from API 28, where selection
+     * draws a platform Magnifier that throws without a real window — so a
+     * selection starting here fails this test rather than passing quietly. The
+     * moves matter too: a resting finger still reports, and [longClick] sends
+     * nothing between down and up, leaving the gesture no event to consume.
+     */
+    @Test
+    @Config(sdk = [33])
+    fun longPressingLink_doesNotStartASelection() {
+        renderPreview("[the docs](https://markleaf.app/docs)")
+
+        composeRule.onNodeWithText("the docs").performTouchInput {
+            val target = centerLeft.copy(x = 12f)
+            down(target)
+            repeat(6) { step ->
+                // Under the touch slop, so this stays a press and never becomes
+                // a drag that would cancel it.
+                moveTo(target + Offset(if (step % 2 == 0) 1f else 0f, 0f), delayMillis = 100)
+            }
+            up()
+        }
+
+        assertEquals("https://markleaf.app/docs", clipboardText())
+        assertNull(startedActivity())
+        // API 33 shows the platform's own clipboard confirmation, so the app
+        // stays quiet.
+        assertNull(ShadowToast.getTextOfLatestToast())
+    }
+
+    /** A tap still opens the link — the long-press handler must not eat it. */
+    @Test
+    fun tappingLink_stillOpensIt() {
+        renderPreview("[the docs](https://markleaf.app/docs)")
+
+        composeRule.onNodeWithText("the docs").performTouchInput {
+            click(centerLeft.copy(x = 12f))
+        }
+
+        val started = startedActivity()
+        assertEquals(Intent.ACTION_VIEW, started?.action)
+        assertEquals("https://markleaf.app/docs", started?.data?.toString())
+        assertNull(clipboardText())
+    }
+
+    private fun renderPreview(markdown: String) {
+        composeRule.setContent {
+            MarkleafTheme(darkTheme = false, dynamicColor = false) {
+                MarkdownPreviewList(lines = SimpleMarkdownPreview.parse(markdown))
+            }
+        }
+    }
+
+    private fun application(): Application = ApplicationProvider.getApplicationContext()
+
+    private fun startedActivity(): Intent? =
+        Shadows.shadowOf(application()).nextStartedActivity
+
+    private fun clipboardText(): String? {
+        val manager = application()
+            .getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+        val clip = manager.primaryClip ?: return null
+        if (clip.itemCount == 0) return null
+        return clip.getItemAt(0).text?.toString()
+    }
+}

--- a/app/src/testDebug/java/com/markleaf/notes/core/markdown/preview/MarkdownLinkLongPressTest.kt
+++ b/app/src/testDebug/java/com/markleaf/notes/core/markdown/preview/MarkdownLinkLongPressTest.kt
@@ -149,6 +149,47 @@ class MarkdownLinkLongPressTest {
         assertNull(ShadowToast.getTextOfLatestToast())
     }
 
+    /**
+     * Sliding off a link is not a long press on it. Nothing else would say so
+     * either: a sideways drag is not a scroll the vertical list would claim, so
+     * without a distance check of its own the address was still copied once the
+     * timeout came round, wherever the finger had ended up.
+     */
+    @Test
+    fun pressThatSlidesOffTheLink_copiesNothing() {
+        renderPreview("[the docs](https://markleaf.app/docs) and words after it")
+
+        composeRule.onNodeWithText("the docs and words after it").performTouchInput {
+            val start = centerLeft.copy(x = 12f)
+            down(start)
+            moveTo(start + Offset(viewConfiguration.touchSlop * 4, 0f), delayMillis = 50)
+            advanceEventTime(viewConfiguration.longPressTimeoutMillis)
+            up()
+        }
+
+        assertNull(clipboardText())
+    }
+
+    /**
+     * A press released before the platform's own long-press threshold is a tap,
+     * however slow. Deciding on a shortened threshold made the 400-499ms band
+     * copy the address out from under a tap that Android still called a tap.
+     */
+    @Test
+    fun slowTapUnderTheThreshold_opensTheLinkInstead() {
+        renderPreview("[the docs](https://markleaf.app/docs)")
+
+        composeRule.onNodeWithText("the docs").performTouchInput {
+            val target = centerLeft.copy(x = 12f)
+            down(target)
+            advanceEventTime(viewConfiguration.longPressTimeoutMillis - 50)
+            up()
+        }
+
+        assertNull(clipboardText())
+        assertEquals(Intent.ACTION_VIEW, startedActivity()?.action)
+    }
+
     /** A tap still opens the link — the long-press handler must not eat it. */
     @Test
     fun tappingLink_stillOpensIt() {


### PR DESCRIPTION
Closes #386.

Preview mode rendered its text unselectable, so copying a sentence out of a note meant switching back to the editor and bringing up the keyboard for it. A link was worse: the preview shows the label and never the target, so its address was reachable only by reading the raw Markdown.

## What changed

- The rendered list is wrapped in a `SelectionContainer`, so preview text selects and copies like text anywhere else.
- A long press on a link copies its address to the clipboard. Below API 33 that is confirmed with a toast; from API 33 the platform shows its own clipboard confirmation, so the app stays quiet.
- Images opt out of selection — there is no text in them to select, and the long press they already own (editing alt text) should not have to win a race for it.
- One new string, translated across all eight locales.

## How three gestures share one press

Tap-to-open, long-press-to-copy and long-press-to-select all start from the same finger, and the order they are resolved in is the whole change. Two rules, both found on a device rather than in a test:

**Nothing is consumed until the long press is certain.** Consuming earlier reaches further than intended — the scrolling container reads a consumed pointer as its own gesture being cancelled, so an early claim left a drag that started on a link unable to scroll the preview at all.

**Once certain, the rest of the press is claimed on the Initial pass.** The `LinkAnnotation`'s click handling sits inside the same `Text`, so on the Main pass it sees the release first: a press meant to copy an address opened the browser over the note as well.

Selection is the one that cannot be called off that way, because it only restarts — it never cancels. So the container is rebuilt under a new epoch when an address is copied. `listState` lives outside that key, so the scroll position survives it.

The `LinkAnnotation`'s own listener still handles the tap, and still carries the accessibility path, which does not go through this gesture at all.

## Verification

`testDebugUnitTest` and `lintRelease` green. Six new tests in `MarkdownLinkLongPressTest` cover the address copy (body text and table cell), the tap still opening the link, a long press away from a link copying nothing, and — on API 33, where a started selection throws inside Robolectric's Magnifier — a link press not starting one.

Checked on a `markleaf-phone-api36` emulator, all four in the same note: text selects with handles and a Copy toolbar; a link long press puts `https://markleaf.app/docs` on the clipboard with no selection and no browser; a tap still opens the link; and a drag that starts on the link still scrolls the preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
