### PR TITLE
feat(editor): offer tables and callouts in the formatting panel (#390)

### DIFF
--- a/THANKS.md
+++ b/THANKS.md
@@ -45,6 +45,7 @@ Listed by first report.
 | [@iamgitcat](https://github.com/iamgitcat) | [#360](https://github.com/jeiel85/markleaf-android/issues/360) |
 | [@canllaith](https://github.com/canllaith) | [#370](https://github.com/jeiel85/markleaf-android/issues/370) |
 | [@Bedz01](https://github.com/Bedz01) | [#386](https://github.com/jeiel85/markleaf-android/issues/386) |
+| [@hawk1335](https://github.com/hawk1335) | [#390](https://github.com/jeiel85/markleaf-android/issues/390) |
 
 Not every request here was accepted — a couple were declined, and saying no to a
 thoughtful suggestion is its own kind of debt. Being told what you want from the

--- a/app/src/main/java/com/markleaf/notes/core/markdown/MarkdownEditActions.kt
+++ b/app/src/main/java/com/markleaf/notes/core/markdown/MarkdownEditActions.kt
@@ -4,11 +4,30 @@ import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 
 object MarkdownEditActions {
+    /**
+     * The two-column GFM table skeleton, and the caret offset that lands inside
+     * its first header cell (right after `| `).
+     *
+     * Shared with the `/table` quick-insert command rather than written twice:
+     * the panel row and the slash command are two doors onto the same
+     * construct, and a user who learns the shape through one and then uses the
+     * other must not get a different table.
+     */
+    const val TABLE_TEMPLATE = "| Column 1 | Column 2 |\n| --- | --- |\n|  |  |"
+    const val TABLE_CARET_OFFSET = 2
+
+    /** The callout head, and the head plus an empty body line for insertion. */
+    const val CALLOUT_HEAD = "> [!NOTE]"
+    const val CALLOUT_TEMPLATE = CALLOUT_HEAD + "\n> "
+
     private val headingPattern = Regex("""^(#{1,6})\s+""")
     private val bulletPattern = Regex("""^([-*+])\s+""")
     private val orderedPattern = Regex("""^(\d+)\.\s+""")
     private val blockquotePattern = Regex("""^(>+)\s+""")
     private val checkboxPattern = Regex("""^(\s*[-*+]) \[([ xX])]""")
+
+    /** A `> [!NOTE]` head on its own line — see [callout]. */
+    private val calloutHeadPattern = Regex("""^\s*>\s*\[![A-Za-z]+]""", RegexOption.MULTILINE)
 
     fun bold(value: TextFieldValue): TextFieldValue =
         wrapSelection(value, "**", "**", "bold")
@@ -182,6 +201,78 @@ object MarkdownEditActions {
         return value.copy(text = updated, selection = TextRange(cursor + insertion.length))
     }
 
+    /**
+     * Insert a two-column GFM table below the line the caret is on.
+     *
+     * Input: the field value, caret anywhere. Output: the value with
+     * [TABLE_TEMPLATE] inserted as its own block, caret inside the first header
+     * cell so the first thing typed names a column.
+     *
+     * Why its own block, with a blank line: a GFM table cannot interrupt a
+     * paragraph, so a skeleton appended straight under a line of prose renders
+     * as literal pipes — the exact failure a beginner reaching for this button
+     * has no way to diagnose. `/table` never met it because that command always
+     * runs on a line holding nothing but the query; a panel tap can land
+     * mid-sentence, so the insertion point is the end of the caret's line
+     * rather than the caret itself, and the separating newlines are computed
+     * from what is actually there.
+     */
+    fun table(value: TextFieldValue): TextFieldValue {
+        val at = blockInsertPoint(value)
+        val leading = blockLeading(value.text, at)
+        val trailing = blockTrailing(value.text, at)
+        val insertion = leading + TABLE_TEMPLATE + trailing
+        val updated = value.text.substring(0, at) + insertion + value.text.substring(at)
+        return value.copy(
+            text = updated,
+            selection = TextRange(at + leading.length + TABLE_CARET_OFFSET)
+        )
+    }
+
+    /**
+     * Insert a `> [!NOTE]` callout, or turn the selected lines into one.
+     *
+     * Input: the field value. Output: with a selection, the selected lines
+     * wrapped in a callout and left selected; without one, an empty callout as
+     * its own block with the caret on its body line.
+     *
+     * Why the selection case exists at all: "I wrote this paragraph, make it a
+     * note" is the way the construct is reached in practice, and the
+     * alternative — dropping an empty callout after the selection and leaving
+     * the user to re-type the text — is worse than doing nothing. The block
+     * separation is the same rule [table] uses and for the same reason: a
+     * blockquote glued to the line above is swallowed into that paragraph.
+     */
+    fun callout(value: TextFieldValue): TextFieldValue {
+        val (blockStart, blockEnd) = selectionLineRange(value)
+        val block = value.text.substring(blockStart, blockEnd)
+        if (!value.selection.collapsed && block.isNotBlank()) {
+            // Wrapping a callout in a callout is a mis-tap every time, and the
+            // `> > [!NOTE]` it would produce is exactly the broken syntax a
+            // beginner cannot unpick. Leave the text alone instead.
+            if (calloutHeadPattern.containsMatchIn(block)) return value
+            val quoted = block.split("\n").joinToString("\n") { line -> "> $line" }
+            val leading = blockLeading(value.text, blockStart)
+            val trailing = blockTrailing(value.text, blockEnd)
+            val body = CALLOUT_HEAD + "\n" + quoted
+            val updated = value.text.substring(0, blockStart) +
+                leading + body + trailing +
+                value.text.substring(blockEnd)
+            val start = blockStart + leading.length
+            return value.copy(text = updated, selection = TextRange(start, start + body.length))
+        }
+
+        val at = blockInsertPoint(value)
+        val leading = blockLeading(value.text, at)
+        val trailing = blockTrailing(value.text, at)
+        val insertion = leading + CALLOUT_TEMPLATE + trailing
+        val updated = value.text.substring(0, at) + insertion + value.text.substring(at)
+        return value.copy(
+            text = updated,
+            selection = TextRange(at + leading.length + CALLOUT_TEMPLATE.length)
+        )
+    }
+
     /** Wrap selection in a fenced code block, or insert an empty one. */
     fun codeBlock(value: TextFieldValue): TextFieldValue {
         val selected = selectedText(value)
@@ -313,6 +404,47 @@ object MarkdownEditActions {
         val nextNewline = text.indexOf('\n', selEnd)
         val blockEnd = if (nextNewline == -1) text.length else nextNewline
         return blockStart to blockEnd
+    }
+
+    /**
+     * Where a block-level construct should be inserted for the current caret:
+     * the end of the line it sits on, or the end of the selection's last line.
+     *
+     * Inserting at the caret would split a word in half; a block belongs after
+     * the line, not inside it.
+     */
+    private fun blockInsertPoint(value: TextFieldValue): Int = selectionLineRange(value).second
+
+    /**
+     * Newlines needed before [at] so a block starting there begins a new block.
+     *
+     * Trailing spaces and tabs are ignored when looking backwards, because a
+     * line of nothing but whitespace is a blank line to Markdown and should not
+     * earn an extra one.
+     */
+    private fun blockLeading(text: String, at: Int): String {
+        val before = text.substring(0, at.coerceIn(0, text.length)).trimEnd(' ', '\t')
+        return when {
+            before.isEmpty() -> ""
+            before.endsWith("\n\n") -> ""
+            before.endsWith("\n") -> "\n"
+            else -> "\n\n"
+        }
+    }
+
+    /**
+     * Newlines needed after [at] so whatever follows is not absorbed by the
+     * block just inserted — a plain line under a table row is read as another
+     * row, and under a blockquote as more of the quote.
+     */
+    private fun blockTrailing(text: String, at: Int): String {
+        val after = text.substring(at.coerceIn(0, text.length))
+        return when {
+            after.isEmpty() -> ""
+            after.startsWith("\n\n") -> ""
+            after.startsWith("\n") -> "\n"
+            else -> "\n\n"
+        }
     }
 
     fun findWordAtCursor(text: String, cursor: Int): TextRange {

--- a/app/src/main/java/com/markleaf/notes/core/markdown/MarkdownEditActions.kt
+++ b/app/src/main/java/com/markleaf/notes/core/markdown/MarkdownEditActions.kt
@@ -395,10 +395,23 @@ object MarkdownEditActions {
         return lineStart to value.text.substring(lineStart, lineEnd)
     }
 
+    /**
+     * The whole-line span a selection (or caret) touches.
+     *
+     * Input: the field value. Output: (start of the first line touched, end of
+     * the last).
+     *
+     * An exclusive endpoint sitting at column 0 belongs to the line that just
+     * ended, not the one starting there: selecting `one\n` in `one\ntwo` used to
+     * expand to cover `two`, which the user never selected, so Callout quoted a
+     * line that was not in the selection and Tab indented it. Found by the
+     * Codex review on #390.
+     */
     private fun selectionLineRange(value: TextFieldValue): Pair<Int, Int> {
         val text = value.text
         val selStart = value.selection.min.coerceIn(0, text.length)
-        val selEnd = value.selection.max.coerceIn(0, text.length)
+        var selEnd = value.selection.max.coerceIn(0, text.length)
+        if (selEnd > selStart && text.getOrNull(selEnd - 1) == '\n') selEnd--
         val blockStart = text.lastIndexOf('\n', (selStart - 1).coerceAtLeast(0))
             .let { if (it == -1) 0 else it + 1 }
         val nextNewline = text.indexOf('\n', selEnd)
@@ -412,8 +425,27 @@ object MarkdownEditActions {
      *
      * Inserting at the caret would split a word in half; a block belongs after
      * the line, not inside it.
+     *
+     * The exception is a line holding nothing but spaces or tabs. [blockLeading]
+     * reads through that whitespace to decide the separator, so inserting after
+     * it would leave the indentation in front of the template — and four spaces
+     * or one tab turn the table or callout into an indented code block, which
+     * is not the construct the button promises. Insert where the indentation
+     * starts instead, and it ends up harmlessly after the block. Found by the
+     * Codex review on #390.
      */
-    private fun blockInsertPoint(value: TextFieldValue): Int = selectionLineRange(value).second
+    private fun blockInsertPoint(value: TextFieldValue): Int {
+        val end = selectionLineRange(value).second
+        // `end == 0` means the caret is on an empty first line of a note that
+        // opens with a newline. Deriving lineStart from `end - 1` there lands
+        // past `end` and the substring below throws, so short-circuit it.
+        val lineStart = if (end == 0) {
+            0
+        } else {
+            value.text.lastIndexOf('\n', end - 1).let { if (it == -1) 0 else it + 1 }
+        }
+        return if (value.text.substring(lineStart, end).isBlank()) lineStart else end
+    }
 
     /**
      * Newlines needed before [at] so a block starting there begins a new block.

--- a/app/src/main/java/com/markleaf/notes/feature/editor/EditorFormattingAction.kt
+++ b/app/src/main/java/com/markleaf/notes/feature/editor/EditorFormattingAction.kt
@@ -21,6 +21,8 @@ internal enum class EditorFormattingAction {
     CHECKLIST,
     QUOTE,
     CODE_BLOCK,
+    TABLE,
+    CALLOUT,
     DIVIDER,
     IMAGE
 }
@@ -71,6 +73,8 @@ internal fun EditorFormattingAction.applyTo(value: TextFieldValue): EditorFormat
     EditorFormattingAction.CHECKLIST -> EditorFormattingResult.Edited(MarkdownEditActions.checkbox(value))
     EditorFormattingAction.QUOTE -> EditorFormattingResult.Edited(MarkdownEditActions.blockquote(value))
     EditorFormattingAction.CODE_BLOCK -> EditorFormattingResult.Edited(MarkdownEditActions.codeBlock(value))
+    EditorFormattingAction.TABLE -> EditorFormattingResult.Edited(MarkdownEditActions.table(value))
+    EditorFormattingAction.CALLOUT -> EditorFormattingResult.Edited(MarkdownEditActions.callout(value))
     EditorFormattingAction.DIVIDER -> EditorFormattingResult.Edited(MarkdownEditActions.horizontalRule(value))
     EditorFormattingAction.IMAGE -> EditorFormattingResult.PickImage
 }

--- a/app/src/main/java/com/markleaf/notes/feature/editor/EditorFormattingControls.kt
+++ b/app/src/main/java/com/markleaf/notes/feature/editor/EditorFormattingControls.kt
@@ -32,8 +32,10 @@ import androidx.compose.material.icons.filled.FormatQuote
 import androidx.compose.material.icons.filled.FormatStrikethrough
 import androidx.compose.material.icons.filled.HorizontalRule
 import androidx.compose.material.icons.filled.Image
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Link
 import androidx.compose.material.icons.filled.MoreHoriz
+import androidx.compose.material.icons.filled.TableChart
 import androidx.compose.material.icons.filled.Title
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -540,6 +542,12 @@ private fun formattingGroups(): List<FormattingGroup> = listOf(
         stringResource(R.string.formatting_block_media),
         listOf(
             FormattingItem(EditorFormattingAction.CODE_BLOCK, stringResource(R.string.code_block), Icons.Default.DataObject),
+            // Tables and callouts were reachable only by typing `/` until #390,
+            // which is a shape you have to already know to look for. They reuse
+            // the quick-insert labels on purpose: one construct must not have
+            // two names depending on which door you came through.
+            FormattingItem(EditorFormattingAction.TABLE, stringResource(R.string.quick_insert_table), Icons.Default.TableChart),
+            FormattingItem(EditorFormattingAction.CALLOUT, stringResource(R.string.quick_insert_callout), Icons.Default.Info),
             FormattingItem(EditorFormattingAction.DIVIDER, stringResource(R.string.horizontal_rule), Icons.Default.HorizontalRule),
             FormattingItem(EditorFormattingAction.IMAGE, stringResource(R.string.insert_image), Icons.Default.Image)
         )

--- a/app/src/main/java/com/markleaf/notes/feature/editor/QuickInsert.kt
+++ b/app/src/main/java/com/markleaf/notes/feature/editor/QuickInsert.kt
@@ -2,6 +2,7 @@ package com.markleaf.notes.feature.editor
 
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
+import com.markleaf.notes.core.markdown.MarkdownEditActions
 import java.time.LocalDate
 import java.util.Locale
 
@@ -120,11 +121,13 @@ private fun insertionFor(
     QuickInsertCommand.QUOTE -> QuickInsertion("> ")
     QuickInsertCommand.CODE_BLOCK -> QuickInsertion("```\n\n```\n", caretOffset = 4)
     QuickInsertCommand.DIVIDER -> QuickInsertion("---\n")
+    // Both templates live in MarkdownEditActions, which the formatting panel
+    // inserts from too — the same construct behind two doors (#390).
     QuickInsertCommand.TABLE -> QuickInsertion(
-        "| Column 1 | Column 2 |\n| --- | --- |\n|  |  |",
-        caretOffset = 2
+        MarkdownEditActions.TABLE_TEMPLATE,
+        caretOffset = MarkdownEditActions.TABLE_CARET_OFFSET
     )
-    QuickInsertCommand.CALLOUT -> QuickInsertion("> [!NOTE]\n> ")
+    QuickInsertCommand.CALLOUT -> QuickInsertion(MarkdownEditActions.CALLOUT_TEMPLATE)
     QuickInsertCommand.WIKILINK -> QuickInsertion("[[]]", caretOffset = 2)
     QuickInsertCommand.IMAGE -> QuickInsertion("")
     QuickInsertCommand.DATE -> QuickInsertion(today.toString())

--- a/app/src/test/java/com/markleaf/notes/core/markdown/MarkdownEditActionsTest.kt
+++ b/app/src/test/java/com/markleaf/notes/core/markdown/MarkdownEditActionsTest.kt
@@ -271,6 +271,106 @@ class MarkdownEditActionsTest {
     }
 
     @Test
+    fun table_insertsSkeletonAsItsOwnBlockAndCaretsTheFirstHeaderCell() {
+        val result = MarkdownEditActions.table(
+            TextFieldValue("hello", selection = TextRange(5))
+        )
+
+        assertEquals(
+            "hello\n\n| Column 1 | Column 2 |\n| --- | --- |\n|  |  |",
+            result.text
+        )
+        // A GFM table cannot interrupt a paragraph, so the blank line is what
+        // makes this render as a table at all rather than as literal pipes.
+        assertEquals(TextRange(9), result.selection)
+    }
+
+    @Test
+    fun table_insertsAfterTheLineRatherThanSplittingIt() {
+        val result = MarkdownEditActions.table(
+            TextFieldValue("hello world", selection = TextRange(5))
+        )
+
+        assertTrue(result.text.startsWith("hello world\n\n|"))
+    }
+
+    @Test
+    fun table_keepsFollowingTextOutOfTheTable() {
+        val result = MarkdownEditActions.table(
+            TextFieldValue("intro\nafter", selection = TextRange(2))
+        )
+
+        // Without the blank line after it, `after` is read as another row.
+        assertTrue(result.text.endsWith("|  |  |\n\nafter"))
+    }
+
+    @Test
+    fun table_addsNoBlankLinesInAnEmptyNote() {
+        val result = MarkdownEditActions.table(
+            TextFieldValue("", selection = TextRange(0))
+        )
+
+        assertEquals(MarkdownEditActions.TABLE_TEMPLATE, result.text)
+        assertEquals(TextRange(MarkdownEditActions.TABLE_CARET_OFFSET), result.selection)
+    }
+
+    @Test
+    fun callout_insertsHeadAndAnEmptyBodyLine() {
+        val result = MarkdownEditActions.callout(
+            TextFieldValue("", selection = TextRange(0))
+        )
+
+        assertEquals("> [!NOTE]\n> ", result.text)
+        assertEquals(TextRange(12), result.selection)
+    }
+
+    @Test
+    fun callout_separatesItselfFromTheParagraphAbove() {
+        val result = MarkdownEditActions.callout(
+            TextFieldValue("hello", selection = TextRange(5))
+        )
+
+        assertEquals("hello\n\n> [!NOTE]\n> ", result.text)
+        assertEquals(TextRange(19), result.selection)
+    }
+
+    @Test
+    fun callout_wrapsTheSelectedLines() {
+        val result = MarkdownEditActions.callout(
+            TextFieldValue("one\ntwo", selection = TextRange(0, 7))
+        )
+
+        assertEquals("> [!NOTE]\n> one\n> two", result.text)
+        assertEquals(TextRange(0, 21), result.selection)
+    }
+
+    @Test
+    fun callout_wrapExpandsAPartialSelectionToWholeLines() {
+        val result = MarkdownEditActions.callout(
+            TextFieldValue("one\ntwo", selection = TextRange(1, 5))
+        )
+
+        // A selection that starts mid-word must not leave `o` outside the quote.
+        assertEquals("> [!NOTE]\n> one\n> two", result.text)
+    }
+
+    @Test
+    fun callout_leavesAnExistingCalloutAloneRatherThanNestingIt() {
+        val value = TextFieldValue("> [!NOTE]\n> body", selection = TextRange(0, 16))
+
+        assertEquals(value, MarkdownEditActions.callout(value))
+    }
+
+    @Test
+    fun callout_insertsEmptyBlockWhenTheSelectionIsBlank() {
+        val result = MarkdownEditActions.callout(
+            TextFieldValue("   ", selection = TextRange(0, 3))
+        )
+
+        assertTrue(result.text.endsWith("> [!NOTE]\n> "))
+    }
+
+    @Test
     fun autoContinuation_continuesBulletList() {
         val before = TextFieldValue("- one", selection = TextRange(5))
         val typed = TextFieldValue("- one\n", selection = TextRange(6))

--- a/app/src/test/java/com/markleaf/notes/core/markdown/MarkdownEditActionsTest.kt
+++ b/app/src/test/java/com/markleaf/notes/core/markdown/MarkdownEditActionsTest.kt
@@ -367,7 +367,69 @@ class MarkdownEditActionsTest {
             TextFieldValue("   ", selection = TextRange(0, 3))
         )
 
-        assertTrue(result.text.endsWith("> [!NOTE]\n> "))
+        assertTrue(result.text.startsWith("> [!NOTE]\n> "))
+    }
+
+    @Test
+    fun callout_leavesNoIndentationInFrontOfTheHead() {
+        // Four spaces in front of it would make the head an indented code
+        // block rather than a callout — from the Codex review on #390.
+        val result = MarkdownEditActions.callout(
+            TextFieldValue("    ", selection = TextRange(4))
+        )
+
+        assertTrue(result.text.startsWith("> [!NOTE]\n> "))
+    }
+
+    @Test
+    fun table_leavesNoIndentationInFrontOfTheHeaderRow() {
+        val result = MarkdownEditActions.table(
+            TextFieldValue("a\n\n    ", selection = TextRange(7))
+        )
+
+        assertTrue(result.text.startsWith("a\n\n| Column 1 |"))
+        assertEquals(TextRange(5), result.selection)
+    }
+
+    @Test
+    fun table_leavesNoTabInFrontOfTheHeaderRow() {
+        val result = MarkdownEditActions.table(
+            TextFieldValue("\t", selection = TextRange(1))
+        )
+
+        assertTrue(result.text.startsWith("| Column 1 |"))
+    }
+
+    @Test
+    fun table_handlesACaretOnAnEmptyFirstLine() {
+        // A note that opens with a newline: the insertion point is 0, which is
+        // where the line-start arithmetic used to run off the front.
+        val result = MarkdownEditActions.table(
+            TextFieldValue("\nafter", selection = TextRange(0))
+        )
+
+        assertTrue(result.text.startsWith("| Column 1 |"))
+        assertTrue(result.text.endsWith("\n\nafter"))
+    }
+
+    @Test
+    fun callout_stopsAtAnExclusiveEndpointOnTheNextLine() {
+        // `one\n` selected: `two` was never in the selection and must not be
+        // quoted — from the Codex review on #390.
+        val result = MarkdownEditActions.callout(
+            TextFieldValue("one\ntwo", selection = TextRange(0, 4))
+        )
+
+        assertEquals("> [!NOTE]\n> one\n\ntwo", result.text)
+    }
+
+    @Test
+    fun indent_stopsAtAnExclusiveEndpointOnTheNextLine() {
+        val result = MarkdownEditActions.indent(
+            TextFieldValue("a\nb", selection = TextRange(0, 2))
+        )
+
+        assertEquals("  a\nb", result.text)
     }
 
     @Test

--- a/app/src/test/java/com/markleaf/notes/feature/editor/QuickInsertTest.kt
+++ b/app/src/test/java/com/markleaf/notes/feature/editor/QuickInsertTest.kt
@@ -2,6 +2,7 @@ package com.markleaf.notes.feature.editor
 
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
+import com.markleaf.notes.core.markdown.MarkdownEditActions
 import java.time.LocalDate
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -103,6 +104,32 @@ class QuickInsertTest {
             assertEquals(case.command.name, case.text, result.text)
             assertEquals(case.command.name, TextRange(case.caret), result.selection)
         }
+    }
+
+    /**
+     * Input: an empty note, and a `/` query. Output: both doors onto the table
+     * and the callout produce byte-identical text and caret.
+     *
+     * The `/` menu and the formatting panel (#390) insert the same two
+     * constructs. Someone who learns the shape through one door and reaches for
+     * the other must not get a different table, so the agreement is pinned here
+     * rather than left to the shared constants staying shared.
+     */
+    @Test
+    fun tableAndCalloutAgreeWithTheFormattingPanel() {
+        val empty = TextFieldValue("", selection = TextRange(0))
+        val slash = TextFieldValue("/", selection = TextRange(1))
+        val query = checkNotNull(detectQuickInsertQuery(slash))
+
+        val slashTable = applyQuickInsertCommand(slash, query, QuickInsertCommand.TABLE)
+        val panelTable = MarkdownEditActions.table(empty)
+        assertEquals(slashTable.text, panelTable.text)
+        assertEquals(slashTable.selection, panelTable.selection)
+
+        val slashCallout = applyQuickInsertCommand(slash, query, QuickInsertCommand.CALLOUT)
+        val panelCallout = MarkdownEditActions.callout(empty)
+        assertEquals(slashCallout.text, panelCallout.text)
+        assertEquals(slashCallout.selection, panelCallout.selection)
     }
 
     private data class Case(

--- a/app/src/testDebug/java/com/markleaf/notes/feature/editor/EditorFormattingControlsTest.kt
+++ b/app/src/testDebug/java/com/markleaf/notes/feature/editor/EditorFormattingControlsTest.kt
@@ -90,6 +90,31 @@ class EditorFormattingControlsTest {
         assertEquals(false, expanded.value)
     }
 
+    /**
+     * Input: the expanded panel. Output: the table and callout rows are there
+     * and dispatch their actions.
+     *
+     * Before #390 both were reachable only by typing `/`, which is a shape a
+     * beginner has to already know to look for — the panel is where someone who
+     * does not know the syntax goes.
+     */
+    @Test
+    fun panelOffersTableAndCallout() {
+        val expanded = mutableStateOf(true)
+        var picked: EditorFormattingAction? = null
+        render(
+            state = { EditorFormattingUiState(expanded = expanded.value) },
+            onExpandedChange = { expanded.value = it },
+            onAction = { picked = it }
+        )
+
+        composeRule.onNodeWithText("Callout").performScrollTo().assertIsDisplayed()
+        composeRule.onNodeWithText("Table").performScrollTo().performClick()
+
+        assertEquals(EditorFormattingAction.TABLE, picked)
+        assertEquals(false, expanded.value)
+    }
+
     @Test
     fun keyboardOpenMovesFocusToFirstPanelAction() {
         val expanded = mutableStateOf(false)


### PR DESCRIPTION
Closes #390.

## What was wrong

The formatting panel (`Aa` → the expanded list, and **More options** with a selection) ends at code block, divider and image. Tables and `> [!NOTE]` callouts are both first-class in the app already — the starter notes use both, and the preview renders both — but the only way to insert either was to type `/` and know the slash menu exists. As [@hawk1335](https://github.com/hawk1335) put it: the example notes show formats the editor cannot insert, so someone who doesn't know the syntax has to type it by hand.

A slash menu is a shape you have to already know to look for. The panel is where someone who doesn't know the syntax goes, so that is where the two constructs belong.

## What changed

**Two new rows in the panel's Blocks and media group**, between the code block and the divider. Placement is deliberate: `EditorFormattingControlsTest.keyboardWrapsFocusFromFirstToLast` pins "Insert image" as the last item, so the new rows go before the divider rather than at the end.

**The insertion is not the slash command's, and the difference is the point.** `/table` always runs on a line holding nothing but the query. A panel tap can land mid-sentence — and a GFM table cannot interrupt a paragraph, so a skeleton appended straight under a line of prose renders as literal pipes. That is a failure a beginner reaching for this button has no way to diagnose, which would have made the fix worse than the gap. So both actions:

- insert at the **end of the caret's line**, not at the caret, so a word is never split in half;
- compute their separating blank lines from what is actually there — including the one *after*, since a plain line under a table row is read as another row, and under a blockquote as more of the quote;
- add nothing at all in an empty note, so the simple case stays clean.

**Callout has a selection case.** "I wrote this paragraph, make it a note" is how the construct is actually reached; dropping an empty callout after the selection and leaving the user to re-type the text would be worse than doing nothing. A partial selection expands to whole lines. It declines to wrap a callout that is already one — `> > [!NOTE]` is a mis-tap every time and is exactly the broken syntax a beginner cannot unpick.

**One definition, two doors.** `TABLE_TEMPLATE` / `TABLE_CARET_OFFSET` / `CALLOUT_TEMPLATE` moved into `MarkdownEditActions`, and `QuickInsert` reads them from there — so the slash command and the panel cannot drift apart. The panel rows reuse the existing `quick_insert_table` / `quick_insert_callout` labels for the same reason: one construct must not have two names depending on which door you came through. That also means **no new strings and no new translations** — nothing for `verify-locales.ps1` or `ResourceParityTest` to catch up with.

## Tests

- `MarkdownEditActionsTest` — 10 new: block separation before and after, mid-line insertion, empty note, callout head + body, wrap, partial-selection expansion, blank selection, and the no-nesting guard.
- `QuickInsertTest` — the two doors are asserted to produce byte-identical text and caret. The existing table narrows this further: it already pins the `/` literals, so a change to the shared constants fails there too.
- `EditorFormattingControlsTest` — the new rows are present in the expanded panel and dispatch their actions.

## Verification, stated plainly

**No Android SDK is available in this environment, so nothing here was compiled or run locally — the build and the test run are CI's.** What I did do: every branch of the new `blockLeading` / `blockTrailing` / `blockInsertPoint` helpers was simulated against the exact strings and offsets the assertions expect, and all eight cases matched. That catches index slips, not compile errors.

**Roborazzi goldens should be byte-identical.** The panel is a `verticalScroll` column capped at `heightIn(max = 268.dp)`, and the first group alone (one label plus five 48dp rows) already exceeds that, so the five expanded-panel goldens never show the third group. Worth confirming against `verifyRoborazziDebug` rather than taking my arithmetic for it.

## Deliberately not in scope

**Footnotes.** The preview renders them and the starter note advertises them, but inserting one means picking a reference number that is free in the document and placing a definition at the end — a different problem from dropping a template at the caret, and not one to solve inside this change. Neither the panel nor the `/` menu offers it today; the gap is unchanged, not widened.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012tKju4psqZ4RjUeLhCxXVp

---
_Generated by [Claude Code](https://claude.ai/code/session_012tKju4psqZ4RjUeLhCxXVp)_